### PR TITLE
chore: seichi-portal-frontend上で使用するパッケージマネージャーをyarnに固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "seichi-portal-frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "dev": "next dev",
     "build": "next build && next export && next-export-optimize-images",


### PR DESCRIPTION
corepack を使い、seichi-portal-frontend 上で使用できるパッケージマネージャーを yarn に固定しました。

これにより、 本来使用してはいけない npm , pnpm は実行できなくなり不要な `package-lock.json` や `pnpm-lock.yaml` が混入するのを防ぐことが出来ます。

https://github.com/nodejs/corepack