### PR TITLE
docs: AI Agent ガイドとして AGENTS.md を追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# seichi-portal-frontend — Agent Guide
+
+## パッケージマネージャー
+
+`pnpm` を使う（Node.js 24.14.1 / pnpm 10.33.0 — `mise.toml` で管理）。
+
+## 技術スタック
+
+- **フレームワーク**: Next.js (App Router), React 19
+- **UI**: Material UI (MUI) v7, Emotion
+- **認証**: Microsoft MSAL (@azure/msal-browser / @azure/msal-react)
+- **API**: openapi-fetch, Zodios, SWR
+- **バリデーション**: Zod v4
+- **フォーム**: React Hook Form
+- **その他**: fp-ts, ts-pattern, dayjs
+- **言語**: TypeScript 5 (`@tsconfig/strictest` ベースの strict モード)
+- **Lint/Format**: ESLint 9 (flat config), Prettier
+- **Git フック**: Lefthook
+
+## 重要な規約
+
+- `src/generated/` は手動編集禁止。スキーマ変更後は `pnpm codegen` を実行する。
+- パス alias `@/*` → `./src/*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## 概要

- AI Agent が `npm`/`npx` を誤って使うのを防ぐため、`AGENTS.md` を追加した
- パッケージマネージャー（pnpm）、技術スタック、編集禁止ファイル（`src/generated/`）など、コードを読んでも判断しづらい非自明な情報を記載
- `CLAUDE.md` は `AGENTS.md` へのシンボリックリンクとし、内容を一元管理する

## 確認事項

- `ls -la CLAUDE.md` でシンボリックリンクが `AGENTS.md` を指していることを確認済み
- ドキュメントのみの変更のため、動作への影響なし

🤖 Generated with Claude Code