### PR TITLE
fix: MSAL 初期化中に AppBar のみ表示される問題を修正

### DIFF
--- a/src/app/(authed)/(standard)/page.tsx
+++ b/src/app/(authed)/(standard)/page.tsx
@@ -3,12 +3,34 @@
 import {
   AuthenticatedTemplate,
   UnauthenticatedTemplate,
+  useMsal,
 } from '@azure/msal-react';
+import { InteractionStatus } from '@azure/msal-browser';
 import { useState } from 'react';
 import { MsalProvider } from '@/app/_components/MsalProvider';
 import { DEBUG_MODE } from '@/env.client';
 import MainMenu from './_components/MainMenu';
 import { NeedToSignin } from './_components/NeedToSignin';
+import LoadingCircular from '@/app/_components/LoadingCircular';
+
+const HomeContent = () => {
+  const { inProgress } = useMsal();
+
+  if (inProgress !== InteractionStatus.None) {
+    return <LoadingCircular />;
+  }
+
+  return (
+    <>
+      <AuthenticatedTemplate>
+        <MainMenu />
+      </AuthenticatedTemplate>
+      <UnauthenticatedTemplate>
+        <NeedToSignin />
+      </UnauthenticatedTemplate>
+    </>
+  );
+};
 
 const Home = () => {
   const [isDebugMode] = useState(
@@ -20,12 +42,7 @@ const Home = () => {
   } else {
     return (
       <MsalProvider>
-        <AuthenticatedTemplate>
-          <MainMenu />
-        </AuthenticatedTemplate>
-        <UnauthenticatedTemplate>
-          <NeedToSignin />
-        </UnauthenticatedTemplate>
+        <HomeContent />
       </MsalProvider>
     );
   }


### PR DESCRIPTION
## 概要

- MSAL の初期化が完了するまでの間、`AuthenticatedTemplate` と `UnauthenticatedTemplate` が両方 `null` を返すため、NavBar のみが表示されるブランク状態が生じていた
- `MsalProvider` 内で `useMsal` の `inProgress` を監視する `HomeContent` コンポーネントに切り出し、初期化中は `LoadingCircular` を表示するよう変更した
- 高速遷移時や dev 環境（HMR による再マウント）で特に目立っていた問題が解消される

## 確認事項

- lint・type-check・fmt はすべて pre-commit hook でパスしていることを確認済み
- MSAL 初期化完了後の動作（認証済み → MainMenu、未認証 → NeedToSignin）は変更していないため、既存の認証フローへの影響はない

🤖 Generated with Claude Code