### PR TITLE
fix: lefthook の lint を staged 変更だけに限定する

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,8 @@ pre-commit:
   parallel: false
   jobs:
     - name: lint
-      run: pnpm lint
+      glob: '*.{js,jsx,ts,tsx,mjs,cjs}'
+      run: pnpm lint -- {staged_files}
 
     - name: type-check
       run: pnpm type-check


### PR DESCRIPTION
## 概要
- pre-commit の lint が常に全ファイルを対象にしていたため、staged の JS/TS 系ファイルだけを eslint に渡すよう変更
- `lefthook.yml` に `glob` と `{staged_files}` を追加し、軽微な変更でも不要に全体 lint が走らないように調整
- `type-check` と `fmt` の既存フック挙動は変更なし

## 確認事項
- コミット時の pre-commit フックで `type-check` と `fmt` が通ることを確認
- 今回の変更対象は `lefthook.yml` のみのため、`lint` は `no files for inspection` で skip されることを確認
- staged 対象への lint 絞り込みは設定変更のみで、アプリケーションコードの実行影響はなし

🤖 Generated with Codex