### PR TITLE
feat: openapi-fetch を導入し fetch エンドポイントを静的検査可能にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dayjs": "^1.11.9",
     "fp-ts": "^2.16.8",
     "next": "^16",
+    "openapi-fetch": "^0.17.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-hook-form": "^7.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next:
         specifier: ^16
         version: 16.2.3(@babel/core@7.28.6)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      openapi-fetch:
+        specifier: ^0.17.0
+        version: 0.17.0
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -2648,8 +2651,14 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   openapi-typescript@7.13.0:
     resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
@@ -6272,7 +6281,13 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
   openapi-types@12.1.3: {}
+
+  openapi-typescript-helpers@0.1.0: {}
 
   openapi-typescript@7.13.0(typescript@5.9.3):
     dependencies:

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/_components/InputMessageField.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/_components/InputMessageField.tsx
@@ -2,8 +2,12 @@
 
 import InputMessageField from '@/app/(authed)/_components/InputMessageField';
 
-const StandardInputMessageField = (props: { answer_id: number }) => (
+const StandardInputMessageField = (props: {
+  form_id: string;
+  answer_id: number;
+}) => (
   <InputMessageField
+    form_id={props.form_id}
     answer_id={props.answer_id}
     textFieldSx={{
       '& .MuiFormLabel-root': { color: 'white' },

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
@@ -9,8 +9,12 @@ import InputMessageField from './_components/InputMessageField';
 import Messages from './_components/Messages';
 import type { GetMessagesResponse } from '@/lib/api-types';
 
-const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
-  const { answerId } = use(params);
+const Home = ({
+  params,
+}: {
+  params: Promise<{ formId: string; answerId: number }>;
+}) => {
+  const { formId, answerId } = use(params);
   const {
     data: messages,
     error,
@@ -59,9 +63,9 @@ const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
           px: { xs: 2, sm: 3 },
         }}
       >
-        <Messages messages={messages} answerId={answerId} />
+        <Messages messages={messages} formId={formId} answerId={answerId} />
       </Container>
-      <InputMessageField answer_id={answerId} />
+      <InputMessageField form_id={formId} answer_id={answerId} />
     </Stack>
   );
 };

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
@@ -58,6 +58,7 @@ const Home = ({
       <AnswerDetails answer={answer} questions={formQuestions} />
       <Comments
         comments={answer.comments as AnswerCommentType[]}
+        formId={answer.form_id}
         answerId={answer.id}
         inputSx={{
           '& .MuiInputBase-input': { color: 'white' },

--- a/src/app/(authed)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -33,7 +33,9 @@ const DiscordNotificationSettings = (props: {
   const { updateSettings } = useNotificationSettings();
 
   const onSubmit = async (data: UpdateNotificationSettingsSchema) => {
-    const result = await updateSettings(data);
+    const result = await updateSettings({
+      is_send_message_notification: data.is_send_message_notification ?? null,
+    });
     if (result.ok) {
       alert('設定を更新しました');
     } else {

--- a/src/app/(authed)/_components/Comments.tsx
+++ b/src/app/(authed)/_components/Comments.tsx
@@ -32,10 +32,12 @@ type DeleteCommentSchema = {
 
 const CommentItem = (props: {
   comment: Comment;
+  formId: string;
+  answerId: number | string;
   showDeleteButton: boolean;
 }) => {
   const { register, handleSubmit } = useForm<DeleteCommentSchema>();
-  const { deleteComment } = useCommentActions();
+  const { deleteComment } = useCommentActions(props.formId, props.answerId);
 
   const onDelete = async (data: DeleteCommentSchema) => {
     await deleteComment(data.comment_id);
@@ -101,14 +103,15 @@ const CommentItem = (props: {
 };
 
 const SendCommentForm = (props: {
+  formId: string;
   answerId: number | string;
   inputSx?: object;
 }) => {
   const { register, handleSubmit, reset } = useForm<SendCommentSchema>();
-  const { sendComment } = useCommentActions();
+  const { sendComment } = useCommentActions(props.formId, props.answerId);
 
   const onSubmit = async (data: SendCommentSchema) => {
-    await sendComment(props.answerId, data.content);
+    await sendComment(data.content);
     reset();
   };
 
@@ -146,6 +149,7 @@ const SendCommentForm = (props: {
 
 const Comments = (props: {
   comments: Comment[];
+  formId: string;
   answerId: number | string;
   showDeleteButton?: boolean;
   inputSx?: object;
@@ -153,6 +157,7 @@ const Comments = (props: {
   return (
     <Stack spacing={2}>
       <SendCommentForm
+        formId={props.formId}
         answerId={props.answerId}
         {...(props.inputSx !== undefined && { inputSx: props.inputSx })}
       />
@@ -163,6 +168,8 @@ const Comments = (props: {
           <CommentItem
             key={comment.comment_id}
             comment={comment}
+            formId={props.formId}
+            answerId={props.answerId}
             showDeleteButton={props.showDeleteButton ?? false}
           />
         ))}

--- a/src/app/(authed)/_components/CreateLabelField.tsx
+++ b/src/app/(authed)/_components/CreateLabelField.tsx
@@ -9,13 +9,9 @@ type CreateLabelSchema = {
   name: string;
 };
 
-const CreateLabelField = (props: { createEndpoint: string }) => {
+const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
   const { handleSubmit, register, reset } = useForm<CreateLabelSchema>();
-  const { createLabel } = useLabelCRUD(
-    props.createEndpoint,
-    props.createEndpoint,
-    props.createEndpoint
-  );
+  const { createLabel } = useLabelCRUD(props.labelType);
 
   const onSubmit = async (data: CreateLabelSchema) => {
     await createLabel(data.name);

--- a/src/app/(authed)/_components/InputMessageField.tsx
+++ b/src/app/(authed)/_components/InputMessageField.tsx
@@ -11,6 +11,7 @@ type SendMessageSchema = {
 };
 
 const InputMessageField = (props: {
+  form_id: string;
   answer_id: number;
   textFieldSx?: object;
 }) => {
@@ -18,7 +19,7 @@ const InputMessageField = (props: {
   const [sendFailedMessage, setSendFailedMessage] = useState<
     string | undefined
   >(undefined);
-  const { sendMessage } = useSendMessage(props.answer_id);
+  const { sendMessage } = useSendMessage(props.form_id, props.answer_id);
 
   const onSubmit = async (data: SendMessageSchema) => {
     if (data.body === '') {

--- a/src/app/(authed)/_components/Labels.tsx
+++ b/src/app/(authed)/_components/Labels.tsx
@@ -32,20 +32,14 @@ enum State {
   None,
 }
 
-const Labels = (props: {
-  labels: Label[];
-  deleteEndpointBase: string;
-  editEndpointBase: string;
-}) => {
+const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
   const [deleteState, setDeleteState] = useState<State>(State.None);
   const [editState, setEditState] = useState<State>(State.None);
   const [editLabel, setEditLabel] = useState<Label>();
   const { handleSubmit, register } = useForm<EditLabelSchema>();
 
   const { deleteLabel, editLabel: editLabelAction } = useLabelCRUD(
-    '',
-    props.deleteEndpointBase,
-    props.editEndpointBase
+    props.labelType
   );
 
   const onDeleteButtonClick = async (label: Label) => {

--- a/src/app/(authed)/_components/Messages.tsx
+++ b/src/app/(authed)/_components/Messages.tsx
@@ -33,6 +33,7 @@ type Message = {
 
 const MessageItem = (props: {
   message: Message;
+  formId: string;
   answerId: number;
   edittingMessageId: string | undefined;
   handleEdit: () => void;
@@ -44,7 +45,10 @@ const MessageItem = (props: {
     string | undefined
   >(undefined);
 
-  const { updateMessage, deleteMessage } = useMessageActions(props.answerId);
+  const { updateMessage, deleteMessage } = useMessageActions(
+    props.formId,
+    props.answerId
+  );
 
   const handleDelete = async () => {
     const result = await deleteMessage(props.message.id);
@@ -165,7 +169,11 @@ const MessageItem = (props: {
   );
 };
 
-const Messages = (props: { messages: Message[]; answerId: number }) => {
+const Messages = (props: {
+  messages: Message[];
+  formId: string;
+  answerId: number;
+}) => {
   const [edittingMessageId, setEdittingMessageId] = useState<
     string | undefined
   >(undefined);
@@ -176,6 +184,7 @@ const Messages = (props: { messages: Message[]; answerId: number }) => {
         <Stack key={message.id} spacing={2}>
           <MessageItem
             message={message}
+            formId={props.formId}
             answerId={props.answerId}
             edittingMessageId={edittingMessageId}
             handleEdit={() => setEdittingMessageId(message.id)}

--- a/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
@@ -25,7 +25,10 @@ const AnswerTitleForm = (props: { answers: GetAnswerResponse }) => {
   const { handleSubmit, register } = useForm<{ title: string }>();
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(props.answers.title);
-  const { updateTitle } = useAnswerActions(props.answers.id);
+  const { updateTitle } = useAnswerActions(
+    props.answers.form_id,
+    props.answers.id
+  );
 
   const onSubmit = async (data: { title: string }) => {
     const result = await updateTitle(data.title);
@@ -72,7 +75,10 @@ const AnswerLabels = (props: {
   labelOptions: GetAnswerLabelsResponse;
   answers: GetAnswerResponse;
 }) => {
-  const { updateLabels } = useAnswerActions(props.answers.id);
+  const { updateLabels } = useAnswerActions(
+    props.answers.form_id,
+    props.answers.id
+  );
 
   return (
     <Autocomplete

--- a/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
@@ -8,22 +8,32 @@ import LoadingCircular from '@/app/_components/LoadingCircular';
 import InputMessageField from './_components/InputMessageField';
 import Messages from './_components/Messages';
 import adminDashboardTheme from '../../../theme/adminDashboardTheme';
-import type { GetMessagesResponse } from '@/lib/api-types';
+import type { GetAnswerResponse, GetMessagesResponse } from '@/lib/api-types';
 
 const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
   const { answerId } = use(params);
   const {
+    data: answer,
+    error: answerError,
+    isLoading: isAnswerLoading,
+  } = useSWR<GetAnswerResponse>(`/api/proxy/forms/answers/${answerId}`);
+  const {
     data: messages,
-    error,
+    error: messagesError,
     isLoading: isMessagesLoading,
   } = useSWR<GetMessagesResponse>(
-    `/api/proxy/forms/answers/${answerId}/messages`,
+    answer
+      ? `/api/proxy/forms/${answer.form_id}/answers/${answerId}/messages`
+      : null,
     { refreshInterval: 1000 }
   );
 
-  if (!messages) {
+  if (!answer || !messages) {
     return <LoadingCircular />;
-  } else if (!isMessagesLoading && error) {
+  } else if (
+    (!isAnswerLoading && answerError) ||
+    (!isMessagesLoading && messagesError)
+  ) {
     return <ErrorModal />;
   }
 
@@ -60,9 +70,13 @@ const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
             px: { xs: 2, sm: 3 },
           }}
         >
-          <Messages messages={messages} answerId={answerId} />
+          <Messages
+            messages={messages}
+            formId={answer.form_id}
+            answerId={answerId}
+          />
         </Container>
-        <InputMessageField answer_id={answerId} />
+        <InputMessageField form_id={answer.form_id} answer_id={answerId} />
       </Stack>
     </ThemeProvider>
   );

--- a/src/app/(authed)/admin/answer/[answerId]/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/page.tsx
@@ -66,6 +66,7 @@ const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
         />
         <Comments
           comments={answers.comments as AnswerCommentType[]}
+          formId={answers.form_id}
           answerId={answerId}
           showDeleteButton
         />

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -106,15 +106,20 @@ const FormEditForm = (props: {
     const metaResult = await updateFormMeta({
       title: data.title,
       description: data.description,
-      has_response_period: data.settings.has_response_period,
-      response_period: {
-        start_at: start_at ? `${start_at}:00+09:00` : undefined,
-        end_at: end_at ? `${end_at}:00+09:00` : undefined,
+      settings: {
+        visibility: data.settings.visibility,
+        webhook_url: data.settings.webhook_url,
+        answer_settings: {
+          visibility: data.settings.answer_visibility,
+          default_answer_title: data.settings.default_answer_title,
+          response_period: data.settings.has_response_period
+            ? {
+                start_at: start_at ? `${start_at}:00+09:00` : null,
+                end_at: end_at ? `${end_at}:00+09:00` : null,
+              }
+            : null,
+        },
       },
-      webhook_url: data.settings.webhook_url,
-      default_answer_title: data.settings.default_answer_title,
-      visibility: data.settings.visibility,
-      answer_visibility: data.settings.answer_visibility,
     });
 
     if (!metaResult.ok) {
@@ -124,21 +129,20 @@ const FormEditForm = (props: {
       });
     }
 
-    const questionsResult = await updateQuestions(
-      data.questions.map((question) => ({
+    const questionsResult = await updateQuestions({
+      questions: data.questions.map((question) => ({
         id: props.form.questions.find(
           (beforeQuestion) => beforeQuestion.id == question.id
         )
           ? question.id
           : null,
         title: question.title,
-        form_id: data.id,
         description: question.description,
         question_type: question.question_type,
         choices: question.choices.map((choice) => choice.choice),
         is_required: question.is_required,
-      }))
-    );
+      })),
+    });
 
     if (!questionsResult.ok) {
       setError('root', {

--- a/src/app/(authed)/admin/labels/_components/CreateLabelField.tsx
+++ b/src/app/(authed)/admin/labels/_components/CreateLabelField.tsx
@@ -2,8 +2,6 @@
 
 import CreateLabelField from '@/app/(authed)/_components/CreateLabelField';
 
-const AnswerCreateLabelField = () => (
-  <CreateLabelField createEndpoint="/api/proxy/forms/labels/answers" />
-);
+const AnswerCreateLabelField = () => <CreateLabelField labelType="answers" />;
 
 export default AnswerCreateLabelField;

--- a/src/app/(authed)/admin/labels/_components/Labels.tsx
+++ b/src/app/(authed)/admin/labels/_components/Labels.tsx
@@ -4,11 +4,7 @@ import Labels from '@/app/(authed)/_components/Labels';
 import type { GetAnswerLabelsResponse } from '@/lib/api-types';
 
 const AnswerLabels = (props: { labels: GetAnswerLabelsResponse }) => (
-  <Labels
-    labels={props.labels}
-    deleteEndpointBase="/api/proxy/forms/labels/answers"
-    editEndpointBase="/api/proxy/forms/labels/answers"
-  />
+  <Labels labels={props.labels} labelType="answers" />
 );
 
 export default AnswerLabels;

--- a/src/app/(authed)/admin/labels/answers/_components/CreateLabelField.tsx
+++ b/src/app/(authed)/admin/labels/answers/_components/CreateLabelField.tsx
@@ -2,8 +2,6 @@
 
 import CreateLabelField from '@/app/(authed)/_components/CreateLabelField';
 
-const AnswerCreateLabelField = () => (
-  <CreateLabelField createEndpoint="/api/proxy/forms/labels/answers" />
-);
+const AnswerCreateLabelField = () => <CreateLabelField labelType="answers" />;
 
 export default AnswerCreateLabelField;

--- a/src/app/(authed)/admin/labels/answers/_components/Labels.tsx
+++ b/src/app/(authed)/admin/labels/answers/_components/Labels.tsx
@@ -4,11 +4,7 @@ import Labels from '@/app/(authed)/_components/Labels';
 import type { GetAnswerLabelsResponse } from '@/lib/api-types';
 
 const AnswerLabels = (props: { labels: GetAnswerLabelsResponse }) => (
-  <Labels
-    labels={props.labels}
-    deleteEndpointBase="/api/proxy/forms/answers/labels"
-    editEndpointBase="/api/proxy/forms/labels/answers"
-  />
+  <Labels labels={props.labels} labelType="answers" />
 );
 
 export default AnswerLabels;

--- a/src/app/(authed)/admin/labels/forms/_components/CreateLabelField.tsx
+++ b/src/app/(authed)/admin/labels/forms/_components/CreateLabelField.tsx
@@ -2,8 +2,6 @@
 
 import CreateLabelField from '@/app/(authed)/_components/CreateLabelField';
 
-const FormCreateLabelField = () => (
-  <CreateLabelField createEndpoint="/api/proxy/labels/forms" />
-);
+const FormCreateLabelField = () => <CreateLabelField labelType="forms" />;
 
 export default FormCreateLabelField;

--- a/src/app/(authed)/admin/labels/forms/_components/Labels.tsx
+++ b/src/app/(authed)/admin/labels/forms/_components/Labels.tsx
@@ -4,11 +4,7 @@ import Labels from '@/app/(authed)/_components/Labels';
 import type { GetFormLabelsResponse } from '@/lib/api-types';
 
 const FormLabels = (props: { labels: GetFormLabelsResponse }) => (
-  <Labels
-    labels={props.labels}
-    deleteEndpointBase="/api/proxy/labels/forms"
-    editEndpointBase="/api/proxy/labels/forms"
-  />
+  <Labels labels={props.labels} labelType="forms" />
 );
 
 export default FormLabels;

--- a/src/hooks/useAnswerActions.ts
+++ b/src/hooks/useAnswerActions.ts
@@ -1,24 +1,27 @@
 'use client';
 
-export const useAnswerActions = (answerId: number | string) => {
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useAnswerActions = (formId: string, answerId: number | string) => {
   const updateTitle = async (title: string): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/forms/answers/${answerId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title }),
-    });
+    const { response } = await proxyClient.PATCH(
+      '/forms/{form_id}/answers/{answer_id}',
+      {
+        params: { path: { form_id: formId, answer_id: String(answerId) } },
+        body: { title },
+      }
+    );
     return { ok: response.ok };
   };
 
   const updateLabels = async (
     labelIds: (string | number)[]
   ): Promise<{ ok: boolean }> => {
-    const response = await fetch(
-      `/api/proxy/forms/answers/${answerId}/labels`,
+    const { response } = await proxyClient.PUT(
+      '/forms/answers/{answer_id}/labels',
       {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ labels: labelIds }),
+        params: { path: { answer_id: String(answerId) } },
+        body: { labels: labelIds.map(String) },
       }
     );
     return { ok: response.ok };

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -1,27 +1,35 @@
 'use client';
 
-export const useCommentActions = () => {
-  const sendComment = async (
-    answerId: number | string,
-    content: string
-  ): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/forms/answers/comment`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        answer_id: Number(answerId),
-        content,
-      }),
-    });
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useCommentActions = (
+  formId: string,
+  answerId: number | string
+) => {
+  const sendComment = async (content: string): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.POST(
+      '/forms/{form_id}/answers/{answer_id}/comments',
+      {
+        params: {
+          path: { form_id: formId, answer_id: String(answerId) },
+        },
+        body: { content },
+      }
+    );
     return { ok: response.ok };
   };
 
   const deleteComment = async (commentId: number): Promise<{ ok: boolean }> => {
-    const response = await fetch(
-      `/api/proxy/forms/answers/comment/${commentId}`,
+    const { response } = await proxyClient.DELETE(
+      '/forms/{form_id}/answers/{answer_id}/comments/{comment_id}',
       {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        params: {
+          path: {
+            form_id: formId,
+            answer_id: String(answerId),
+            comment_id: String(commentId),
+          },
+        },
       }
     );
     return { ok: response.ok };

--- a/src/hooks/useDiscordActions.ts
+++ b/src/hooks/useDiscordActions.ts
@@ -1,10 +1,10 @@
 'use client';
 
+import { proxyClient } from '@/lib/proxyClient';
+
 export const useDiscordActions = () => {
   const unlinkDiscord = async () => {
-    await fetch('/api/proxy/link-discord', {
-      method: 'DELETE',
-    });
+    await proxyClient.DELETE('/link-discord', {});
   };
 
   return { unlinkDiscord };

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -1,9 +1,11 @@
 'use client';
 
+import { proxyClient } from '@/lib/proxyClient';
+
 export const useFormActions = () => {
   const deleteForm = async (formId: string): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/forms/${formId}`, {
-      method: 'DELETE',
+    const { response } = await proxyClient.DELETE('/forms/{id}', {
+      params: { path: { id: formId } },
     });
     return { ok: response.ok };
   };

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -1,53 +1,30 @@
 'use client';
 
-type FormMetaBody = {
-  title: string;
-  description: string;
-  has_response_period: boolean;
-  response_period: {
-    start_at: string | undefined;
-    end_at: string | undefined;
-  };
-  webhook_url: string | null;
-  default_answer_title: string | null;
-  visibility: string;
-  answer_visibility: string;
-};
+import { proxyClient } from '@/lib/proxyClient';
+import type { paths } from '@/generated/api-types';
 
-type Question = {
-  id: number | null;
-  title: string;
-  form_id: string;
-  description: string;
-  question_type: string;
-  choices: string[];
-  is_required: boolean;
-};
+type FormUpdateBody =
+  paths['/forms/{id}']['patch']['requestBody']['content']['application/json'];
+type QuestionsUpdateBody =
+  paths['/forms/{id}/questions']['put']['requestBody']['content']['application/json'];
 
 export const useFormEditActions = (formId: string) => {
   const updateFormMeta = async (
-    body: FormMetaBody
+    body: FormUpdateBody
   ): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/forms/${formId}`, {
-      method: 'PATCH',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-      cache: 'no-cache',
+    const { response } = await proxyClient.PATCH('/forms/{id}', {
+      params: { path: { id: formId } },
+      body,
     });
     return { ok: response.ok };
   };
 
   const updateQuestions = async (
-    questions: Question[]
+    body: QuestionsUpdateBody
   ): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/forms/questions`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ form_id: formId, questions }),
-      cache: 'no-cache',
+    const { response } = await proxyClient.PUT('/forms/{id}/questions', {
+      params: { path: { id: formId } },
+      body,
     });
     return { ok: response.ok };
   };

--- a/src/hooks/useFormLabelActions.ts
+++ b/src/hooks/useFormLabelActions.ts
@@ -1,11 +1,12 @@
 'use client';
 
+import { proxyClient } from '@/lib/proxyClient';
+
 export const useFormLabelActions = (formId: string) => {
   const updateLabels = async (labelIds: (string | number)[]) => {
-    await fetch(`/api/proxy/forms/${formId}/labels`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ labels: labelIds }),
+    await proxyClient.PUT('/forms/{form_id}/labels', {
+      params: { path: { form_id: formId } },
+      body: { labels: labelIds.map(String) },
     });
   };
 

--- a/src/hooks/useLabelCRUD.ts
+++ b/src/hooks/useLabelCRUD.ts
@@ -1,44 +1,54 @@
 'use client';
 
-/**
- * ラベルの作成・削除・編集を行う汎用フック。
- * エンドポイントは呼び出し元が指定する。
- *
- * @param createEndpoint  POST 先 URL（例: '/api/proxy/forms/labels/forms'）
- * @param deleteEndpointBase DELETE 先 URL のベース（例: '/api/proxy/forms/labels/forms'）→ `${base}/${id}` で呼ばれる
- * @param editEndpointBase  PATCH 先 URL のベース（例: '/api/proxy/forms/labels/forms'）→ `${base}/${id}` で呼ばれる
- */
-export const useLabelCRUD = (
-  createEndpoint: string,
-  deleteEndpointBase: string,
-  editEndpointBase: string
-) => {
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
   const createLabel = async (name: string) => {
-    await fetch(createEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
+    if (labelType === 'answers') {
+      await proxyClient.POST('/labels/answers', { body: { name } });
+    } else {
+      await proxyClient.POST('/labels/forms', { body: { name } });
+    }
   };
 
   const deleteLabel = async (id: string | number): Promise<{ ok: boolean }> => {
-    const response = await fetch(`${deleteEndpointBase}/${id}`, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-    });
-    return { ok: response.ok };
+    if (labelType === 'answers') {
+      const { response } = await proxyClient.DELETE(
+        '/labels/answers/{label_id}',
+        { params: { path: { label_id: String(id) } } }
+      );
+      return { ok: response.ok };
+    } else {
+      const { response } = await proxyClient.DELETE(
+        '/labels/forms/{label_id}',
+        {
+          params: { path: { label_id: String(id) } },
+        }
+      );
+      return { ok: response.ok };
+    }
   };
 
   const editLabel = async (
     id: string | number,
     name: string
   ): Promise<{ ok: boolean }> => {
-    const response = await fetch(`${editEndpointBase}/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    return { ok: response.ok };
+    if (labelType === 'answers') {
+      const { response } = await proxyClient.PATCH(
+        '/labels/answers/{label_id}',
+        {
+          params: { path: { label_id: String(id) } },
+          body: { name },
+        }
+      );
+      return { ok: response.ok };
+    } else {
+      const { response } = await proxyClient.PATCH('/labels/forms/{label_id}', {
+        params: { path: { label_id: String(id) } },
+        body: { name },
+      });
+      return { ok: response.ok };
+    }
   };
 
   return { createLabel, deleteLabel, editLabel };

--- a/src/hooks/useMessageActions.ts
+++ b/src/hooks/useMessageActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { errorResponseSchema } from '@/lib/api-types';
+import { proxyClient } from '@/lib/proxyClient';
 
 type MessageActionResult = { success: boolean; forbidden?: boolean };
 
@@ -14,17 +15,22 @@ const parseForbidden = async (response: Response): Promise<boolean> => {
   }
 };
 
-export const useMessageActions = (answerId: number) => {
+export const useMessageActions = (formId: string, answerId: number) => {
   const updateMessage = async (
     messageId: string,
     body: string
   ): Promise<MessageActionResult> => {
-    const response = await fetch(
-      `/api/proxy/forms/answers/${answerId}/messages/${messageId}`,
+    const { response } = await proxyClient.PATCH(
+      '/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
       {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
+        params: {
+          path: {
+            form_id: formId,
+            answer_id: String(answerId),
+            message_id: messageId,
+          },
+        },
+        body: { body },
       }
     );
 
@@ -39,11 +45,16 @@ export const useMessageActions = (answerId: number) => {
   const deleteMessage = async (
     messageId: string
   ): Promise<MessageActionResult> => {
-    const response = await fetch(
-      `/api/proxy/forms/answers/${answerId}/messages/${messageId}`,
+    const { response } = await proxyClient.DELETE(
+      '/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
       {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
+        params: {
+          path: {
+            form_id: formId,
+            answer_id: String(answerId),
+            message_id: messageId,
+          },
+        },
       }
     );
 

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -1,15 +1,17 @@
 'use client';
 
-import type { UpdateNotificationSettingsSchema } from '@/lib/api-types';
+import { proxyClient } from '@/lib/proxyClient';
+import type { paths } from '@/generated/api-types';
+
+type NotificationSettingsUpdateBody =
+  paths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
 
 export const useNotificationSettings = () => {
   const updateSettings = async (
-    data: UpdateNotificationSettingsSchema
+    data: NotificationSettingsUpdateBody
   ): Promise<{ ok: boolean }> => {
-    const response = await fetch(`/api/proxy/notifications/settings/me`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+    const { response } = await proxyClient.PATCH('/notifications/settings/me', {
+      body: data,
     });
     return { ok: response.ok };
   };

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -1,13 +1,14 @@
 'use client';
 
-export const useSendMessage = (answerId: number) => {
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useSendMessage = (formId: string, answerId: number) => {
   const sendMessage = async (body: string): Promise<{ ok: boolean }> => {
-    const response = await fetch(
-      `/api/proxy/forms/answers/${answerId}/messages`,
+    const { response } = await proxyClient.POST(
+      '/forms/{form_id}/answers/{answer_id}/messages',
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
+        params: { path: { form_id: formId, answer_id: String(answerId) } },
+        body: { body },
       }
     );
     return { ok: response.ok };

--- a/src/hooks/useUserRoleActions.ts
+++ b/src/hooks/useUserRoleActions.ts
@@ -1,11 +1,12 @@
 'use client';
 
+import { proxyClient } from '@/lib/proxyClient';
+
 export const useUserRoleActions = () => {
   const updateUserRole = async (uuid: string, role: string) => {
-    await fetch(`/api/proxy/forms/users/${uuid}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ role }),
+    await proxyClient.PATCH('/users/{uuid}', {
+      params: { path: { uuid } },
+      body: { role },
     });
   };
 

--- a/src/lib/proxyClient.ts
+++ b/src/lib/proxyClient.ts
@@ -1,0 +1,4 @@
+import createClient from 'openapi-fetch';
+import type { paths } from '@/generated/api-types';
+
+export const proxyClient = createClient<paths>({ baseUrl: '/api/proxy' });


### PR DESCRIPTION
## 概要

- `openapi-fetch` を導入し、`src/lib/proxyClient.ts` に OpenAPI 型付きクライアントを作成した
- 全ミューテーション系フック（`use*Actions` 系・`useLabelCRUD`）を `proxyClient` 経由に置き換え、存在しないパス・メソッド・body フィールドを渡すとコンパイルエラーになるようにした
- 移行に伴い、既存の fetch URL バグや body スキーマ不一致を複数修正した

## 修正したバグ（静的検査で検出）

| 箇所 | 問題 | 修正内容 |
|---|---|---|
| `useUserRoleActions` | `/forms/users/{uuid}` → 正しくは `/users/{uuid}` | パスを修正 |
| `useCommentActions` / `useSendMessage` / `useMessageActions` | `form_id` がパスに欠落 | フックに `formId` 引数を追加しパスに含める |
| `useFormEditActions.updateFormMeta` | `has_response_period` 等 `FormUpdateSchema` に存在しないフィールドを送信 | `settings` ネスト構造に再マッピング |
| `useFormEditActions.updateQuestions` | 配列を直接 body に渡していたが正しくは `{ questions: [...] }` | ラップして修正 |
| `useLabelCRUD` 呼び出し元 | 文字列 URL で `/forms/labels/answers` 等のパスバグあり | `labelType: 'answers' \| 'forms'` で型安全に統一 |

## 確認事項

- `pnpm tsc --noEmit` がエラーゼロで通ることを確認済み
- `admin/answer/[answerId]/messages/page.tsx` は URL に `formId` がないルートのため、answer を追加で fetch して `form_id` を取得するよう変更した（レビュアーに確認していただきたい点）

## 補足

- `src/app/_swr/fetcher.ts` および SWR の GET 系 fetch は今回の対象外。GET 系も移行するかは別途検討が必要
- `useLabelCRUD` は `'answers' | 'forms'` の2種類しか現状ないため union で表現したが、将来種類が増えた場合は再設計が必要

🤖 Generated with Claude Code