### PR TITLE
fix: Comments コンポーネントの key prop 警告を修正

### DIFF
--- a/src/app/(authed)/_components/Comments.tsx
+++ b/src/app/(authed)/_components/Comments.tsx
@@ -164,9 +164,12 @@ const Comments = (props: {
       {props.comments
         .slice()
         .reverse()
-        .map((comment, index) => (
+        .map((comment) => (
           <CommentItem
-            key={comment.comment_id ?? `comment-${index}`}
+            key={
+              comment.comment_id ??
+              `${comment.commented_by.name}-${comment.timestamp}`
+            }
             comment={comment}
             formId={props.formId}
             answerId={props.answerId}

--- a/src/app/(authed)/_components/Comments.tsx
+++ b/src/app/(authed)/_components/Comments.tsx
@@ -164,9 +164,9 @@ const Comments = (props: {
       {props.comments
         .slice()
         .reverse()
-        .map((comment) => (
+        .map((comment, index) => (
           <CommentItem
-            key={comment.comment_id}
+            key={comment.comment_id ?? `comment-${index}`}
             comment={comment}
             formId={props.formId}
             answerId={props.answerId}


### PR DESCRIPTION
## 概要
- `/forms/{formId}/answers/{answerId}` ページで回答詳細を表示した際に、Comments コンポーネントで React の key prop 警告が出ていた問題を修正
- API レスポンスの `AnswerComment` に `comment_id` が含まれていない場合、`key` が `undefined` となり一意でない key として React に検出されていた
- `.map` の第二引数 `index` をフォールバックとして使い、`comment_id` が存在しない場合も一意な key を生成するように変更

## 確認事項
- `pnpm lint`、`pnpm type-check`、`pnpm fmt` が pre-commit フックで通過することを確認
- 修正対象は `src/app/(authed)/_components/Comments.tsx` のみで、影響範囲は回答詳細画面のコメント表示に限定される

## 補足
- `comment_id` が API レスポンスに含まれていないのは、OpenAPI スキーマ側で `comment_id` が定義されていないため。根本解決はバックエンドのスキーマ更新が必要だが、フロントエンド側でもフォールバックを設けることで警告を抑止した

🤖 Generated with OpenCode