### PR TITLE
fix: Text質問にchoicesが送信され422エラーになる問題を修正

### DIFF
--- a/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
+++ b/src/app/(authed)/admin/forms/create/_lib/formRequestBuilders.ts
@@ -8,10 +8,18 @@ type FormUpdateBody =
 type FormLabelsUpdateBody =
   paths['/forms/{form_id}/labels']['put']['requestBody']['content']['application/json'];
 
-export const toCreateFormBody = (data: Form): CreateFormBody => ({
-  title: data.title,
-  description: data.description,
-  questions: data.questions.map((question) => ({
+const mapQuestion = (question: Form['questions'][number]) => {
+  if (question.question_type === 'Text') {
+    return {
+      title: question.title,
+      description: question.description,
+      question_type: question.question_type,
+      is_required: question.is_required,
+      position: question.position,
+      template_key: question.template_key,
+    };
+  }
+  return {
     title: question.title,
     description: question.description,
     question_type: question.question_type,
@@ -22,7 +30,13 @@ export const toCreateFormBody = (data: Form): CreateFormBody => ({
       label: choice.choice,
       position: index,
     })),
-  })),
+  };
+};
+
+export const toCreateFormBody = (data: Form): CreateFormBody => ({
+  title: data.title,
+  description: data.description,
+  questions: data.questions.map(mapQuestion),
 });
 
 export const toFormUpdateBody = (
@@ -55,18 +69,7 @@ export const toFormUpdateBody = (
   };
 
   if (includeQuestions) {
-    body.questions = data.questions.map((question) => ({
-      title: question.title,
-      description: question.description,
-      question_type: question.question_type,
-      is_required: question.is_required,
-      position: question.position,
-      template_key: question.template_key,
-      choices: question.choices.map((choice, index) => ({
-        label: choice.choice,
-        position: index,
-      })),
-    }));
+    body.questions = data.questions.map(mapQuestion);
   }
 
   return body;

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -122,23 +122,40 @@ const FormEditForm = (props: {
             : null,
         },
       },
-      questions: data.questions.map((question) => ({
-        id: props.form.questions.find(
-          (beforeQuestion) => beforeQuestion.id === question.id
-        )
-          ? question.id
-          : null,
-        title: question.title,
-        description: question.description,
-        question_type: question.question_type,
-        is_required: question.is_required,
-        position: question.position,
-        template_key: question.template_key,
-        choices: question.choices.map((choice, index) => ({
-          label: choice.choice,
-          position: index,
-        })),
-      })),
+      questions: data.questions.map((question) => {
+        if (question.question_type === 'Text') {
+          return {
+            id: props.form.questions.find(
+              (beforeQuestion) => beforeQuestion.id === question.id
+            )
+              ? question.id
+              : null,
+            title: question.title,
+            description: question.description,
+            question_type: question.question_type,
+            is_required: question.is_required,
+            position: question.position,
+            template_key: question.template_key,
+          };
+        }
+        return {
+          id: props.form.questions.find(
+            (beforeQuestion) => beforeQuestion.id === question.id
+          )
+            ? question.id
+            : null,
+          title: question.title,
+          description: question.description,
+          question_type: question.question_type,
+          is_required: question.is_required,
+          position: question.position,
+          template_key: question.template_key,
+          choices: question.choices.map((choice, index) => ({
+            label: choice.choice,
+            position: index,
+          })),
+        };
+      }),
     });
 
     if (!result.ok) {

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -123,22 +123,7 @@ const FormEditForm = (props: {
         },
       },
       questions: data.questions.map((question) => {
-        if (question.question_type === 'Text') {
-          return {
-            id: props.form.questions.find(
-              (beforeQuestion) => beforeQuestion.id === question.id
-            )
-              ? question.id
-              : null,
-            title: question.title,
-            description: question.description,
-            question_type: question.question_type,
-            is_required: question.is_required,
-            position: question.position,
-            template_key: question.template_key,
-          };
-        }
-        return {
+        const questionFields = {
           id: props.form.questions.find(
             (beforeQuestion) => beforeQuestion.id === question.id
           )
@@ -146,10 +131,20 @@ const FormEditForm = (props: {
             : null,
           title: question.title,
           description: question.description,
-          question_type: question.question_type,
           is_required: question.is_required,
           position: question.position,
           template_key: question.template_key,
+        };
+
+        if (question.question_type === 'Text') {
+          return {
+            ...questionFields,
+            question_type: question.question_type,
+          };
+        }
+        return {
+          ...questionFields,
+          question_type: question.question_type,
           choices: question.choices.map((choice, index) => ({
             label: choice.choice,
             position: index,


### PR DESCRIPTION
## 概要
- フォームの更新・作成時に、質問タイプに関係なく常に `choices` フィールドが送信されていた
- `Text` タイプの質問には `choices` フィールドが存在しないため、バックエンド（Rust/serde）の strict なデシリアライズで `unknown field 'choices'` の 422 エラーが発生していた
- `question_type === 'Text'` の場合は `choices` を除外するよう、フォーム作成・編集の両方のリクエスト構築処理を修正

## 確認事項
- `pnpm run type-check` および `pnpm run lint` が通過することを確認
- フォーム作成時 (`toCreateFormBody`, `toFormUpdateBody`) と編集時 (`FormEditForm.tsx`) の両方で、Text / SingleChoice / MultipleChoice それぞれの質問タイプで適切に choices が制御されることをロジック上確認

## 補足
- 編集画面の `onSubmit` と作成画面の `formRequestBuilders` で同じ分岐ロジックが必要だったが、`formRequestBuilders` 側のみ `mapQuestion` に共通化した（編集画面は `id` フィールドの扱いが異なるため共通化していない）

🤖 Generated with opencode