### PR TITLE
 prevent from sending BrowserAuthError with popup_window_blocked to sentry

### DIFF
--- a/src/features/user/types/error.ts
+++ b/src/features/user/types/error.ts
@@ -12,21 +12,21 @@ export class MsAccountOwnsNoMcAccount extends BaseError {
 
 export class UserCancelledMsSignIn extends BaseError {
   constructor() {
-    super('Microsoftアカウントへのサインインが取り消されました');
+    super('Microsoftアカウントへのサインインを取り消しました');
   }
 }
 
 export class UserDeniedAccess extends BaseError {
   constructor() {
     super(
-      '本サービスがあなたのMicrosoftアカウントにアクセスすることが拒否されました',
+      'あなたのMicrosoftアカウントにアクセスすることが拒否されました。許可してください',
     );
   }
 }
 
 export class MinecraftIdIsUndefined extends BaseError {
   constructor() {
-    super('MinecraftIDが設定されていません');
+    super('MinecraftIDが設定されていません。Minecraft側で設定してください');
   }
 }
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,3 +1,4 @@
+import { AuthError } from '@azure/msal-browser';
 import * as Sentry from '@sentry/nextjs';
 import { NextPage } from 'next';
 import NextErrorComponent, { ErrorProps } from 'next/error';
@@ -38,6 +39,23 @@ MyError.getInitialProps = async (context) => {
     return errorInitialProps;
   }
 
+  if (!err) {
+    // If this point is reached, getInitialProps was called without any
+    // information about what the error might be. This is unexpected and may
+    // indicate a bug introduced in Next.js, so record it in Sentry
+    Sentry.captureException(
+      new Error(`_error.tsx getInitialProps missing data at path: ${asPath}`),
+    );
+    await Sentry.flush(2000);
+
+    return errorInitialProps;
+  }
+
+  // ポップアップウィンドウがブロックされたというエラーはSentryに送信しない
+  if (err instanceof AuthError && err.errorMessage === 'pop_window_error') {
+    return errorInitialProps;
+  }
+
   // Running on the server, the response object (`res`) is available.
   //
   // Next.js will pass an err on the server if a page's data fetching methods
@@ -51,22 +69,10 @@ MyError.getInitialProps = async (context) => {
   //    Boundary. Read more about what types of exceptions are caught by Error
   //    Boundaries: https://reactjs.org/docs/error-boundaries.html
 
-  if (err) {
-    Sentry.captureException(err);
+  Sentry.captureException(err);
 
-    // Flushing before returning is necessary if deploying to Vercel, see
-    // https://vercel.com/docs/platform/limits#streaming-responses
-    await Sentry.flush(2000);
-
-    return errorInitialProps;
-  }
-
-  // If this point is reached, getInitialProps was called without any
-  // information about what the error might be. This is unexpected and may
-  // indicate a bug introduced in Next.js, so record it in Sentry
-  Sentry.captureException(
-    new Error(`_error.tsx getInitialProps missing data at path: ${asPath}`),
-  );
+  // Flushing before returning is necessary if deploying to Vercel, see
+  // https://vercel.com/docs/platform/limits#streaming-responses
   await Sentry.flush(2000);
 
   return errorInitialProps;


### PR DESCRIPTION
- refactor: make err msg more readable
- fix: prevent BrowserAuthError with popup_window_blocked to sentry
