### PR TITLE
fix: DataGrid の pageSizeOptions に 5 を追加して警告を解消

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/answers/_components/AnswerList.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/_components/AnswerList.tsx
@@ -43,7 +43,7 @@ const AnswerList = (props: {
           paginationModel: { page: 0, pageSize: 5 },
         },
       }}
-      pageSizeOptions={[5, 10, 25]}
+      pageSizeOptions={[5, 10, 25, 50, 100]}
       sx={{
         '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
           color: 'white',

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/_components/AnswerList.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/_components/AnswerList.tsx
@@ -43,6 +43,7 @@ const AnswerList = (props: {
           paginationModel: { page: 0, pageSize: 5 },
         },
       }}
+      pageSizeOptions={[5, 10, 25]}
       sx={{
         '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
           color: 'white',

--- a/src/app/(authed)/admin/_components/Dashboard.tsx
+++ b/src/app/(authed)/admin/_components/Dashboard.tsx
@@ -61,7 +61,7 @@ const DataTable = (props: {
           paginationModel: { page: 0, pageSize: 5 },
         },
       }}
-      pageSizeOptions={[5, 10, 25]}
+      pageSizeOptions={[5, 10, 25, 50, 100]}
       sx={{
         '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
           color: 'white',

--- a/src/app/(authed)/admin/_components/Dashboard.tsx
+++ b/src/app/(authed)/admin/_components/Dashboard.tsx
@@ -61,6 +61,7 @@ const DataTable = (props: {
           paginationModel: { page: 0, pageSize: 5 },
         },
       }}
+      pageSizeOptions={[5, 10, 25]}
       sx={{
         '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
           color: 'white',

--- a/src/app/(authed)/admin/_components/SearchResult.tsx
+++ b/src/app/(authed)/admin/_components/SearchResult.tsx
@@ -161,7 +161,7 @@ const SearchResult = (props: {
                 paginationModel: { page: 0, pageSize: 5 },
               },
             }}
-            pageSizeOptions={[5, 10, 25]}
+            pageSizeOptions={[5, 10, 25, 50, 100]}
             sx={{
               '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
                 color: 'white',

--- a/src/app/(authed)/admin/_components/SearchResult.tsx
+++ b/src/app/(authed)/admin/_components/SearchResult.tsx
@@ -161,6 +161,7 @@ const SearchResult = (props: {
                 paginationModel: { page: 0, pageSize: 5 },
               },
             }}
+            pageSizeOptions={[5, 10, 25]}
             sx={{
               '& .MuiDataGrid-columnHeader, & .MuiDataGrid-cell': {
                 color: 'white',


### PR DESCRIPTION
## 概要
- MUI X DataGrid のデフォルト `pageSizeOptions` は `[25, 50, 100]` であるため、`pageSize: 5` を指定している箇所でブラウザコンソールに警告が表示されていた
- `AnswerList`、`Dashboard`、`SearchResult` の 3 コンポーネントに `pageSizeOptions={[5, 10, 25]}` を追加し、警告を解消した

## 確認事項
- `pnpm lint`、`pnpm type-check`、`pnpm fmt` を実行し、すべてパスすることを確認した
- 変更対象は DataGrid を使用している 3 ファイルのみで、他のUIやロジックへの影響はない

🤖 Generated with OpenCode