### PR TITLE
REST API 呼び出し周りの信頼性向上 - Phase 1 & Phase 2 基盤

### DIFF
--- a/src/app/(authed)/(standard)/forms/page.tsx
+++ b/src/app/(authed)/(standard)/forms/page.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import useSWR from 'swr';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormList from './_components/FormList';
-import type { GetFormsResponse } from '@/lib/api-types';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 
 const Home = () => {
-  const {
-    data: forms,
-    error,
-    isLoading,
-  } = useSWR<GetFormsResponse>('/api/proxy/forms');
+  const { data: forms, error, isLoading } = useApiQuery('/forms');
 
   if (error) {
     return <ErrorModal error={error} />;

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -2,26 +2,26 @@
 
 import { Grid, Stack } from '@mui/material';
 import { useMemo, useState } from 'react';
-import useSWR from 'swr';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import { Forms } from './_components/DashboardFormList';
 import FormCreateButton from './_components/FormCreateButton';
 import FormLabelFilter from './_components/FormLabelFilter';
 import ToManageFormLabelButton from './_components/ToManageFormLabelButton';
-import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+import type { GetFormLabelsResponse } from '@/lib/api-types';
 
 const Home = () => {
   const {
     data: forms,
     error: formsError,
     isLoading: isLoadingForms,
-  } = useSWR<GetFormsResponse>('/api/proxy/forms');
+  } = useApiQuery('/forms');
   const {
     data: labels,
     error: labelsError,
     isLoading: isLoadingLabels,
-  } = useSWR<GetFormLabelsResponse>('/api/proxy/labels/forms');
+  } = useApiQuery('/labels/forms');
   const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
 
   const filteredForms = useMemo(() => {

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -18,14 +18,13 @@ import {
   ListItemText,
 } from '@mui/material';
 import { useState } from 'react';
-import useSWR from 'swr';
 import { MsalProvider } from './MsalProvider';
 import { SigninButton } from './SigninButton';
 import { SignoutButton } from './SignoutButton';
-import type { GetUsersResponse } from '@/lib/api-types';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 
 const NavBar = () => {
-  const { data } = useSWR<GetUsersResponse>('/api/proxy/users/me');
+  const { data } = useApiQuery('/users/me');
   const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
 
   return (

--- a/src/app/_swr/fetcher.ts
+++ b/src/app/_swr/fetcher.ts
@@ -1,5 +1,8 @@
 import { HttpError } from '@/lib/httpError';
+import { proxyClient } from '@/lib/proxyClient';
+import type { paths } from '@/generated/api-types';
 
+/** @deprecated useApiQuery を使用してください */
 export const fetcher = async (url: string) => {
   const res = await fetch(url);
 
@@ -12,4 +15,45 @@ export const fetcher = async (url: string) => {
   }
 
   return res.json();
+};
+
+type GetPaths = {
+  [P in keyof paths]: paths[P] extends { get: unknown } ? P : never;
+}[keyof paths];
+
+type GetParams<P extends GetPaths> = paths[P] extends {
+  get: { parameters?: infer Params };
+}
+  ? Params
+  : never;
+
+type GetResponse<P extends GetPaths> = paths[P] extends {
+  get: {
+    responses: {
+      200: {
+        content: {
+          'application/json': infer R;
+        };
+      };
+    };
+  };
+}
+  ? R
+  : never;
+
+export const typedFetcher = async <P extends GetPaths>(
+  path: P,
+  params?: GetParams<P>
+): Promise<GetResponse<P>> => {
+  const { data, response } = await proxyClient.GET(path, params as never);
+
+  if (!response.ok || data === undefined) {
+    throw new HttpError({
+      message: `Request failed: ${response.status}`,
+      status: response.status,
+      url: path,
+    });
+  }
+
+  return data;
 };

--- a/src/app/_swr/fetcher.ts
+++ b/src/app/_swr/fetcher.ts
@@ -17,17 +17,17 @@ export const fetcher = async (url: string) => {
   return res.json();
 };
 
-type GetPaths = {
+export type GetPaths = {
   [P in keyof paths]: paths[P] extends { get: unknown } ? P : never;
 }[keyof paths];
 
-type GetParams<P extends GetPaths> = paths[P] extends {
+export type GetParams<P extends GetPaths> = paths[P] extends {
   get: { parameters?: infer Params };
 }
   ? Params
   : never;
 
-type GetResponse<P extends GetPaths> = paths[P] extends {
+export type GetResponse<P extends GetPaths> = paths[P] extends {
   get: {
     responses: {
       200: {
@@ -41,19 +41,32 @@ type GetResponse<P extends GetPaths> = paths[P] extends {
   ? R
   : never;
 
+type TypedClient = {
+  GET<P extends GetPaths>(
+    path: P,
+    params?: GetParams<P>
+  ): Promise<{
+    data: GetResponse<P> | undefined;
+    response: Response;
+    error?: unknown;
+  }>;
+};
+
+const typedClient = proxyClient as unknown as TypedClient;
+
 export const typedFetcher = async <P extends GetPaths>(
   path: P,
   params?: GetParams<P>
 ): Promise<GetResponse<P>> => {
-  const { data, response } = await proxyClient.GET(path, params as never);
+  const result = await typedClient.GET(path, params);
 
-  if (!response.ok || data === undefined) {
+  if (!result.response.ok || result.data === undefined) {
     throw new HttpError({
-      message: `Request failed: ${response.status}`,
-      status: response.status,
+      message: `Request failed: ${result.response.status}`,
+      status: result.response.status,
       url: path,
     });
   }
 
-  return data;
+  return result.data;
 };

--- a/src/app/_swr/useApiQuery.ts
+++ b/src/app/_swr/useApiQuery.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import useSWR from 'swr';
+import { typedFetcher } from './fetcher';
+import type { paths } from '@/generated/api-types';
+
+type GetPaths = {
+  [P in keyof paths]: paths[P] extends { get: unknown } ? P : never;
+}[keyof paths];
+
+type GetParams<P extends GetPaths> = paths[P] extends {
+  get: { parameters?: infer Params };
+}
+  ? Params
+  : never;
+
+type GetResponse<P extends GetPaths> = paths[P] extends {
+  get: {
+    responses: {
+      200: {
+        content: {
+          'application/json': infer R;
+        };
+      };
+    };
+  };
+}
+  ? R
+  : never;
+
+export const useApiQuery = <P extends GetPaths>(
+  path: P,
+  params?: GetParams<P>
+) => {
+  const key = params ? [path, params] : [path];
+
+  return useSWR<GetResponse<P>>(key, () => typedFetcher(path, params as never));
+};

--- a/src/app/_swr/useApiQuery.ts
+++ b/src/app/_swr/useApiQuery.ts
@@ -2,31 +2,7 @@
 
 import useSWR from 'swr';
 import { typedFetcher } from './fetcher';
-import type { paths } from '@/generated/api-types';
-
-type GetPaths = {
-  [P in keyof paths]: paths[P] extends { get: unknown } ? P : never;
-}[keyof paths];
-
-type GetParams<P extends GetPaths> = paths[P] extends {
-  get: { parameters?: infer Params };
-}
-  ? Params
-  : never;
-
-type GetResponse<P extends GetPaths> = paths[P] extends {
-  get: {
-    responses: {
-      200: {
-        content: {
-          'application/json': infer R;
-        };
-      };
-    };
-  };
-}
-  ? R
-  : never;
+import type { GetPaths, GetParams, GetResponse } from './fetcher';
 
 export const useApiQuery = <P extends GetPaths>(
   path: P,
@@ -34,5 +10,5 @@ export const useApiQuery = <P extends GetPaths>(
 ) => {
   const key = params ? [path, params] : [path];
 
-  return useSWR<GetResponse<P>>(key, () => typedFetcher(path, params as never));
+  return useSWR<GetResponse<P>>(key, () => typedFetcher(path, params));
 };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2,8 +2,11 @@ import { z } from 'zod';
 import { schemas } from '@/generated/api-client';
 
 export const errorResponseSchema = z.object({
+  detail: z.string(),
   errorCode: z.string(),
-  reason: z.string(),
+  status: z.number(),
+  title: z.string(),
+  type: z.string(),
 });
 
 export type ErrorResponse = z.infer<typeof errorResponseSchema>;


### PR DESCRIPTION
## 概要
- #631 の Phase 1（エラーレスポンススキーマの修正）を完遂
- Phase 2 の型安全なクエリ基盤として `typedFetcher` と `useApiQuery` を新規作成
- 代表ページ3つを `useApiQuery` に移行し、URL とレスポンス型が機械的に紐付く新パターンを確立

## 確認事項
- `pnpm tsc --noEmit` で型エラーがないことを確認
- `pnpm lint` と `pnpm fmt` が通ることを確認（Lefthook pre-commit で自動実行済み）
- `pnpm build` は環境変数未設定により静的生成で失敗するが、型チェック自体は成功

## 補足
- 残りの `useSWR` 呼び出し（~17箇所）は次のPRで `useApiQuery` に機械的に移行予定
- OpenAPI 定義に存在しないパス（`/forms/{id}/questions` など）は現状 `useApiQuery` 化不可
- 旧 `fetcher` は既存の `useSWR` 呼び出しとの後方互換のため `@deprecated` 付きで残存

🤖 Generated with OpenCode