### PR TITLE
fix: フォーム一覧での <a> タグ入れ子による hydration エラーを修正する

### DIFF
--- a/src/app/(authed)/(standard)/forms/_components/FormList.tsx
+++ b/src/app/(authed)/(standard)/forms/_components/FormList.tsx
@@ -33,9 +33,14 @@ const EachForm = ({ form }: { form: FormItem }) => {
     <Box sx={{ minWidth: 275 }}>
       <Card variant="outlined">
         <CardContent>
-          <Typography variant="h5" component="div">
-            {form.title}
-          </Typography>
+          <Link
+            href={`/forms/${form.id}`}
+            sx={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <Typography variant="h5" component="div">
+              {form.title}
+            </Typography>
+          </Link>
           <Typography color="text.secondary">
             {formatResponsePeriod(
               responsePeriod?.start_at ?? null,
@@ -82,15 +87,9 @@ const FormList = ({ forms }: Props) => {
         ) : (
           forms.map((form) => {
             return (
-              <Link
-                href={`/forms/${form.id}`}
-                key={form.id}
-                sx={{ textDecoration: 'none' }}
-              >
-                <Item>
-                  <EachForm form={form} />
-                </Item>
-              </Link>
+              <Item key={form.id}>
+                <EachForm form={form} />
+              </Item>
             );
           })
         )}


### PR DESCRIPTION
## 概要

- フォームカード全体を MUI `<Link>`（= `<a>`）で囲みつつ、内側の「回答一覧」`<Button href=...>`（= `<a>`）も `<a>` としてレンダリングされており、HTML 仕様違反の `<a>` 入れ子が発生していた
- これにより Next.js が hydration エラーを報告していた
- 外側の `<Link>` ラッパーを削除し、フォームタイトルのみを `<Link>` でラップすることで入れ子を解消した

## 確認事項

- lint / type-check / fmt いずれも pre-commit フックで通過を確認済み
- ブラウザでの動作確認は未実施（環境依存のため）。レビュアーに `/forms` ページでの表示と hydration エラーが消えているかを確認いただけると助かります

🤖 Generated with Claude Code