### PR TITLE
fix: 各ページのブラウザタブにページタイトルを表示する

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/messages/page.tsx
@@ -10,6 +10,7 @@ import {
   AUTCHED_DRAWER_WIDTH_PX,
   AUTCHED_MESSAGE_CONTAINER_OFFSET_PX,
 } from '@/app/(authed)/layoutConstants';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import InputMessageField from './_components/InputMessageField';
 import Messages from './_components/Messages';
 
@@ -18,6 +19,7 @@ const Home = ({
 }: {
   params: Promise<{ formId: string; answerId: string }>;
 }) => {
+  usePageTitle('メッセージ');
   const { formId, answerId } = use(params);
   const {
     data: messages,

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
@@ -8,6 +8,7 @@ import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerDetails from './_components/AnswerDetails';
 import AnswerMeta from './_components/AnswerMeta';
 import Comments from './_components/Comments';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import type { AnswerCommentType } from '@/lib/api-types';
 
 const Home = ({
@@ -15,6 +16,7 @@ const Home = ({
 }: {
   params: Promise<{ formId: string; answerId: string }>;
 }) => {
+  usePageTitle('回答詳細');
   const { formId, answerId } = use(params);
   const {
     data: answer,

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
@@ -6,8 +6,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerList from './_components/AnswerList';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = ({ params }: { params: Promise<{ formId: string }> }) => {
+  usePageTitle('回答一覧');
   const { formId } = use(params);
   const {
     data: answers,

--- a/src/app/(authed)/(standard)/forms/[formId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/page.tsx
@@ -5,8 +5,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerForm from './_components/AnswerForm';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = ({ params }: { params: Promise<{ formId: string }> }) => {
+  usePageTitle('フォーム回答');
   const { formId } = use(params);
   const {
     data: form,

--- a/src/app/(authed)/(standard)/forms/page.tsx
+++ b/src/app/(authed)/(standard)/forms/page.tsx
@@ -5,8 +5,10 @@ import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormList from './_components/FormList';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('フォーム一覧');
   const { data: forms, error, isLoading } = useApiQuery('/forms');
 
   if (error) {

--- a/src/app/(authed)/(standard)/page.tsx
+++ b/src/app/(authed)/(standard)/page.tsx
@@ -8,6 +8,7 @@ import {
 import { InteractionStatus } from '@azure/msal-browser';
 import { useState } from 'react';
 import { DEBUG_MODE } from '@/env.client';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import MainMenu from './_components/MainMenu';
 import { NeedToSignin } from './_components/NeedToSignin';
 import LoadingCircular from '@/app/_components/LoadingCircular';
@@ -32,6 +33,7 @@ const HomeContent = () => {
 };
 
 const Home = () => {
+  usePageTitle('ホーム');
   const [isDebugMode] = useState(
     () => process.env.NODE_ENV === 'development' && DEBUG_MODE
   );

--- a/src/app/(authed)/(standard)/users/[userId]/page.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/page.tsx
@@ -9,8 +9,10 @@ import DiscordNotificationSettings from './_components/DiscordNotificationSettin
 import LinkDiscordButton from './_components/LinkDiscordButton';
 import UnlinkDiscordButton from './_components/UnlinkDiscordButton';
 import UserInformation from './_components/UserInformation';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = ({ params }: { params: Promise<{ userId: string }> }) => {
+  usePageTitle('ユーザー情報');
   const { userId } = use(params);
   const { data, error, isLoading } = useApiQuery('/users/{uuid}', {
     path: { uuid: userId },

--- a/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/messages/page.tsx
@@ -10,10 +10,12 @@ import {
   AUTCHED_DRAWER_WIDTH_PX,
   AUTCHED_MESSAGE_CONTAINER_OFFSET_PX,
 } from '@/app/(authed)/layoutConstants';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import InputMessageField from './_components/InputMessageField';
 import Messages from './_components/Messages';
 
 const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
+  usePageTitle('メッセージ管理');
   const { answerId } = use(params);
   const {
     data: allAnswers,

--- a/src/app/(authed)/admin/answer/[answerId]/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/page.tsx
@@ -7,9 +7,11 @@ import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerDetails from './_components/AnswerDetails';
 import Comments from './_components/Comments';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import type { AnswerCommentType } from '@/lib/api-types';
 
 const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
+  usePageTitle('回答管理');
   const { answerId } = use(params);
   const {
     data: allAnswers,

--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -4,8 +4,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormCreateForm from './_components/FormCreateForm';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('フォーム作成');
   const {
     data: labels,
     error,

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -5,8 +5,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormEditForm from './_components/FormEditForm';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = ({ params }: { params: Promise<{ id: number }> }) => {
+  usePageTitle('フォーム編集');
   const { id } = use(params);
   const {
     data: form,

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -9,9 +9,11 @@ import FormCreateButton from './_components/FormCreateButton';
 import FormLabelFilter from './_components/FormLabelFilter';
 import ToManageFormLabelButton from './_components/ToManageFormLabelButton';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import type { GetFormLabelsResponse } from '@/lib/api-types';
 
 const Home = () => {
+  usePageTitle('フォーム管理');
   const {
     data: forms,
     error: formsError,

--- a/src/app/(authed)/admin/labels/answers/page.tsx
+++ b/src/app/(authed)/admin/labels/answers/page.tsx
@@ -6,8 +6,10 @@ import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import CreateLabelField from '../_components/CreateLabelField';
 import Labels from '../_components/Labels';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('回答設定用ラベル管理');
   const { data, error, isLoading } = useApiQuery('/labels/answers');
 
   if (error) {

--- a/src/app/(authed)/admin/labels/forms/page.tsx
+++ b/src/app/(authed)/admin/labels/forms/page.tsx
@@ -6,8 +6,10 @@ import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import CreateLabelField from './_components/CreateLabelField';
 import Labels from './_components/Labels';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('フォーム設定用ラベル管理');
   const { data, error, isLoading } = useApiQuery('/labels/forms');
 
   if (error) {

--- a/src/app/(authed)/admin/page.tsx
+++ b/src/app/(authed)/admin/page.tsx
@@ -4,8 +4,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import DataTable from './_components/Dashboard';
 import ErrorModal from '../../_components/ErrorModal';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('管理ダッシュボード');
   const {
     data: answers,
     error: answersError,

--- a/src/app/(authed)/admin/users/page.tsx
+++ b/src/app/(authed)/admin/users/page.tsx
@@ -4,8 +4,10 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import UserList from './_components/UserList';
+import { usePageTitle } from '@/hooks/usePageTitle';
 
 const Home = () => {
+  usePageTitle('ユーザー管理');
   const { data, error, isLoading } = useApiQuery('/users');
 
   if (error) {

--- a/src/app/(unauthed)/(errors)/badrequest/page.tsx
+++ b/src/app/(unauthed)/(errors)/badrequest/page.tsx
@@ -1,9 +1,10 @@
-'use client';
+import type { Metadata } from 'next';
 
-import { usePageTitle } from '@/hooks/usePageTitle';
+export const metadata: Metadata = {
+  title: '不正なリクエスト | Seichi Portal',
+};
 
 const Home = () => {
-  usePageTitle('不正なリクエスト');
   return <p>不正なリクエストです</p>;
 };
 

--- a/src/app/(unauthed)/(errors)/badrequest/page.tsx
+++ b/src/app/(unauthed)/(errors)/badrequest/page.tsx
@@ -1,4 +1,9 @@
+'use client';
+
+import { usePageTitle } from '@/hooks/usePageTitle';
+
 const Home = () => {
+  usePageTitle('不正なリクエスト');
   return <p>不正なリクエストです</p>;
 };
 

--- a/src/app/(unauthed)/login/page.tsx
+++ b/src/app/(unauthed)/login/page.tsx
@@ -8,6 +8,7 @@ import { useMsal } from '@azure/msal-react';
 import { Alert, Button, Stack, Typography } from '@mui/material';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState, Suspense } from 'react';
+import { usePageTitle } from '@/hooks/usePageTitle';
 import type { SilentRequest } from '@azure/msal-browser';
 
 const loginRequest = {
@@ -15,6 +16,7 @@ const loginRequest = {
 };
 
 const LoginContent = () => {
+  usePageTitle('ログイン');
   const { instance, inProgress, accounts } = useMsal();
   const [isInitialized, setState] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SITE_TITLE = 'Seichi Portal';
+
+export const usePageTitle = (title: string) => {
+  useEffect(() => {
+    document.title = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
+  }, [title]);
+};

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -7,5 +7,9 @@ const SITE_TITLE = 'Seichi Portal';
 export const usePageTitle = (title: string) => {
   useEffect(() => {
     document.title = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
+
+    return () => {
+      document.title = SITE_TITLE;
+    };
   }, [title]);
 };


### PR DESCRIPTION
## 概要
- Issue #650 向けに、各ページでブラウザタブへ URL ではなく画面名を表示するようにしました。
- `usePageTitle` hook を追加し、ログイン画面・通常画面・管理画面の各 `page.tsx` から `document.title` を統一的に更新する構成にしています。
- App Router の server-side metadata への全面移行は行わず、既存の client component 構成を崩さずに対応しています。

## 確認事項
- `pnpm type-check` を実行し、型エラーがないことを確認しました。
- 変更対象ファイルに対して `pnpm lint ...` を実行し、ESLint の指摘が出ないことを確認しました。
- ブラウザ上での遷移確認は未実施です。タブタイトルの切り替わりは、通常画面と管理画面の代表ルートで実画面確認をお願いします。

## 補足
- 詳細ページでも今回は固定の画面名を設定しており、フォーム名や回答タイトルのような API 由来の動的タイトル表示までは含めていません。

close #650

🤖 Generated with Codex