### PR TITLE
fix: 新OpenAPIスキーマへの型定義・APIクライアント対応

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
@@ -31,11 +31,11 @@ import type { NonEmptyArray } from '@/generic/Types';
 import { proxyClient } from '@/lib/proxyClient';
 
 type Question = {
-  id?: number | null | undefined;
+  id?: string | null | undefined;
   title: string;
   description?: string | null | undefined;
-  question_type: string;
-  choices: string[];
+  question_type: 'Text' | 'SingleChoice' | 'MultipleChoice';
+  choices: { id?: number | null; label: string; position: number }[];
   is_required: boolean;
 };
 
@@ -88,19 +88,19 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
       // 複数選択可能で選択されているものがない回答: boolean
       if (typeof values == 'string') {
         return {
-          question_id: Number(key),
+          question_id: key,
           answer: values,
         };
       } else if (typeof values === 'boolean') {
         return [
           {
-            question_id: Number(key),
+            question_id: key,
             answer: '',
           },
         ];
       } else {
         return values.map((value) => ({
-          question_id: Number(key),
+          question_id: key,
           answer: value,
         }));
       }
@@ -138,9 +138,9 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
   };
 
   const generateInputSpace = (question: Question) => {
-    const qId = (question.id ?? '').toString();
+    const qId = question.id ?? '';
     switch (question.question_type) {
-      case 'TEXT':
+      case 'Text':
         return (
           <Input
             {...register(qId)}
@@ -150,7 +150,7 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
             fullWidth
           />
         );
-      case 'SINGLE': {
+      case 'SingleChoice': {
         // TODO: 選択をリセットできるようにする
         // TODO: 何も選択されなかったとき、APIに送られる値は空文字になるが許容されるか？undefinedやnullでなくてよい？
         const questionId = qId;
@@ -181,15 +181,15 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
           >
             {question.choices.map((choice, index) => {
               return (
-                <MenuItem key={`q-${qId}.a-${index}`} value={choice}>
-                  {choice}
+                <MenuItem key={`q-${qId}.a-${index}`} value={choice.label}>
+                  {choice.label}
                 </MenuItem>
               );
             })}
           </Select>
         );
       }
-      case 'MULTIPLE':
+      case 'MultipleChoice':
         return (
           <>
             <FormGroup
@@ -213,20 +213,19 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
                             if (!question.is_required) return true;
                             const errorMessage =
                               'この項目は必須です。少なくとも1つの項目にチェックを入れてください';
-                            // valueがbooleanであることは、何も選択されている項目がないことを示しているので、エラーとしてよい
                             if (typeof v === 'boolean') return errorMessage;
 
                             return v.length >= 1 || errorMessage;
                           },
                         },
                       })}
-                      value={choice}
+                      value={choice.label}
                       sx={{
                         wordBreak: 'break-all',
                       }}
                     />
                   }
-                  label={choice}
+                  label={choice.label}
                 />
               ))}
             </FormGroup>
@@ -308,7 +307,9 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
                         </Markdown>
                       </Box>
                     )}
-                    <Box width={'70%'}>{generateInputSpace(question)}</Box>
+                    <Box width={'70%'}>
+                      {generateInputSpace(question as unknown as Question)}
+                    </Box>
                   </Box>
                 </Item>
               );

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
@@ -31,11 +31,11 @@ import type { NonEmptyArray } from '@/generic/Types';
 import { proxyClient } from '@/lib/proxyClient';
 
 type Question = {
-  id?: string | null | undefined;
+  id: string;
   title: string;
   description?: string | null | undefined;
   question_type: 'Text' | 'SingleChoice' | 'MultipleChoice';
-  choices: { id?: number | null; label: string; position: number }[];
+  choices?: { id?: number | null; label: string; position: number }[];
   is_required: boolean;
 };
 
@@ -179,7 +179,7 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
               marginTop: '1rem',
             }}
           >
-            {question.choices.map((choice, index) => {
+            {question.choices?.map((choice, index) => {
               return (
                 <MenuItem key={`q-${qId}.a-${index}`} value={choice.label}>
                   {choice.label}
@@ -201,7 +201,7 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
                 alignItems: 'center',
               }}
             >
-              {question.choices.map((choice, index) => (
+              {question.choices?.map((choice, index) => (
                 <FormControlLabel
                   key={`q-${qId}.a-${index}`}
                   sx={{ width: '24%', justifyContent: 'center' }}
@@ -308,7 +308,7 @@ const AnswerForm = ({ questions: questions, formId }: Props) => {
                       </Box>
                     )}
                     <Box width={'70%'}>
-                      {generateInputSpace(question as unknown as Question)}
+                      {generateInputSpace(question as Question)}
                     </Box>
                   </Box>
                 </Item>

--- a/src/app/(authed)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(authed)/admin/forms/create/_components/FormCreateForm.tsx
@@ -50,9 +50,11 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
     append({
       title: '',
       description: '',
-      question_type: 'TEXT',
+      question_type: 'Text',
       choices: [],
       is_required: false,
+      position: 0,
+      template_key: '',
     });
   };
 

--- a/src/app/(authed)/admin/forms/create/_components/Question.tsx
+++ b/src/app/(authed)/admin/forms/create/_components/Question.tsx
@@ -87,7 +87,7 @@ const QuestionComponent = ({
         label="質問の種類"
         select
         required
-        defaultValue="TEXT"
+        defaultValue="Text"
         helperText="質問の種類を選択してください。"
         onChange={(event) => {
           // NOTE: 単純に onChange 書くと useWatchQuestionType が動作しないので field.onChangeを呼び出す必要がある

--- a/src/app/(authed)/admin/forms/create/_components/Question.tsx
+++ b/src/app/(authed)/admin/forms/create/_components/Question.tsx
@@ -48,7 +48,7 @@ const QuestionComponent = ({
   });
 
   const addChoice = useCallback(() => {
-    if (useWatchQuestionType !== 'TEXT') {
+    if (useWatchQuestionType !== 'Text') {
       appendChoices({ choice: '' });
     }
   }, [useWatchQuestionType, appendChoices]);
@@ -94,7 +94,7 @@ const QuestionComponent = ({
           // ref: https://github.com/orgs/react-hook-form/discussions/9144
           field.onChange(event);
 
-          if (event.target.value === 'TEXT') {
+          if (event.target.value === 'Text') {
             removeChoices();
           } else if (choicesField.length === 0) {
             // NOTE: choicesField.lengthが0であることを確認しないと
@@ -103,11 +103,11 @@ const QuestionComponent = ({
           }
         }}
       >
-        <MenuItem onSelect={() => removeChoices()} value="TEXT">
+        <MenuItem onSelect={() => removeChoices()} value="Text">
           テキスト
         </MenuItem>
-        <MenuItem value="SINGLE">単一選択</MenuItem>
-        <MenuItem value="MULTIPLE">複数選択</MenuItem>
+        <MenuItem value="SingleChoice">単一選択</MenuItem>
+        <MenuItem value="MultipleChoice">複数選択</MenuItem>
       </TextField>
       <FormControlLabel
         label="この質問への回答を必須にする"
@@ -119,7 +119,7 @@ const QuestionComponent = ({
         variant="outlined"
         startIcon={<Add />}
         onClick={() => addChoice()}
-        disabled={useWatchQuestionType == 'TEXT'}
+        disabled={useWatchQuestionType === 'Text'}
       >
         選択肢の追加
       </Button>

--- a/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
@@ -4,7 +4,6 @@ import {
   toCreateFormBody,
   toFormLabelsUpdateBody,
   toFormUpdateBody,
-  toQuestionsUpdateBody,
 } from '../_lib/formRequestBuilders';
 import type { Form } from '../_schema/createFormSchema';
 
@@ -27,26 +26,15 @@ export const useCreateForm = () => {
       }
       const createdFormId = createdForm.id;
 
-      const { response: setFormMetadataResponse } = await proxyClient.PATCH(
+      const { response: setFormMetadataResponse } = await proxyClient.PUT(
         '/forms/{id}',
         {
           params: { path: { id: createdFormId } },
-          body: toFormUpdateBody(data),
+          body: toFormUpdateBody(data, false),
         }
       );
       if (!setFormMetadataResponse.ok) {
         throw new Error('フォームのメタデータの設定に失敗しました。');
-      }
-
-      const { response: addQuestionResponse } = await proxyClient.PUT(
-        '/forms/{id}/questions',
-        {
-          params: { path: { id: createdFormId } },
-          body: toQuestionsUpdateBody(data),
-        }
-      );
-      if (!addQuestionResponse.ok) {
-        throw new Error('質問の追加に失敗しました。');
       }
 
       const { response: putLabelsResponse } = await proxyClient.PUT(

--- a/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
+++ b/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
@@ -4,18 +4,31 @@ import type { Form } from '../_schema/createFormSchema';
 type CreateFormBody =
   paths['/forms']['post']['requestBody']['content']['application/json'];
 type FormUpdateBody =
-  paths['/forms/{id}']['patch']['requestBody']['content']['application/json'];
-type QuestionsUpdateBody =
-  paths['/forms/{id}/questions']['put']['requestBody']['content']['application/json'];
+  paths['/forms/{id}']['put']['requestBody']['content']['application/json'];
 type FormLabelsUpdateBody =
   paths['/forms/{form_id}/labels']['put']['requestBody']['content']['application/json'];
 
 export const toCreateFormBody = (data: Form): CreateFormBody => ({
   title: data.title,
   description: data.description,
+  questions: data.questions.map((question) => ({
+    title: question.title,
+    description: question.description,
+    question_type: question.question_type,
+    is_required: question.is_required,
+    position: question.position,
+    template_key: question.template_key,
+    choices: question.choices.map((choice) => ({
+      label: choice.choice,
+      position: 0,
+    })),
+  })),
 });
 
-export const toFormUpdateBody = (data: Form): FormUpdateBody => {
+export const toFormUpdateBody = (
+  data: Form,
+  includeQuestions: boolean
+): FormUpdateBody => {
   const start_at = data.settings.response_period.start_at;
   const end_at = data.settings.response_period.end_at;
 
@@ -39,15 +52,22 @@ export const toFormUpdateBody = (data: Form): FormUpdateBody => {
         visibility: data.settings.answer_visibility,
       },
     },
+    questions: includeQuestions
+      ? data.questions.map((question) => ({
+          title: question.title,
+          description: question.description,
+          question_type: question.question_type,
+          is_required: question.is_required,
+          position: question.position,
+          template_key: question.template_key,
+          choices: question.choices.map((choice) => ({
+            label: choice.choice,
+            position: 0,
+          })),
+        }))
+      : null,
   };
 };
-
-export const toQuestionsUpdateBody = (data: Form): QuestionsUpdateBody => ({
-  questions: data.questions.map((question) => ({
-    ...question,
-    choices: question.choices.map((choice) => choice.choice),
-  })),
-});
 
 export const toFormLabelsUpdateBody = (data: Form): FormLabelsUpdateBody => ({
   labels: data.labels.map((label) => label.id),

--- a/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
+++ b/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
@@ -18,9 +18,9 @@ export const toCreateFormBody = (data: Form): CreateFormBody => ({
     is_required: question.is_required,
     position: question.position,
     template_key: question.template_key,
-    choices: question.choices.map((choice) => ({
+    choices: question.choices.map((choice, index) => ({
       label: choice.choice,
-      position: 0,
+      position: index,
     })),
   })),
 });
@@ -32,7 +32,7 @@ export const toFormUpdateBody = (
   const start_at = data.settings.response_period.start_at;
   const end_at = data.settings.response_period.end_at;
 
-  return {
+  const body: FormUpdateBody = {
     title: data.title,
     description: data.description,
     settings: {
@@ -52,21 +52,24 @@ export const toFormUpdateBody = (
         visibility: data.settings.answer_visibility,
       },
     },
-    questions: includeQuestions
-      ? data.questions.map((question) => ({
-          title: question.title,
-          description: question.description,
-          question_type: question.question_type,
-          is_required: question.is_required,
-          position: question.position,
-          template_key: question.template_key,
-          choices: question.choices.map((choice) => ({
-            label: choice.choice,
-            position: 0,
-          })),
-        }))
-      : null,
   };
+
+  if (includeQuestions) {
+    body.questions = data.questions.map((question) => ({
+      title: question.title,
+      description: question.description,
+      question_type: question.question_type,
+      is_required: question.is_required,
+      position: question.position,
+      template_key: question.template_key,
+      choices: question.choices.map((choice, index) => ({
+        label: choice.choice,
+        position: index,
+      })),
+    }));
+  }
+
+  return body;
 };
 
 export const toFormLabelsUpdateBody = (data: Form): FormLabelsUpdateBody => ({

--- a/src/app/(authed)/admin/forms/create/_schema/createFormSchema.ts
+++ b/src/app/(authed)/admin/forms/create/_schema/createFormSchema.ts
@@ -7,9 +7,11 @@ const choiceSchema = z.object({
 export const questionSchema = z.object({
   title: z.string(),
   description: z.string(),
-  question_type: z.enum(['TEXT', 'SINGLE', 'MULTIPLE']),
+  question_type: z.enum(['Text', 'SingleChoice', 'MultipleChoice']),
   choices: choiceSchema.array(),
   is_required: z.boolean(),
+  position: z.number().int().gte(0),
+  template_key: z.string(),
 });
 
 const visibility = z.enum(['PUBLIC', 'PRIVATE']);

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -134,9 +134,9 @@ const FormEditForm = (props: {
         is_required: question.is_required,
         position: question.position,
         template_key: question.template_key,
-        choices: question.choices.map((choice) => ({
+        choices: question.choices.map((choice, index) => ({
           label: choice.choice,
-          position: 0,
+          position: index,
         })),
       })),
     });

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -17,7 +17,7 @@ import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { fromStringToJSTDateTime } from '@/generic/DateFormatter';
 import { useFormEditActions } from '@/hooks/useFormEditActions';
 
-const questionTypeSchema = z.enum(['TEXT', 'SINGLE', 'MULTIPLE']);
+const questionTypeSchema = z.enum(['Text', 'SingleChoice', 'MultipleChoice']);
 const formVisibilitySchema = z.enum(['PUBLIC', 'PRIVATE']);
 import FormSettings from './FormSettings';
 import QuestionComponent from './Question';
@@ -49,10 +49,17 @@ const FormEditForm = (props: {
         description: question.description ?? '',
         question_type: (() => {
           const result = questionTypeSchema.safeParse(question.question_type);
-          return result.success ? result.data : 'TEXT';
+          return result.success ? result.data : 'Text';
         })(),
         is_required: question.is_required,
-        choices: question.choices.map((choice) => ({ choice })),
+        position: question.position,
+        template_key: question.template_key,
+        choices:
+          'choices' in question
+            ? (question as { choices: { label: string }[] }).choices.map(
+                (choice) => ({ choice: choice.label })
+              )
+            : [],
       })),
       settings: {
         has_response_period: start_at && end_at ? true : false,
@@ -92,13 +99,13 @@ const FormEditForm = (props: {
   });
 
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const { updateFormMeta, updateQuestions } = useFormEditActions(props.form.id);
+  const { updateForm } = useFormEditActions(props.form.id);
 
   const onSubmit = async (data: Form) => {
     const start_at = data.settings.response_period?.start_at;
     const end_at = data.settings.response_period?.end_at;
 
-    const metaResult = await updateFormMeta({
+    const result = await updateForm({
       title: data.title,
       description: data.description,
       settings: {
@@ -115,38 +122,31 @@ const FormEditForm = (props: {
             : null,
         },
       },
-    });
-
-    if (!metaResult.ok) {
-      setError('root', {
-        type: 'manual',
-        message: 'フォームのメタデータの更新に失敗しました。',
-      });
-    }
-
-    const questionsResult = await updateQuestions({
       questions: data.questions.map((question) => ({
         id: props.form.questions.find(
-          (beforeQuestion) => beforeQuestion.id == question.id
+          (beforeQuestion) => beforeQuestion.id === question.id
         )
           ? question.id
           : null,
         title: question.title,
         description: question.description,
         question_type: question.question_type,
-        choices: question.choices.map((choice) => choice.choice),
         is_required: question.is_required,
+        position: question.position,
+        template_key: question.template_key,
+        choices: question.choices.map((choice) => ({
+          label: choice.choice,
+          position: 0,
+        })),
       })),
     });
 
-    if (!questionsResult.ok) {
+    if (!result.ok) {
       setError('root', {
         type: 'manual',
-        message: 'フォームの質問の更新に失敗しました。',
+        message: 'フォームの更新に失敗しました。',
       });
-    }
-
-    if (metaResult.ok && questionsResult.ok) {
+    } else {
       setIsSubmitted(true);
     }
   };
@@ -180,6 +180,8 @@ const FormEditForm = (props: {
                       question_type: field.question_type,
                       is_required: field.is_required,
                       choices: field.choices.map((choice) => choice.choice),
+                      position: field.position,
+                      template_key: field.template_key,
                     }}
                     index={index}
                   />
@@ -209,9 +211,11 @@ const FormEditForm = (props: {
                   id: null,
                   title: '',
                   description: '',
-                  question_type: 'TEXT',
+                  question_type: 'Text',
                   choices: [],
                   is_required: false,
+                  position: 0,
+                  template_key: '',
                 });
               }}
               endIcon={<Add />}

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/Question.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/Question.tsx
@@ -18,12 +18,14 @@ import type { Form } from '../_schema/editFormSchema';
 import type { Control, UseFormRegister } from 'react-hook-form';
 
 interface Question {
-  id: number | null;
+  id: string | null;
   title: string;
   description: string;
-  question_type: 'TEXT' | 'SINGLE' | 'MULTIPLE';
+  question_type: 'Text' | 'SingleChoice' | 'MultipleChoice';
   choices: string[];
   is_required: boolean;
+  position: number;
+  template_key: string;
 }
 
 const QuestionComponent = ({
@@ -59,7 +61,7 @@ const QuestionComponent = ({
   });
 
   const addChoice = useCallback(() => {
-    if (useWatchQuestionType !== 'TEXT') {
+    if (useWatchQuestionType !== 'Text') {
       appendChoices({ choice: '' });
     }
   }, [useWatchQuestionType, appendChoices]);
@@ -108,7 +110,7 @@ const QuestionComponent = ({
         onChange={(event) => {
           field.onChange(event);
 
-          if (event.target.value === 'TEXT') {
+          if (event.target.value === 'Text') {
             removeChoices();
           } else if (choicesField.length === 0) {
             // NOTE: choicesField.lengthが0であることを確認しないと
@@ -117,11 +119,11 @@ const QuestionComponent = ({
           }
         }}
       >
-        <MenuItem onSelect={() => removeChoices()} value="TEXT">
+        <MenuItem onSelect={() => removeChoices()} value="Text">
           テキスト
         </MenuItem>
-        <MenuItem value="SINGLE">単一選択</MenuItem>
-        <MenuItem value="MULTIPLE">複数選択</MenuItem>
+        <MenuItem value="SingleChoice">単一選択</MenuItem>
+        <MenuItem value="MultipleChoice">複数選択</MenuItem>
       </TextField>
       <FormControlLabel
         label="この質問への回答を必須にする"
@@ -133,7 +135,7 @@ const QuestionComponent = ({
         variant="outlined"
         startIcon={<Add />}
         onClick={() => addChoice()}
-        disabled={useWatchQuestionType == 'TEXT'}
+        disabled={useWatchQuestionType === 'Text'}
       >
         選択肢の追加
       </Button>

--- a/src/app/(authed)/admin/forms/edit/[id]/_schema/editFormSchema.ts
+++ b/src/app/(authed)/admin/forms/edit/[id]/_schema/editFormSchema.ts
@@ -7,9 +7,11 @@ const choiceSchema = z.object({
 export const questionSchema = z.object({
   title: z.string(),
   description: z.string(),
-  question_type: z.enum(['TEXT', 'SINGLE', 'MULTIPLE']),
+  question_type: z.enum(['Text', 'SingleChoice', 'MultipleChoice']),
   choices: choiceSchema.array(),
   is_required: z.boolean(),
+  position: z.number().int().gte(0),
+  template_key: z.string(),
 });
 
 const _visibility = z.enum(['PUBLIC', 'PRIVATE']);
@@ -20,12 +22,14 @@ export const formSchema = z.object({
   description: z.string(),
   questions: z
     .object({
-      id: z.number().nullable(),
+      id: z.string().nullable(),
       title: z.string(),
       description: z.string(),
-      question_type: z.enum(['TEXT', 'SINGLE', 'MULTIPLE']),
+      question_type: z.enum(['Text', 'SingleChoice', 'MultipleChoice']),
       choices: z.object({ choice: z.string() }).array(),
       is_required: z.boolean(),
+      position: z.number().int().gte(0),
+      template_key: z.string(),
     })
     .array(),
   settings: z.object({

--- a/src/generated/api-client.ts
+++ b/src/generated/api-client.ts
@@ -10,17 +10,38 @@ const FormMetaSchema = z
     updated_at: z.string().datetime({ offset: true }),
   })
   .passthrough();
-const QuestionResponseSchema = z
+const QuestionDefinitionResponseSchema = z
   .object({
-    choices: z.array(z.string()),
     description: z.union([z.string(), z.null()]).optional(),
-    form_id: z.string(),
-    id: z.union([z.number(), z.null()]).optional(),
+    id: z.string().uuid(),
     is_required: z.boolean(),
-    question_type: z.string(),
+    position: z.number().int().gte(0),
+    template_key: z.string(),
     title: z.string(),
   })
   .passthrough();
+const TextQuestionResponseSchema = QuestionDefinitionResponseSchema;
+const ChoiceResponseSchema = z
+  .object({
+    id: z.union([z.number(), z.null()]).optional(),
+    label: z.string(),
+    position: z.number().int().gte(0),
+  })
+  .passthrough();
+const SelectQuestionResponseSchema = QuestionDefinitionResponseSchema.and(
+  z.object({ choices: z.array(ChoiceResponseSchema) }).passthrough()
+);
+const QuestionResponseSchema = z.union([
+  TextQuestionResponseSchema.and(
+    z.object({ question_type: z.literal("Text") }).passthrough()
+  ),
+  SelectQuestionResponseSchema.and(
+    z.object({ question_type: z.literal("SingleChoice") }).passthrough()
+  ),
+  SelectQuestionResponseSchema.and(
+    z.object({ question_type: z.literal("MultipleChoice") }).passthrough()
+  ),
+]);
 const ResponsePeriodInput = z
   .object({
     end_at: z.union([z.string(), z.null()]),
@@ -55,11 +76,47 @@ const FormSchema = z
     title: z.string(),
   })
   .passthrough();
+const QuestionDefinitionSchema = z
+  .object({
+    description: z.union([z.string(), z.null()]).optional(),
+    id: z.union([z.string(), z.null()]).optional(),
+    is_required: z.boolean(),
+    position: z.number().int().gte(0),
+    template_key: z.string(),
+    title: z.string(),
+  })
+  .passthrough();
+const TextQuestionSchema = QuestionDefinitionSchema;
+const ChoiceSchema = z
+  .object({
+    id: z.union([z.number(), z.null()]).optional(),
+    label: z.string(),
+    position: z.number().int().gte(0),
+  })
+  .passthrough();
+const SelectQuestionSchema = QuestionDefinitionSchema.and(
+  z.object({ choices: z.array(ChoiceSchema) }).passthrough()
+);
+const QuestionSchema = z.union([
+  TextQuestionSchema.and(
+    z.object({ question_type: z.literal("Text") }).passthrough()
+  ),
+  SelectQuestionSchema.and(
+    z.object({ question_type: z.literal("SingleChoice") }).passthrough()
+  ),
+  SelectQuestionSchema.and(
+    z.object({ question_type: z.literal("MultipleChoice") }).passthrough()
+  ),
+]);
 const FormCreateSchema = z
-  .object({ description: z.string(), title: z.string() })
+  .object({
+    description: z.string(),
+    questions: z.array(QuestionSchema).min(1),
+    title: z.string(),
+  })
   .passthrough();
 const AnswerContent = z
-  .object({ answer: z.string(), question_id: z.number().int() })
+  .object({ answer: z.string(), question_id: z.string().uuid() })
   .passthrough();
 const Role = z.enum(["STANDARD_USER", "ADMINISTRATOR"]);
 const User = z
@@ -124,33 +181,17 @@ const ReplaceFormLabelSchema = z
 const FormUpdateSchema = z
   .object({
     description: z.union([z.string(), z.null()]),
+    questions: z.union([z.array(QuestionSchema), z.null()]),
     settings: z.union([z.null(), FormSettingsSchema]),
     title: z.union([z.string(), z.null()]),
   })
   .partial()
   .passthrough();
 const AnswerContentSchema = z
-  .object({ answer: z.string(), question_id: z.number().int() })
+  .object({ answer: z.string(), question_id: z.string().uuid() })
   .passthrough();
 const AnswerCreateSchema = z
   .object({ contents: z.array(AnswerContentSchema) })
-  .passthrough();
-const QuestionSchema = z
-  .object({
-    choices: z.array(z.string()).optional(),
-    description: z.union([z.string(), z.null()]).optional(),
-    id: z.union([z.number(), z.null()]).optional(),
-    is_required: z.boolean(),
-    question_type: z.string(),
-    title: z.string(),
-  })
-  .passthrough();
-const FormQuestionPutSchema = z
-  .object({ questions: z.array(QuestionSchema) })
-  .partial()
-  .passthrough();
-const PutQuestionsResponseSchema = z
-  .object({ questions: z.array(QuestionResponseSchema) })
   .passthrough();
 const AnswerLabelResponseSchema = z
   .object({ id: z.string(), name: z.string() })
@@ -222,11 +263,20 @@ const UserUpdateSchema = z
 export const schemas = {
   FormLabelResponseSchema,
   FormMetaSchema,
+  QuestionDefinitionResponseSchema,
+  TextQuestionResponseSchema,
+  ChoiceResponseSchema,
+  SelectQuestionResponseSchema,
   QuestionResponseSchema,
   ResponsePeriodInput,
   AnswerSettingsSchema,
   FormSettingsSchema,
   FormSchema,
+  QuestionDefinitionSchema,
+  TextQuestionSchema,
+  ChoiceSchema,
+  SelectQuestionSchema,
+  QuestionSchema,
   FormCreateSchema,
   AnswerContent,
   Role,
@@ -247,9 +297,6 @@ export const schemas = {
   FormUpdateSchema,
   AnswerContentSchema,
   AnswerCreateSchema,
-  QuestionSchema,
-  FormQuestionPutSchema,
-  PutQuestionsResponseSchema,
   AnswerLabelResponseSchema,
   AnswerLabelSchema,
   AnswerLabelUpdateSchema,
@@ -987,50 +1034,10 @@ const endpoints = makeApi([
     ],
   },
   {
-    method: "delete",
-    path: "/forms/:id",
-    alias: "delete_form_handler",
-    requestFormat: "json",
-    parameters: [
-      {
-        name: "id",
-        type: "Path",
-        schema: z.string(),
-      },
-    ],
-    response: z.void(),
-    errors: [
-      {
-        status: 400,
-        description: `The server could not understand the request due to invalid syntax.`,
-        schema: z.void(),
-      },
-      {
-        status: 401,
-        description: `Access is unauthorized.`,
-        schema: z.void(),
-      },
-      {
-        status: 403,
-        description: `Access is forbidden.`,
-        schema: z.void(),
-      },
-      {
-        status: 404,
-        description: `The server cannot find the requested resource.`,
-        schema: z.void(),
-      },
-      {
-        status: 500,
-        description: `Server error`,
-        schema: z.void(),
-      },
-    ],
-  },
-  {
-    method: "patch",
+    method: "put",
     path: "/forms/:id",
     alias: "update_form_handler",
+    description: `questions を含めた場合、その form 配下の question 定義全体を指定内容で置換します。questions を省略した場合は既存 question を保持します。`,
     requestFormat: "json",
     parameters: [
       {
@@ -1069,6 +1076,47 @@ const endpoints = makeApi([
       {
         status: 422,
         description: `Client error`,
+        schema: z.void(),
+      },
+      {
+        status: 500,
+        description: `Server error`,
+        schema: z.void(),
+      },
+    ],
+  },
+  {
+    method: "delete",
+    path: "/forms/:id",
+    alias: "delete_form_handler",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "id",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: z.void(),
+    errors: [
+      {
+        status: 400,
+        description: `The server could not understand the request due to invalid syntax.`,
+        schema: z.void(),
+      },
+      {
+        status: 401,
+        description: `Access is unauthorized.`,
+        schema: z.void(),
+      },
+      {
+        status: 403,
+        description: `Access is forbidden.`,
+        schema: z.void(),
+      },
+      {
+        status: 404,
+        description: `The server cannot find the requested resource.`,
         schema: z.void(),
       },
       {
@@ -1142,98 +1190,6 @@ const endpoints = makeApi([
       },
     ],
     response: z.void(),
-    errors: [
-      {
-        status: 400,
-        description: `The server could not understand the request due to invalid syntax.`,
-        schema: z.void(),
-      },
-      {
-        status: 401,
-        description: `Access is unauthorized.`,
-        schema: z.void(),
-      },
-      {
-        status: 403,
-        description: `Access is forbidden.`,
-        schema: z.void(),
-      },
-      {
-        status: 404,
-        description: `The server cannot find the requested resource.`,
-        schema: z.void(),
-      },
-      {
-        status: 422,
-        description: `Client error`,
-        schema: z.void(),
-      },
-      {
-        status: 500,
-        description: `Server error`,
-        schema: z.void(),
-      },
-    ],
-  },
-  {
-    method: "get",
-    path: "/forms/:id/questions",
-    alias: "get_questions_handler",
-    requestFormat: "json",
-    parameters: [
-      {
-        name: "id",
-        type: "Path",
-        schema: z.string(),
-      },
-    ],
-    response: z.array(QuestionResponseSchema),
-    errors: [
-      {
-        status: 400,
-        description: `The server could not understand the request due to invalid syntax.`,
-        schema: z.void(),
-      },
-      {
-        status: 401,
-        description: `Access is unauthorized.`,
-        schema: z.void(),
-      },
-      {
-        status: 403,
-        description: `Access is forbidden.`,
-        schema: z.void(),
-      },
-      {
-        status: 404,
-        description: `The server cannot find the requested resource.`,
-        schema: z.void(),
-      },
-      {
-        status: 500,
-        description: `Server error`,
-        schema: z.void(),
-      },
-    ],
-  },
-  {
-    method: "put",
-    path: "/forms/:id/questions",
-    alias: "put_question_handler",
-    requestFormat: "json",
-    parameters: [
-      {
-        name: "body",
-        type: "Body",
-        schema: FormQuestionPutSchema,
-      },
-      {
-        name: "id",
-        type: "Path",
-        schema: z.string(),
-      },
-    ],
-    response: PutQuestionsResponseSchema,
     errors: [
       {
         status: 400,

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -170,14 +170,17 @@ export interface paths {
         };
         /** フォームの取得 */
         get: operations["get_form_handler"];
-        put?: never;
+        /**
+         * フォームの更新
+         * @description questions を含めた場合、その form 配下の question 定義全体を指定内容で置換します。questions を省略した場合は既存 question を保持します。
+         */
+        put: operations["update_form_handler"];
         post?: never;
         /** フォームの削除 */
         delete: operations["delete_form_handler"];
         options?: never;
         head?: never;
-        /** フォームの更新 */
-        patch: operations["update_form_handler"];
+        patch?: never;
         trace?: never;
     };
     "/forms/{id}/answers": {
@@ -192,24 +195,6 @@ export interface paths {
         put?: never;
         /** 回答の作成 */
         post: operations["post_answer_handler"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/forms/{id}/questions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** 質問の一覧取得 */
-        get: operations["get_questions_handler"];
-        /** 質問の上書き */
-        put: operations["put_question_handler"];
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -456,13 +441,13 @@ export interface components {
         };
         AnswerContent: {
             answer: string;
-            /** Format: int32 */
-            question_id: number;
+            /** Format: uuid */
+            question_id: string;
         };
         AnswerContentSchema: {
             answer: string;
-            /** Format: int32 */
-            question_id: number;
+            /** Format: uuid */
+            question_id: string;
         };
         AnswerCreateSchema: {
             contents: components["schemas"]["AnswerContentSchema"][];
@@ -492,6 +477,20 @@ export interface components {
         };
         /** @enum {string} */
         AnswerVisibility: "PUBLIC" | "PRIVATE";
+        ChoiceResponseSchema: {
+            /** Format: int32 */
+            id?: number | null;
+            label: string;
+            /** Format: int32 */
+            position: number;
+        };
+        ChoiceSchema: {
+            /** Format: int32 */
+            id?: number | null;
+            label: string;
+            /** Format: int32 */
+            position: number;
+        };
         CommentPostSchema: {
             content: components["schemas"]["NonEmptyString"];
         };
@@ -541,6 +540,7 @@ export interface components {
         };
         FormCreateSchema: {
             description: string;
+            questions: components["schemas"]["QuestionSchema"][];
             title: string;
         };
         FormLabelCreateSchema: {
@@ -559,9 +559,6 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
-        FormQuestionPutSchema: {
-            questions?: components["schemas"]["QuestionSchema"][];
-        };
         FormSchema: {
             description: string;
             /** Format: uuid */
@@ -579,6 +576,11 @@ export interface components {
         };
         FormUpdateSchema: {
             description?: string | null;
+            /**
+             * @description When provided, replaces the full set of question definitions under the form.
+             *     Omit this field to leave existing questions unchanged.
+             */
+            questions?: components["schemas"]["QuestionSchema"][] | null;
             settings?: null | components["schemas"]["FormSettingsSchema"];
             title?: string | null;
         };
@@ -603,28 +605,46 @@ export interface components {
         PostedMessageSchema: {
             body: string;
         };
-        PutQuestionsResponseSchema: {
-            questions: components["schemas"]["QuestionResponseSchema"][];
-        };
-        QuestionResponseSchema: {
-            choices: string[];
+        QuestionDefinitionResponseSchema: {
             description?: string | null;
-            form_id: string;
-            /** Format: int32 */
-            id?: number | null;
+            /** Format: uuid */
+            id: string;
             is_required: boolean;
-            question_type: string;
+            /** Format: int32 */
+            position: number;
+            template_key: string;
             title: string;
         };
-        QuestionSchema: {
-            choices?: string[];
+        QuestionDefinitionSchema: {
             description?: string | null;
-            /** Format: int32 */
-            id?: number | null;
+            /** Format: uuid */
+            id?: string | null;
             is_required: boolean;
-            question_type: string;
+            /** Format: int32 */
+            position: number;
+            template_key: string;
             title: string;
         };
+        QuestionResponseSchema: (components["schemas"]["TextQuestionResponseSchema"] & {
+            /** @enum {string} */
+            question_type: "Text";
+        }) | (components["schemas"]["SelectQuestionResponseSchema"] & {
+            /** @enum {string} */
+            question_type: "SingleChoice";
+        }) | (components["schemas"]["SelectQuestionResponseSchema"] & {
+            /** @enum {string} */
+            question_type: "MultipleChoice";
+        });
+        QuestionSchema: (components["schemas"]["TextQuestionSchema"] & {
+            /** @enum {string} */
+            question_type: "Text";
+        }) | (components["schemas"]["SelectQuestionSchema"] & {
+            /** @enum {string} */
+            question_type: "SingleChoice";
+        }) | (components["schemas"]["SelectQuestionSchema"] & {
+            /** @enum {string} */
+            question_type: "MultipleChoice";
+        });
         ReplaceAnswerLabelSchema: {
             labels: string[];
         };
@@ -643,6 +663,12 @@ export interface components {
         };
         /** @enum {string} */
         Role: "STANDARD_USER" | "ADMINISTRATOR";
+        SelectQuestionResponseSchema: components["schemas"]["QuestionDefinitionResponseSchema"] & {
+            choices: components["schemas"]["ChoiceResponseSchema"][];
+        };
+        SelectQuestionSchema: components["schemas"]["QuestionDefinitionSchema"] & {
+            choices: components["schemas"]["ChoiceSchema"][];
+        };
         SenderSchema: {
             name: string;
             role: string;
@@ -652,6 +678,8 @@ export interface components {
             /** Format: int32 */
             expires: number;
         };
+        TextQuestionResponseSchema: components["schemas"]["QuestionDefinitionResponseSchema"];
+        TextQuestionSchema: components["schemas"]["QuestionDefinitionSchema"];
         User: {
             name: string;
             role: components["schemas"]["Role"];
@@ -1875,72 +1903,6 @@ export interface operations {
             };
         };
     };
-    delete_form_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description There is no content to send for this request, but the headers may be useful. */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
     update_form_handler: {
         parameters: {
             query?: never;
@@ -2004,6 +1966,72 @@ export interface operations {
             };
             /** @description Client error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    delete_form_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description There is no content to send for this request, but the headers may be useful. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2121,155 +2149,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Client error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    get_questions_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["QuestionResponseSchema"][];
-                };
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    put_question_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FormQuestionPutSchema"];
-            };
-        };
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PutQuestionsResponseSchema"];
-                };
             };
             /** @description The server could not understand the request due to invalid syntax. */
             400: {

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -4,30 +4,16 @@ import { proxyClient } from '@/lib/proxyClient';
 import type { paths } from '@/generated/api-types';
 
 type FormUpdateBody =
-  paths['/forms/{id}']['patch']['requestBody']['content']['application/json'];
-type QuestionsUpdateBody =
-  paths['/forms/{id}/questions']['put']['requestBody']['content']['application/json'];
+  paths['/forms/{id}']['put']['requestBody']['content']['application/json'];
 
 export const useFormEditActions = (formId: string) => {
-  const updateFormMeta = async (
-    body: FormUpdateBody
-  ): Promise<{ ok: boolean }> => {
-    const { response } = await proxyClient.PATCH('/forms/{id}', {
+  const updateForm = async (body: FormUpdateBody): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.PUT('/forms/{id}', {
       params: { path: { id: formId } },
       body,
     });
     return { ok: response.ok };
   };
 
-  const updateQuestions = async (
-    body: QuestionsUpdateBody
-  ): Promise<{ ok: boolean }> => {
-    const { response } = await proxyClient.PUT('/forms/{id}/questions', {
-      params: { path: { id: formId } },
-      body,
-    });
-    return { ok: response.ok };
-  };
-
-  return { updateFormMeta, updateQuestions };
+  return { updateForm };
 };


### PR DESCRIPTION
## 概要
- バックエンドの OpenAPI スキーマ変更（question_id UUID 化、PATCH→PUT、質問スキーマ再設計）に追従するため、フロントエンドの型定義・API クライアント・フォームコンポーネントを修正
- `pnpm codegen` で生成ファイルを再生成、その後スキーマ変更に伴う型エラーを全件修正

## 確認事項
- `pnpm type-check`（tsc --noEmit）がパスすることを確認
- `pnpm lint`（ESLint）がパスすることを確認
- `pnpm build`（Next.js 本番ビルド）が成功することを確認
- Prettier フォーマット確認済み

## 補足
- 生成ファイル (`src/generated/`) は手動編集禁止のため、`pnpm codegen` で再生成している
- 選択肢の内部フィールド名は `choice` のまま維持し、API へのマッピング時のみ `label` に変換している

🤖 Generated with OpenCode