### PR TITLE
fix: フォームラベル API のプロキシパスを修正

### DIFF
--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -13,7 +13,7 @@ const Home = () => {
     data: labels,
     error,
     isLoading: isLoadingLabels,
-  } = useSWR<GetFormLabelsResponse>('/api/proxy/forms/labels/forms');
+  } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
 
   if (!labels) {
     return <LoadingCircular />;

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -21,7 +21,7 @@ const Home = ({ params }: { params: Promise<{ id: number }> }) => {
     data: labels,
     error: labelsError,
     isLoading: isLoadingLabels,
-  } = useSWR<GetFormLabelsResponse>('/api/proxy/forms/labels/forms');
+  } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
 
   if (!form || !labels) {
     return <LoadingCircular />;

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -21,7 +21,7 @@ const Home = () => {
     data: labels,
     error: labelsError,
     isLoading: isLoadingLabels,
-  } = useSWR<GetFormLabelsResponse>('/api/proxy/forms/labels/forms');
+  } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
   const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
 
   const filteredForms = useMemo(() => {

--- a/src/app/(authed)/admin/labels/forms/_components/CreateLabelField.tsx
+++ b/src/app/(authed)/admin/labels/forms/_components/CreateLabelField.tsx
@@ -3,7 +3,7 @@
 import CreateLabelField from '@/app/(authed)/_components/CreateLabelField';
 
 const FormCreateLabelField = () => (
-  <CreateLabelField createEndpoint="/api/proxy/forms/labels/forms" />
+  <CreateLabelField createEndpoint="/api/proxy/labels/forms" />
 );
 
 export default FormCreateLabelField;

--- a/src/app/(authed)/admin/labels/forms/_components/Labels.tsx
+++ b/src/app/(authed)/admin/labels/forms/_components/Labels.tsx
@@ -6,8 +6,8 @@ import type { GetFormLabelsResponse } from '@/lib/api-types';
 const FormLabels = (props: { labels: GetFormLabelsResponse }) => (
   <Labels
     labels={props.labels}
-    deleteEndpointBase="/api/proxy/forms/labels/forms"
-    editEndpointBase="/api/proxy/forms/labels/forms"
+    deleteEndpointBase="/api/proxy/labels/forms"
+    editEndpointBase="/api/proxy/labels/forms"
   />
 );
 

--- a/src/app/(authed)/admin/labels/forms/page.tsx
+++ b/src/app/(authed)/admin/labels/forms/page.tsx
@@ -11,7 +11,7 @@ import type { GetAnswerLabelsResponse } from '@/lib/api-types';
 
 const Home = () => {
   const { data, error, isLoading } = useSWR<GetAnswerLabelsResponse>(
-    '/api/proxy/forms/labels/forms',
+    '/api/proxy/labels/forms',
     { refreshInterval: 1000 }
   );
 


### PR DESCRIPTION
## 概要

- `admin/forms` を開いたとき、`/api/proxy/forms/labels/forms` へ GET リクエストが送られ 404 が発生していた
- プロキシは `/api/proxy` を除去してバックエンドに転送するため、このパスは `/forms/labels/forms` に転送されていた
- バックエンドの正しいエンドポイントは `/labels/forms` なので、フロントエンド側のパスを `/api/proxy/labels/forms` に修正した
- 影響範囲: フォーム一覧・フォーム作成・フォーム編集・フォームラベル管理ページ（計 6 ファイル）

## 確認事項

- `src/generated/api-types.ts` の OpenAPI 定義で `/labels/forms` が正しいエンドポイントであることを確認した
- プロキシの実装（`src/proxy.ts`）がパス変換のみを行うシンプルな rewrite であることを確認し、他に変換ロジックがないことを確認した
- ローカル環境での動作確認は未実施。バックエンドが `/labels/forms` を実装済みであることを前提としているため、レビュアーはバックエンド側のルート定義と照合してほしい

🤖 Generated with Claude Code