### PR TITLE
fix: MUI の Hydration ミスマッチを解消するため AppRouterCacheProvider を追加

### DIFF
--- a/src/app/(authed)/(standard)/layout.tsx
+++ b/src/app/(authed)/(standard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import '../../globals.css';
 import { Inter } from 'next/font/google';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import { SWRConfig } from 'swr';
 import NavBar from '@/app/_components/NavBar';
 import { fetcher } from '@/app/_swr/fetcher';
@@ -18,16 +19,18 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <meta name="description" content="整地鯖公式のポータルサイトです。" />
       </head>
       <body className={inter.className}>
-        <main className={styles['main']}>
-          <SWRConfig
-            value={{
-              fetcher: fetcher,
-            }}
-          >
-            <NavBar />
-            {children}
-          </SWRConfig>
-        </main>
+        <AppRouterCacheProvider>
+          <main className={styles['main']}>
+            <SWRConfig
+              value={{
+                fetcher: fetcher,
+              }}
+            >
+              <NavBar />
+              {children}
+            </SWRConfig>
+          </main>
+        </AppRouterCacheProvider>
       </body>
     </html>
   );

--- a/src/app/(authed)/admin/layout.tsx
+++ b/src/app/(authed)/admin/layout.tsx
@@ -3,7 +3,7 @@
 import '../../globals.css';
 import { ThemeProvider } from '@emotion/react';
 import { CssBaseline } from '@mui/material';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import { Inter } from 'next/font/google';
 import { SWRConfig } from 'swr';
 import { MsalProvider } from '@/app/_components/MsalProvider';

--- a/src/app/(unauthed)/layout.tsx
+++ b/src/app/(unauthed)/layout.tsx
@@ -1,5 +1,6 @@
 import '../globals.css';
 import { Inter } from 'next/font/google';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import NavBar from '@/app/_components/NavBar';
 import { MsalProvider } from '../_components/MsalProvider';
 import styles from '../page.module.css';
@@ -17,10 +18,12 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ja">
       <body className={inter.className}>
-        <NavBar />
-        <main className={styles['main']}>
-          <MsalProvider>{children}</MsalProvider>
-        </main>
+        <AppRouterCacheProvider>
+          <NavBar />
+          <main className={styles['main']}>
+            <MsalProvider>{children}</MsalProvider>
+          </main>
+        </AppRouterCacheProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## 概要

- `(unauthed)` および `(authed)/(standard)` の layout に `AppRouterCacheProvider` が設定されておらず、MUI (Emotion CSS-in-JS) の SSR 時に `<style>` タグとクライアント側の `<div>` が一致しない Hydration エラーが発生していた
- 両 layout に `AppRouterCacheProvider` を追加して修正した
- あわせて全 layout のバージョン指定を Next.js 16 に合わせ `v15-appRouter` → `v16-appRouter` に統一した

## 確認事項

- ブラウザコンソールに出ていた `Hydration failed because the server rendered HTML didn't match the client` エラーが `AppRouterCacheProvider` の追加で解消されることを確認済み（admin layout では既に同プロバイダーが設定されており、同様のエラーが出ていなかったことからも有効な対処と判断）
- admin layout はすでに `AppRouterCacheProvider` を使用していたため、バージョン統一のみ

🤖 Generated with Claude Code