### PR TITLE
feat: ユーザー設定ページの UI をカード形式に刷新

### DIFF
--- a/src/app/(authed)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -1,14 +1,14 @@
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import {
   Button,
-  Container,
+  CardContent,
+  Divider,
   FormControlLabel,
   Stack,
-  TextField,
   Typography,
 } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import type {
   GetNotificationSettingsResponse,
   UpdateNotificationSettingsSchema,
@@ -18,8 +18,14 @@ const DiscordNotificationSettings = (props: {
   currentSettings: GetNotificationSettingsResponse;
   userId: string;
 }) => {
-  const { handleSubmit, register } =
-    useForm<UpdateNotificationSettingsSchema>();
+  const { handleSubmit, register, control } =
+    useForm<UpdateNotificationSettingsSchema>({
+      defaultValues: {
+        recipient_id: props.userId,
+        is_send_message_notification:
+          props.currentSettings.is_send_message_notification,
+      },
+    });
 
   const onSubmit = async (data: UpdateNotificationSettingsSchema) => {
     const response = await fetch(`/api/proxy/notifications/settings/me`, {
@@ -30,8 +36,6 @@ const DiscordNotificationSettings = (props: {
       body: JSON.stringify(data),
     });
 
-    console.log(response.status);
-
     if (response.ok) {
       alert('設定を更新しました');
     } else {
@@ -40,30 +44,40 @@ const DiscordNotificationSettings = (props: {
   };
 
   return (
-    <Container component="form" onSubmit={handleSubmit(onSubmit)}>
+    <CardContent component="form" onSubmit={handleSubmit(onSubmit)}>
+      <input type="hidden" {...register('recipient_id')} />
+      <Typography variant="h6" gutterBottom>
+        通知設定
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
       <Stack spacing={2}>
-        <TextField
-          {...register('recipient_id')}
-          defaultValue={props.userId}
-          hidden
-        />
-        <Typography variant="h6">Discord への通知設定</Typography>
-        <FormControlLabel
-          label="自身の回答に対するメッセージ通知を受け取る"
-          control={
-            <Checkbox
-              defaultChecked={
-                props.currentSettings.is_send_message_notification
+        <Controller
+          name="is_send_message_notification"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              label="自身の回答に対するメッセージ通知を受け取る"
+              control={
+                <Checkbox
+                  checked={field.value ?? false}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  ref={field.ref}
+                />
               }
-              {...register('is_send_message_notification')}
             />
-          }
+          )}
         />
-        <Button variant="contained" endIcon={<SaveAltIcon />} type="submit">
-          送信
+        <Button
+          variant="contained"
+          endIcon={<SaveAltIcon />}
+          type="submit"
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          保存
         </Button>
       </Stack>
-    </Container>
+    </CardContent>
   );
 };
 

--- a/src/app/(authed)/(standard)/users/[userId]/_components/LinkDiscordButton.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/_components/LinkDiscordButton.tsx
@@ -1,10 +1,36 @@
-import Button from '@mui/material/Button';
+import LinkIcon from '@mui/icons-material/Link';
+import {
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
 
 const LinkDiscordButton = () => {
   return (
-    <Button variant="contained" href="/api/discord">
-      Discord と連携する
-    </Button>
+    <Card variant="outlined">
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Typography variant="h6">Discord 連携</Typography>
+            <Chip label="未連携" color="default" size="small" />
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Discord と連携すると、回答へのメッセージ通知を受け取れます。
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<LinkIcon />}
+            href="/api/discord"
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            Discord と連携する
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/app/(authed)/(standard)/users/[userId]/_components/UnlinkDiscordButton.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/_components/UnlinkDiscordButton.tsx
@@ -1,4 +1,5 @@
-import Button from '@mui/material/Button';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import { Button, Chip, Stack, Typography } from '@mui/material';
 
 const UnlinkDiscordButton = () => {
   const onClick = async () => {
@@ -9,9 +10,21 @@ const UnlinkDiscordButton = () => {
   };
 
   return (
-    <Button variant="contained" onClick={onClick}>
-      Discord との連携を解除する
-    </Button>
+    <Stack direction="row" alignItems="center" justifyContent="space-between">
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography variant="h6">Discord 連携</Typography>
+        <Chip label="連携済み" color="success" size="small" />
+      </Stack>
+      <Button
+        variant="outlined"
+        color="error"
+        startIcon={<LinkOffIcon />}
+        onClick={onClick}
+        size="small"
+      >
+        連携を解除する
+      </Button>
+    </Stack>
   );
 };
 

--- a/src/app/(authed)/(standard)/users/[userId]/_components/UserInformation.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/_components/UserInformation.tsx
@@ -1,26 +1,46 @@
-import Grid from '@mui/material/Grid';
+import { Card, CardContent, Divider, Stack, Typography } from '@mui/material';
 import type { GetUsersResponse } from '@/lib/api-types';
+
+const InfoRow = ({ label, value }: { label: string; value: string }) => (
+  <Stack>
+    <Typography variant="caption" color="text.secondary">
+      {label}
+    </Typography>
+    <Typography variant="body1" sx={{ wordBreak: 'break-all' }}>
+      {value}
+    </Typography>
+  </Stack>
+);
 
 const UserInformation = (props: { user: GetUsersResponse }) => {
   return (
-    <Grid container spacing={2}>
-      <Grid size={2}>Minecraft ユーザー名: </Grid>
-      <Grid size={2}>{props.user.name}</Grid>
-      <Grid size={2}>Minecraft UUID: </Grid>
-      <Grid size={6}>{props.user.id}</Grid>
-      <Grid size={2}>Discord ユーザー名: </Grid>
-      <Grid size={2}>
-        {!props.user['discord_username']
-          ? '未設定'
-          : String(props.user['discord_username'])}
-      </Grid>
-      <Grid size={2}>Discord ID: </Grid>
-      <Grid size={6}>
-        {!props.user['discord_user_id']
-          ? '未設定'
-          : String(props.user['discord_user_id'])}
-      </Grid>
-    </Grid>
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          ユーザー情報
+        </Typography>
+        <Stack spacing={2} divider={<Divider />}>
+          <InfoRow label="Minecraft ユーザー名" value={props.user.name} />
+          <InfoRow label="Minecraft UUID" value={props.user.id} />
+          <InfoRow
+            label="Discord ユーザー名"
+            value={
+              props.user['discord_username']
+                ? String(props.user['discord_username'])
+                : '未設定'
+            }
+          />
+          <InfoRow
+            label="Discord ID"
+            value={
+              props.user['discord_user_id']
+                ? String(props.user['discord_user_id'])
+                : '未設定'
+            }
+          />
+        </Stack>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/app/(authed)/(standard)/users/[userId]/page.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/page.tsx
@@ -40,23 +40,23 @@ const Home = ({ params }: { params: Promise<{ userId: string }> }) => {
 
   return (
     <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-    <Stack spacing={3} sx={{ maxWidth: 640, width: '100%' }}>
-      <UserInformation user={data} />
-      {data['discord_user_id'] ? (
-        <Card variant="outlined">
-          <CardContent>
-            <UnlinkDiscordButton />
-          </CardContent>
-          <Divider />
-          <DiscordNotificationSettings
-            userId={userId}
-            currentSettings={notificationSettings}
-          />
-        </Card>
-      ) : (
-        <LinkDiscordButton />
-      )}
-    </Stack>
+      <Stack spacing={3} sx={{ maxWidth: 640, width: '100%' }}>
+        <UserInformation user={data} />
+        {data['discord_user_id'] ? (
+          <Card variant="outlined">
+            <CardContent>
+              <UnlinkDiscordButton />
+            </CardContent>
+            <Divider />
+            <DiscordNotificationSettings
+              userId={userId}
+              currentSettings={notificationSettings}
+            />
+          </Card>
+        ) : (
+          <LinkDiscordButton />
+        )}
+      </Stack>
     </Box>
   );
 };

--- a/src/app/(authed)/(standard)/users/[userId]/page.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Stack } from '@mui/material';
+import { Box, Card, CardContent, Divider, Stack } from '@mui/material';
 import { use } from 'react';
 import useSWR from 'swr';
 import ErrorModal from '@/app/_components/ErrorModal';
@@ -28,38 +28,35 @@ const Home = ({ params }: { params: Promise<{ userId: string }> }) => {
     `/api/proxy/notifications/settings/${userId}`
   );
 
-  if (!data || !notificationSettings) {
+  if (isLoading || isNotificationSettingsLoading) {
     return <LoadingCircular />;
-  } else if (
-    (!isLoading && error) ||
-    (!isNotificationSettingsLoading && notificationError)
-  ) {
+  } else if (error || notificationError) {
     return <ErrorModal />;
   }
 
+  if (!data || !notificationSettings) {
+    return <LoadingCircular />;
+  }
+
   return (
-    <Box
-      sx={{
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'start',
-      }}
-    >
-      <Stack spacing={2}>
-        <UserInformation user={data} />
-        {data['discord_user_id'] ? (
-          <Stack>
+    <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+    <Stack spacing={3} sx={{ maxWidth: 640, width: '100%' }}>
+      <UserInformation user={data} />
+      {data['discord_user_id'] ? (
+        <Card variant="outlined">
+          <CardContent>
             <UnlinkDiscordButton />
-            <DiscordNotificationSettings
-              userId={userId}
-              currentSettings={notificationSettings}
-            />
-          </Stack>
-        ) : (
-          <LinkDiscordButton />
-        )}
-      </Stack>
+          </CardContent>
+          <Divider />
+          <DiscordNotificationSettings
+            userId={userId}
+            currentSettings={notificationSettings}
+          />
+        </Card>
+      ) : (
+        <LinkDiscordButton />
+      )}
+    </Stack>
     </Box>
   );
 };


### PR DESCRIPTION
## 概要

- 各セクションの区切りが不明瞭で見にくかったユーザー設定ページを、カード形式に刷新
- `UserInformation` はラベル（小さい灰色テキスト）＋値の縦ペアで表示し、項目間を `Divider` で区切る形に変更
- Discord 連携状態を `Chip`（連携済み / 未連携）で視覚的に表示し、連携済みの場合は連携ヘッダーと通知設定を 1 枚のカードにまとめた
- 合わせて `DiscordNotificationSettings` の `Checkbox` を `Controller` を使った controlled コンポーネントに変更し、MUI の uncontrolled 警告を解消

## 確認事項

- ブラウザ上で連携済み・未連携それぞれの表示を目視確認（UIの区切りとレイアウト）
- TypeScript のビルドエラーがないことをローカルで確認

## 補足

- `page.module.css` の `main` が `flex-direction: row` のため `mx: auto` が効かない構造になっており、外側に `display: flex; justify-content: center` の `Box` を置いて中央寄せしている

🤖 Generated with Claude Code