### PR TITLE
fix: 認証フローと画面安定性を改善する

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
@@ -26,10 +26,12 @@ const Home = ({
     }
   );
 
-  if (!messages) {
-    return <LoadingCircular />;
-  } else if (!isMessagesLoading && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isMessagesLoading || !messages) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
@@ -36,13 +36,12 @@ const Home = ({
     answer ? `/api/proxy/forms/${answer.form_id}/questions` : null
   );
 
-  if (!answer || !formQuestions) {
-    return <LoadingCircular />;
-  } else if (
-    (!isLoadingAnswers && answerError) ||
-    (!isLoadingFormQuestions && formQuestionsError)
-  ) {
+  if (answerError || formQuestionsError) {
     return <ErrorModal />;
+  }
+
+  if (isLoadingAnswers || isLoadingFormQuestions || !answer || !formQuestions) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/(standard)/layout.tsx
+++ b/src/app/(authed)/(standard)/layout.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import '../../globals.css';
-import { Inter } from 'next/font/google';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import { SWRConfig } from 'swr';
 import NavBar from '@/app/_components/NavBar';
 import { fetcher } from '@/app/_swr/fetcher';
 import styles from '../../page.module.css';
 import type { ReactNode } from 'react';
-
-const inter = Inter({ subsets: ['latin'] });
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
@@ -18,7 +15,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <title>Seichi Portal</title>
         <meta name="description" content="整地鯖公式のポータルサイトです。" />
       </head>
-      <body className={inter.className}>
+      <body>
         <AppRouterCacheProvider>
           <main className={styles['main']}>
             <SWRConfig

--- a/src/app/(authed)/admin/_components/SearchResult.tsx
+++ b/src/app/(authed)/admin/_components/SearchResult.tsx
@@ -29,10 +29,12 @@ const SearchResult = (props: {
     encodeURI(`/api/proxy/search?query=${props.searchContent}`)
   );
 
-  if (!data) {
-    return null;
-  } else if (!isLoading && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isLoading || !data) {
+    return null;
   }
 
   const columns: GridColDef[] = [

--- a/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
@@ -28,13 +28,12 @@ const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
     { refreshInterval: 1000 }
   );
 
-  if (!answer || !messages) {
-    return <LoadingCircular />;
-  } else if (
-    (!isAnswerLoading && answerError) ||
-    (!isMessagesLoading && messagesError)
-  ) {
+  if (answerError || messagesError) {
     return <ErrorModal />;
+  }
+
+  if (isAnswerLoading || isMessagesLoading || !answer || !messages) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/answer/[answerId]/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/page.tsx
@@ -39,14 +39,19 @@ const Home = ({ params }: { params: Promise<{ answerId: number }> }) => {
     isLoading: isLabelsLoading,
   } = useSWR<GetAnswerLabelsResponse>('/api/proxy/forms/labels/answers');
 
-  if (!answers || !formQuestions || !labels) {
-    return <LoadingCircular />;
-  } else if (
-    (!isAnswersLoading && answersError) ||
-    (!isFormQuestionsLoading && formQuestionsError) ||
-    (!isLabelsLoading && labelsError)
-  ) {
+  if (answersError || formQuestionsError || labelsError) {
     return <ErrorModal />;
+  }
+
+  if (
+    isAnswersLoading ||
+    isFormQuestionsLoading ||
+    isLabelsLoading ||
+    !answers ||
+    !formQuestions ||
+    !labels
+  ) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -15,10 +15,12 @@ const Home = () => {
     isLoading: isLoadingLabels,
   } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
 
-  if (!labels) {
-    return <LoadingCircular />;
-  } else if (!isLoadingLabels && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isLoadingLabels || !labels) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -23,13 +23,12 @@ const Home = ({ params }: { params: Promise<{ id: number }> }) => {
     isLoading: isLoadingLabels,
   } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
 
-  if (!form || !labels) {
-    return <LoadingCircular />;
-  } else if (
-    (!isLoadingForms && formError) ||
-    (!isLoadingLabels && labelsError)
-  ) {
+  if (formError || labelsError) {
     return <ErrorModal />;
+  }
+
+  if (isLoadingForms || isLoadingLabels || !form || !labels) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -34,13 +34,12 @@ const Home = () => {
     );
   }, [labelFilter, forms]);
 
-  if (!forms || !labels) {
-    return <LoadingCircular />;
-  } else if (
-    (!isLoadingForms && formsError) ||
-    (!isLoadingLabels && labelsError)
-  ) {
+  if (formsError || labelsError) {
     return <ErrorModal />;
+  }
+
+  if (isLoadingForms || isLoadingLabels || !forms || !labels) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/labels/answers/page.tsx
+++ b/src/app/(authed)/admin/labels/answers/page.tsx
@@ -11,14 +11,15 @@ import type { GetAnswerLabelsResponse } from '@/lib/api-types';
 
 const Home = () => {
   const { data, error, isLoading } = useSWR<GetAnswerLabelsResponse>(
-    '/api/proxy/forms/labels/answers',
-    { refreshInterval: 1000 }
+    '/api/proxy/forms/labels/answers'
   );
 
-  if (!data) {
-    return <LoadingCircular />;
-  } else if (!isLoading && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isLoading || !data) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/labels/forms/page.tsx
+++ b/src/app/(authed)/admin/labels/forms/page.tsx
@@ -11,14 +11,15 @@ import type { GetAnswerLabelsResponse } from '@/lib/api-types';
 
 const Home = () => {
   const { data, error, isLoading } = useSWR<GetAnswerLabelsResponse>(
-    '/api/proxy/labels/forms',
-    { refreshInterval: 1000 }
+    '/api/proxy/labels/forms'
   );
 
-  if (!data) {
-    return <LoadingCircular />;
-  } else if (!isLoading && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isLoading || !data) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/layout.tsx
+++ b/src/app/(authed)/admin/layout.tsx
@@ -4,7 +4,6 @@ import '../../globals.css';
 import { ThemeProvider } from '@emotion/react';
 import { CssBaseline } from '@mui/material';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
-import { Inter } from 'next/font/google';
 import { SWRConfig } from 'swr';
 import { MsalProvider } from '@/app/_components/MsalProvider';
 import { fetcher } from '@/app/_swr/fetcher';
@@ -14,15 +13,13 @@ import adminDashboardTheme from './theme/adminDashboardTheme';
 import styles from '../../page.module.css';
 import type { ReactNode } from 'react';
 
-const inter = Inter({ subsets: ['latin'] });
-
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ja">
       <head>
         <title>Seichi Portal Admin</title>
       </head>
-      <body className={inter.className}>
+      <body>
         <AppRouterCacheProvider>
           <ThemeProvider theme={adminDashboardTheme}>
             <CssBaseline />

--- a/src/app/(authed)/admin/page.tsx
+++ b/src/app/(authed)/admin/page.tsx
@@ -21,10 +21,12 @@ const Home = () => {
     isLoading: isLoadingForms,
   } = useSWR<GetFormsResponse>('/api/proxy/forms');
 
-  if (!answers || !forms) {
-    return <LoadingCircular />;
-  } else if ((!isLoading && answersError) || (!isLoadingForms && formsError)) {
+  if (answersError || formsError) {
     return <ErrorModal />;
+  }
+
+  if (isLoading || isLoadingForms || !answers || !forms) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(authed)/admin/users/page.tsx
+++ b/src/app/(authed)/admin/users/page.tsx
@@ -10,14 +10,15 @@ import type { GetUserListResponse } from '@/lib/api-types';
 
 const Home = () => {
   const { data, error, isLoading } = useSWR<GetUserListResponse>(
-    '/api/proxy/users/list',
-    { refreshInterval: 1000 }
+    '/api/proxy/users/list'
   );
 
-  if (!data) {
-    return <LoadingCircular />;
-  } else if (!isLoading && error) {
+  if (error) {
     return <ErrorModal />;
+  }
+
+  if (isLoading || !data) {
+    return <LoadingCircular />;
   }
 
   return (

--- a/src/app/(unauthed)/layout.tsx
+++ b/src/app/(unauthed)/layout.tsx
@@ -1,13 +1,10 @@
 import '../globals.css';
-import { Inter } from 'next/font/google';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import NavBar from '@/app/_components/NavBar';
 import { MsalProvider } from '../_components/MsalProvider';
 import styles from '../page.module.css';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'Seichi Portal',
@@ -17,7 +14,7 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ja">
-      <body className={inter.className}>
+      <body>
         <AppRouterCacheProvider>
           <NavBar />
           <main className={styles['main']}>

--- a/src/app/(unauthed)/login/page.tsx
+++ b/src/app/(unauthed)/login/page.tsx
@@ -5,6 +5,7 @@ import {
   InteractionStatus,
 } from '@azure/msal-browser';
 import { useMsal } from '@azure/msal-react';
+import { Alert, Button, Stack, Typography } from '@mui/material';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState, Suspense } from 'react';
 import type { SilentRequest } from '@azure/msal-browser';
@@ -16,19 +17,29 @@ const loginRequest = {
 const LoginContent = () => {
   const { instance, inProgress, accounts } = useMsal();
   const [isInitialized, setState] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl');
+
+  const handleFailure = (message: string, error: unknown) => {
+    console.error(message, error);
+    setErrorMessage(message);
+  };
 
   useEffect(() => {
     (async () => {
       await instance.initialize();
       await instance.handleRedirectPromise();
       setState(true);
-    })().catch((e) => console.log(e));
+    })().catch((error) =>
+      handleFailure('ログインの初期化に失敗しました。', error)
+    );
   }, [instance]);
 
   useEffect(() => {
+    if (errorMessage) return;
+
     (async () => {
       if (isInitialized && accounts.length > 0 && accounts[0]) {
         const requestWithAccount: SilentRequest = {
@@ -77,10 +88,34 @@ const LoginContent = () => {
             ...loginRequest,
             redirectStartPage: `/login?${callbackQuery}`,
           })
-          .catch((e) => console.log(e));
+          .catch((error) =>
+            handleFailure('ログイン画面への遷移に失敗しました。', error)
+          );
       }
-    })().catch((e) => console.log(e));
-  }, [inProgress, accounts, isInitialized, instance, router, callbackUrl]);
+    })().catch((error) => handleFailure('ログイン処理に失敗しました。', error));
+  }, [
+    inProgress,
+    accounts,
+    isInitialized,
+    instance,
+    router,
+    callbackUrl,
+    errorMessage,
+  ]);
+
+  if (errorMessage) {
+    return (
+      <Stack spacing={2} alignItems="flex-start">
+        <Alert severity="error">{errorMessage}</Alert>
+        <Typography variant="body2">
+          時間を置いて再試行するか、設定を確認してください。
+        </Typography>
+        <Button variant="contained" onClick={() => window.location.reload()}>
+          再試行
+        </Button>
+      </Stack>
+    );
+  }
 
   return <></>;
 };

--- a/src/app/_components/SignoutButton.tsx
+++ b/src/app/_components/SignoutButton.tsx
@@ -20,7 +20,7 @@ export const SignoutButton = () => {
       await fetch('/api/logout', { method: 'DELETE' });
 
       if (accounts[0]) {
-        await instance.initialize().catch((e) => console.log(e));
+        await instance.initialize();
         await instance.logoutRedirect({
           account: instance.getAccountByHomeId(accounts[0].homeAccountId),
           postLogoutRedirectUri: '/',
@@ -30,7 +30,7 @@ export const SignoutButton = () => {
 
       router.push('/');
     } catch (e) {
-      console.log(e);
+      console.error('Failed to sign out:', e);
       setIsSubmitting(false);
     }
   };

--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -3,19 +3,35 @@ import { getBackendServerUrl, getDiscordConfig } from '@/env.server';
 import { getCachedToken } from '@/user-token/mcToken';
 import { discordTokenSchema } from '../_schemas/External';
 import type { NextRequest } from 'next/server';
+
 const DISCORD_TOKEN_URL = 'https://discord.com/api/oauth2/token';
+const DISCORD_OAUTH_STATE_COOKIE = 'SEICHI_PORTAL__DISCORD_OAUTH_STATE';
+
+const setDiscordOauthStateCookie = (response: NextResponse, state: string) => {
+  response.cookies.set(DISCORD_OAUTH_STATE_COOKIE, state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 60 * 10,
+  });
+};
+
+const clearDiscordOauthStateCookie = (response: NextResponse) => {
+  response.cookies.set(DISCORD_OAUTH_STATE_COOKIE, '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 0,
+  });
+};
 
 export async function GET(req: NextRequest) {
   const { clientId, clientSecret, redirectUri } = getDiscordConfig();
   const backendServerUrl = getBackendServerUrl();
-  const oauthQuery = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    scope: 'identify',
-  }).toString();
-  const discordOauthUrl = `https://discord.com/oauth2/authorize?${oauthQuery}`;
   const seichiPortalToken = await getCachedToken();
+
   if (!seichiPortalToken) {
     return NextResponse.redirect(
       `${req.nextUrl.origin}/login?callbackUrl=${req.nextUrl.pathname}`
@@ -24,9 +40,29 @@ export async function GET(req: NextRequest) {
 
   const searchParams = req.nextUrl.searchParams;
   const code = searchParams.get('code');
+  const state = searchParams.get('state');
 
   if (code === null) {
-    return NextResponse.redirect(discordOauthUrl);
+    const oauthState = crypto.randomUUID();
+    const oauthQuery = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: 'identify',
+      state: oauthState,
+    }).toString();
+    const response = NextResponse.redirect(
+      `https://discord.com/oauth2/authorize?${oauthQuery}`
+    );
+    setDiscordOauthStateCookie(response, oauthState);
+    return response;
+  }
+
+  const storedState = req.cookies.get(DISCORD_OAUTH_STATE_COOKIE)?.value;
+  if (!state || !storedState || state !== storedState) {
+    const response = NextResponse.redirect(`${req.nextUrl.origin}/badrequest`);
+    clearDiscordOauthStateCookie(response);
+    return response;
   }
 
   const body = new URLSearchParams({
@@ -48,20 +84,24 @@ export async function GET(req: NextRequest) {
     });
 
     if (!tokenResponse.ok) {
-      return NextResponse.json(
+      const response = NextResponse.json(
         { error: 'Failed to get token from Discord' },
         { status: 502 }
       );
+      clearDiscordOauthStateCookie(response);
+      return response;
     }
 
     const tokenBody: unknown = await tokenResponse.json().catch(() => null);
     const token = discordTokenSchema.safeParse(tokenBody);
 
     if (!token.success) {
-      return NextResponse.json(
+      const response = NextResponse.json(
         { error: 'Failed to parse token response from Discord' },
         { status: 502 }
       );
+      clearDiscordOauthStateCookie(response);
+      return response;
     }
 
     const linkDiscordResponse = await fetch(
@@ -80,18 +120,24 @@ export async function GET(req: NextRequest) {
     );
 
     if (!linkDiscordResponse.ok) {
-      return NextResponse.json(
+      const response = NextResponse.json(
         { error: 'Failed to link discord account' },
         { status: 502 }
       );
+      clearDiscordOauthStateCookie(response);
+      return response;
     }
 
-    return NextResponse.redirect(`${req.nextUrl.origin}/`);
+    const response = NextResponse.redirect(`${req.nextUrl.origin}/`);
+    clearDiscordOauthStateCookie(response);
+    return response;
   } catch (error) {
     console.error('Discord link flow failed:', error);
-    return NextResponse.json(
+    const response = NextResponse.json(
       { error: 'Unexpected error during Discord link flow' },
       { status: 500 }
     );
+    clearDiscordOauthStateCookie(response);
+    return response;
   }
 }

--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -30,7 +30,7 @@ const clearDiscordOauthStateCookie = (response: NextResponse) => {
 export async function GET(req: NextRequest) {
   const { clientId, clientSecret, redirectUri } = getDiscordConfig();
   const backendServerUrl = getBackendServerUrl();
-  const seichiPortalToken = await getCachedToken();
+  const seichiPortalToken = await getCachedToken(req.cookies);
 
   if (!seichiPortalToken) {
     return NextResponse.redirect(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,8 @@ body {
 }
 
 body {
+  font-family:
+    'Segoe UI', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -104,5 +104,10 @@ export const proxy = async (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: ['/api/proxy/:path*', '/admin/:path*', '/forms/:path*'],
+  matcher: [
+    '/api/proxy/:path*',
+    '/admin/:path*',
+    '/forms/:path*',
+    '/users/:path*',
+  ],
 };


### PR DESCRIPTION
## 概要
- Discord 連携の OAuth フローに state 検証を追加し、`/users/:id` をミドルウェア保護対象に含めて認証境界の抜けを塞いだ
- ログイン画面で初期化失敗時に空画面で止まらないようにし、複数画面で SWR のエラー判定順を修正して失敗時にローディングに張り付く挙動を減らした
- `next/font/google` への依存を外してビルド時の外部通信を不要にし、ラベル管理とユーザー一覧の過剰な 1 秒ポーリングをやめた

## 確認事項
- pre-commit フック経由で `pnpm lint` `pnpm type-check` `pnpm fmt` が通ることを確認した
- `pnpm build` は Google Fonts 取得エラーを解消して静的生成フェーズまで進むことを確認したが、最終的には `Next.js build worker exited with code: 1` で失敗する別件が残っている
- Discord OAuth の state と `/users/:id` 保護追加はコード上で確認済みだが、実ブラウザでの OAuth 往復確認はこの場では未実施

## 補足
- 残っている `pnpm build` の失敗は今回の主修正とは別で、後続でプリレンダー失敗箇所の切り分けが必要

🤖 Generated with Codex