### PR TITLE
回答フォームと投稿一覧UIの責務を分離して共通化する

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
@@ -39,6 +39,14 @@ const AnswerForm = ({ questions, formId, title, description }: Props) => {
           回答期間が終了しています
         </Alert>
       )}
+      {submissionErrorCode === 'UNKNOWN' && (
+        <Alert
+          severity="error"
+          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
+        >
+          回答の送信に失敗しました。時間をおいて再度お試しください。
+        </Alert>
+      )}
       <AnswerSubmissionForm
         questions={questions}
         title={title}

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerForm.tsx
@@ -1,37 +1,10 @@
 'use client';
 
-import { ArrowBack, ArrowForward } from '@mui/icons-material';
-import SendIcon from '@mui/icons-material/Send';
-import {
-  Box,
-  Alert,
-  AlertTitle,
-  Stack,
-  Button,
-  Typography,
-  Link,
-  Paper,
-  Input,
-  Select,
-  MenuItem,
-  FormHelperText,
-  FormControlLabel,
-  Checkbox,
-  Grid,
-  Chip,
-  FormControl,
-  InputLabel,
-} from '@mui/material';
-import NextLink from 'next/link';
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import type { paths } from '@/generated/api-types';
-import { errorResponseSchema } from '@/lib/api/errors';
+import { Alert } from '@mui/material';
 import type { GetQuestionsResponse } from '@/lib/api-types';
-import type { NonEmptyArray } from '@/generic/Types';
-import { proxyClient } from '@/lib/proxyClient';
+import AnswerSubmissionForm from './AnswerSubmissionForm';
+import AnswerSubmissionSuccess from './AnswerSubmissionSuccess';
+import { useAnswerSubmission } from './useAnswerSubmission';
 
 interface Props {
   questions: GetQuestionsResponse;
@@ -40,270 +13,40 @@ interface Props {
   description: string;
 }
 
-interface IFormInput {
-  [key: string]: string | NonEmptyArray<string> | boolean;
-}
-
-type AnswerCreateBody =
-  paths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
-
+/**
+ * 回答画面から見た entry point。
+ * 入力中と送信完了後の画面切り替えだけを持ち、詳細責務は下位へ委譲する。
+ */
 const AnswerForm = ({ questions, formId, title, description }: Props) => {
-  const [isSubmitted, toggleIsSubmitted] = useState(false);
-  const [selectedValues, setSelectedValues] = useState<{ [x: string]: string }>(
-    {}
-  );
   const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<IFormInput>();
-
-  const resetIsSubmitted = () => {
-    toggleIsSubmitted(false);
-  };
-
-  const onSubmit = async (data: IFormInput) => {
-    const formAnswers = Object.entries(data).flatMap(([key, values]) => {
-      if (typeof values == 'string') {
-        return {
-          question_id: key,
-          answer: values,
-        };
-      } else if (typeof values === 'boolean') {
-        return [
-          {
-            question_id: key,
-            answer: '',
-          },
-        ];
-      } else {
-        return values.map((value) => ({
-          question_id: key,
-          answer: value,
-        }));
-      }
-    });
-
-    const body: AnswerCreateBody = {
-      contents: formAnswers,
-    };
-
-    const { response, error } = await proxyClient.POST('/forms/{id}/answers', {
-      params: {
-        path: {
-          id: formId,
-        },
-      },
-      body,
-    });
-
-    if (response.ok) {
-      toggleIsSubmitted(true);
-      reset();
-      setSelectedValues({});
-
-      return;
-    }
-
-    const safeParsedErrorResponse = errorResponseSchema.safeParse(error);
-
-    if (
-      safeParsedErrorResponse.success &&
-      safeParsedErrorResponse.data.errorCode == 'OUT_OF_PERIOD'
-    ) {
-      alert('回答期間が終了しています');
-    }
-  };
-
-  const generateInputSpace = (question: GetQuestionsResponse[number]) => {
-    const qId = question.id ?? '';
-    switch (question.question_type) {
-      case 'Text':
-        return (
-          <Input
-            {...register(qId)}
-            className="materialUIInput"
-            required={question.is_required}
-            multiline
-            fullWidth
-          />
-        );
-      case 'SingleChoice': {
-        const questionId = qId;
-        return (
-          <FormControl fullWidth sx={{ mt: 2 }}>
-            <InputLabel id={`select-label-${questionId}`}>
-              選択してください
-            </InputLabel>
-            <Select
-              {...register(questionId)}
-              required={question.is_required}
-              fullWidth
-              labelId={`select-label-${questionId}`}
-              label="選択してください"
-              value={selectedValues[questionId] ?? ''}
-              onChange={(event) => {
-                setSelectedValues({
-                  ...selectedValues,
-                  [questionId]: event.target.value,
-                });
-              }}
-              displayEmpty
-            >
-              {question.choices?.map((choice, index) => {
-                return (
-                  <MenuItem key={`q-${qId}.a-${index}`} value={choice.label}>
-                    {choice.label}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-          </FormControl>
-        );
-      }
-      case 'MultipleChoice':
-        return (
-          <>
-            <Grid container spacing={2} sx={{ mt: 1 }}>
-              {question.choices?.map((choice, index) => (
-                <Grid
-                  size={{ xs: 12, sm: 6, md: 4 }}
-                  key={`q-${qId}.a-${index}`}
-                >
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        {...register(qId, {
-                          validate: {
-                            itemMustBeChecked: (v) => {
-                              if (!question.is_required) return true;
-                              const errorMessage =
-                                'この項目は必須です。少なくとも1つの項目にチェックを入れてください';
-                              if (typeof v === 'boolean') return errorMessage;
-
-                              return v.length >= 1 || errorMessage;
-                            },
-                          },
-                        })}
-                        value={choice.label}
-                      />
-                    }
-                    label={choice.label}
-                  />
-                </Grid>
-              ))}
-            </Grid>
-            {errors[qId] && (
-              <FormHelperText sx={{ color: 'red' }}>
-                {errors[qId]?.message}
-              </FormHelperText>
-            )}
-          </>
-        );
-      default:
-        return null;
-    }
-  };
+    isSubmitted,
+    submissionErrorCode,
+    submitAnswers,
+    resetSubmissionState,
+  } = useAnswerSubmission(formId);
 
   if (isSubmitted) {
-    return (
-      <Stack
-        spacing={2}
-        sx={{ width: '100%', justifyContent: 'center', alignItems: 'center' }}
-      >
-        <Alert severity="success" sx={{ width: '100%', maxWidth: 600 }}>
-          <AlertTitle>Success</AlertTitle>
-          回答を送信しました
-        </Alert>
-        <Stack
-          spacing={2}
-          direction="row"
-          sx={{ justifyContent: 'space-between', alignItems: 'center' }}
-        >
-          <Button
-            variant="contained"
-            onClick={resetIsSubmitted}
-            startIcon={<ArrowBack />}
-          >
-            別の回答をする
-          </Button>
-          <Link component={NextLink} href="/forms">
-            <Button variant="contained" endIcon={<ArrowForward />}>
-              フォーム一覧へ
-            </Button>
-          </Link>
-        </Stack>
-      </Stack>
-    );
-  } else {
-    return (
-      <Box
-        sx={{ width: '100%', maxWidth: 800, mx: 'auto', alignSelf: 'center' }}
-      >
-        <Typography variant="h4" gutterBottom>
-          {title}
-        </Typography>
-        {description && (
-          <Box sx={{ whiteSpace: 'pre-wrap', mb: 4 }}>
-            <Markdown remarkPlugins={[remarkGfm]}>{description}</Markdown>
-          </Box>
-        )}
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <Stack spacing={3}>
-            {questions.map((question) => {
-              return (
-                <Paper key={question.id} variant="outlined" sx={{ p: 3 }}>
-                  <Stack spacing={2}>
-                    <Box>
-                      <Typography variant="h6" component="span">
-                        {question.title}
-                      </Typography>
-                      {question.is_required && (
-                        <Chip
-                          size="small"
-                          color="error"
-                          label="必須"
-                          sx={{ ml: 1, verticalAlign: 'middle' }}
-                        />
-                      )}
-                    </Box>
-                    {question.description && (
-                      <Box
-                        sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
-                      >
-                        <Markdown remarkPlugins={[remarkGfm]}>
-                          {question.description}
-                        </Markdown>
-                      </Box>
-                    )}
-                    {generateInputSpace(question)}
-                  </Stack>
-                </Paper>
-              );
-            })}
-            <Box
-              sx={{
-                width: '100%',
-                display: 'flex',
-                justifyContent: 'flex-end',
-                mt: 2,
-              }}
-            >
-              <Button
-                type="submit"
-                variant="contained"
-                size="large"
-                endIcon={<SendIcon />}
-              >
-                送信
-              </Button>
-            </Box>
-          </Stack>
-        </form>
-      </Box>
-    );
+    return <AnswerSubmissionSuccess onReset={resetSubmissionState} />;
   }
+
+  return (
+    <>
+      {submissionErrorCode === 'OUT_OF_PERIOD' && (
+        <Alert
+          severity="error"
+          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
+        >
+          回答期間が終了しています
+        </Alert>
+      )}
+      <AnswerSubmissionForm
+        questions={questions}
+        title={title}
+        description={description}
+        onSubmitAnswers={submitAnswers}
+      />
+    </>
+  );
 };
 
 export default AnswerForm;

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -31,6 +31,7 @@ const AnswerSubmissionForm = ({
     {}
   );
   const {
+    control,
     register,
     handleSubmit,
     reset,
@@ -49,7 +50,7 @@ const AnswerSubmissionForm = ({
 
   return (
     <Box sx={{ width: '100%', maxWidth: 800, mx: 'auto', alignSelf: 'center' }}>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h4" component="h1" gutterBottom>
         {title}
       </Typography>
       {description && (
@@ -84,6 +85,7 @@ const AnswerSubmissionForm = ({
                 )}
                 <QuestionFieldRenderer
                   question={question}
+                  control={control}
                   register={register}
                   errors={errors}
                   selectedValues={selectedValues}

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import SendIcon from '@mui/icons-material/Send';
+import { Box, Button, Chip, Paper, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { GetQuestionsResponse } from '@/lib/api-types';
+import type { AnswerFormInput } from './answerFormTypes';
+import QuestionFieldRenderer from './QuestionFieldRenderer';
+
+type Props = {
+  questions: GetQuestionsResponse;
+  title: string;
+  description: string;
+  onSubmitAnswers: (data: AnswerFormInput) => Promise<{ ok: boolean }>;
+};
+
+/**
+ * 回答入力中の UI を担う component。
+ * 質問描画と form state 管理を持ち、送信処理そのものは外から注入する。
+ */
+const AnswerSubmissionForm = ({
+  questions,
+  title,
+  description,
+  onSubmitAnswers,
+}: Props) => {
+  const [selectedValues, setSelectedValues] = useState<Record<string, string>>(
+    {}
+  );
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<AnswerFormInput>();
+
+  const handleAnswerSubmit = async (data: AnswerFormInput) => {
+    const result = await onSubmitAnswers(data);
+    if (!result.ok) {
+      return;
+    }
+
+    reset();
+    setSelectedValues({});
+  };
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: 800, mx: 'auto', alignSelf: 'center' }}>
+      <Typography variant="h4" gutterBottom>
+        {title}
+      </Typography>
+      {description && (
+        <Box sx={{ whiteSpace: 'pre-wrap', mb: 4 }}>
+          <Markdown remarkPlugins={[remarkGfm]}>{description}</Markdown>
+        </Box>
+      )}
+      <form onSubmit={handleSubmit(handleAnswerSubmit)}>
+        <Stack spacing={3}>
+          {questions.map((question) => (
+            <Paper key={question.id} variant="outlined" sx={{ p: 3 }}>
+              <Stack spacing={2}>
+                <Box>
+                  <Typography variant="h6" component="span">
+                    {question.title}
+                  </Typography>
+                  {question.is_required && (
+                    <Chip
+                      size="small"
+                      color="error"
+                      label="必須"
+                      sx={{ ml: 1, verticalAlign: 'middle' }}
+                    />
+                  )}
+                </Box>
+                {question.description && (
+                  <Box sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}>
+                    <Markdown remarkPlugins={[remarkGfm]}>
+                      {question.description}
+                    </Markdown>
+                  </Box>
+                )}
+                <QuestionFieldRenderer
+                  question={question}
+                  register={register}
+                  errors={errors}
+                  selectedValues={selectedValues}
+                  setSelectedValues={setSelectedValues}
+                />
+              </Stack>
+            </Paper>
+          ))}
+          <Box
+            sx={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'flex-end',
+              mt: 2,
+            }}
+          >
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              endIcon={<SendIcon />}
+            >
+              送信
+            </Button>
+          </Box>
+        </Stack>
+      </form>
+    </Box>
+  );
+};
+
+export default AnswerSubmissionForm;

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionSuccess.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/AnswerSubmissionSuccess.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { ArrowBack, ArrowForward } from '@mui/icons-material';
+import { Alert, AlertTitle, Button, Link, Stack } from '@mui/material';
+import NextLink from 'next/link';
+
+type Props = {
+  onReset: () => void;
+};
+
+/**
+ * 回答送信完了後の共通 success surface。
+ */
+const AnswerSubmissionSuccess = ({ onReset }: Props) => (
+  <Stack
+    spacing={2}
+    sx={{ width: '100%', justifyContent: 'center', alignItems: 'center' }}
+  >
+    <Alert severity="success" sx={{ width: '100%', maxWidth: 600 }}>
+      <AlertTitle>Success</AlertTitle>
+      回答を送信しました
+    </Alert>
+    <Stack
+      spacing={2}
+      direction="row"
+      sx={{ justifyContent: 'space-between', alignItems: 'center' }}
+    >
+      <Button variant="contained" onClick={onReset} startIcon={<ArrowBack />}>
+        別の回答をする
+      </Button>
+      <Link component={NextLink} href="/forms">
+        <Button variant="contained" endIcon={<ArrowForward />}>
+          フォーム一覧へ
+        </Button>
+      </Link>
+    </Stack>
+  </Stack>
+);
+
+export default AnswerSubmissionSuccess;

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+  Input,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@mui/material';
+import type { Dispatch, SetStateAction } from 'react';
+import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import type { AnswerFormInput, AnswerQuestion } from './answerFormTypes';
+
+type Props = {
+  question: AnswerQuestion;
+  register: UseFormRegister<AnswerFormInput>;
+  errors: FieldErrors<AnswerFormInput>;
+  selectedValues: Record<string, string>;
+  setSelectedValues: Dispatch<SetStateAction<Record<string, string>>>;
+};
+
+const requiredMultiSelectMessage =
+  'この項目は必須です。少なくとも1つの項目にチェックを入れてください';
+
+/**
+ * 質問タイプごとの入力 UI 差分を閉じ込める renderer。
+ * 新しい質問タイプを足す場合はまずここを拡張する。
+ */
+const QuestionFieldRenderer = ({
+  question,
+  register,
+  errors,
+  selectedValues,
+  setSelectedValues,
+}: Props) => {
+  const questionId = question.id ?? '';
+
+  switch (question.question_type) {
+    case 'Text':
+      return (
+        <Input
+          {...register(questionId)}
+          className="materialUIInput"
+          required={question.is_required}
+          multiline
+          fullWidth
+        />
+      );
+    case 'SingleChoice':
+      return (
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id={`select-label-${questionId}`}>
+            選択してください
+          </InputLabel>
+          <Select
+            {...register(questionId)}
+            required={question.is_required}
+            fullWidth
+            labelId={`select-label-${questionId}`}
+            label="選択してください"
+            value={selectedValues[questionId] ?? ''}
+            onChange={(event) =>
+              setSelectedValues((current) => ({
+                ...current,
+                [questionId]: event.target.value,
+              }))
+            }
+            displayEmpty
+          >
+            {question.choices?.map((choice, index) => (
+              <MenuItem key={`q-${questionId}.a-${index}`} value={choice.label}>
+                {choice.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      );
+    case 'MultipleChoice':
+      return (
+        <>
+          <Grid container spacing={2} sx={{ mt: 1 }}>
+            {question.choices?.map((choice, index) => (
+              <Grid
+                size={{ xs: 12, sm: 6, md: 4 }}
+                key={`q-${questionId}.a-${index}`}
+              >
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      {...register(questionId, {
+                        validate: {
+                          itemMustBeChecked: (value) => {
+                            if (!question.is_required) return true;
+                            if (typeof value === 'boolean') {
+                              return requiredMultiSelectMessage;
+                            }
+
+                            return (
+                              value.length >= 1 || requiredMultiSelectMessage
+                            );
+                          },
+                        },
+                      })}
+                      value={choice.label}
+                    />
+                  }
+                  label={choice.label}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          {errors[questionId] && (
+            <FormHelperText sx={{ color: 'red' }}>
+              {errors[questionId]?.message}
+            </FormHelperText>
+          )}
+        </>
+      );
+    default:
+      return null;
+  }
+};
+
+export default QuestionFieldRenderer;

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -12,11 +12,13 @@ import {
   Select,
 } from '@mui/material';
 import type { Dispatch, SetStateAction } from 'react';
-import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
+import type { Control, FieldErrors, UseFormRegister } from 'react-hook-form';
 import type { AnswerFormInput, AnswerQuestion } from './answerFormTypes';
 
 type Props = {
   question: AnswerQuestion;
+  control: Control<AnswerFormInput>;
   register: UseFormRegister<AnswerFormInput>;
   errors: FieldErrors<AnswerFormInput>;
   selectedValues: Record<string, string>;
@@ -32,6 +34,7 @@ const requiredMultiSelectMessage =
  */
 const QuestionFieldRenderer = ({
   question,
+  control,
   register,
   errors,
   selectedValues,
@@ -56,27 +59,42 @@ const QuestionFieldRenderer = ({
           <InputLabel id={`select-label-${questionId}`}>
             選択してください
           </InputLabel>
-          <Select
-            {...register(questionId)}
-            required={question.is_required}
-            fullWidth
-            labelId={`select-label-${questionId}`}
-            label="選択してください"
-            value={selectedValues[questionId] ?? ''}
-            onChange={(event) =>
-              setSelectedValues((current) => ({
-                ...current,
-                [questionId]: event.target.value,
-              }))
-            }
-            displayEmpty
-          >
-            {question.choices?.map((choice, index) => (
-              <MenuItem key={`q-${questionId}.a-${index}`} value={choice.label}>
-                {choice.label}
-              </MenuItem>
-            ))}
-          </Select>
+          <Controller
+            control={control}
+            name={questionId}
+            render={({ field }) => (
+              <Select
+                {...field}
+                required={question.is_required}
+                fullWidth
+                labelId={`select-label-${questionId}`}
+                label="選択してください"
+                value={field.value ?? selectedValues[questionId] ?? ''}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  if (typeof nextValue !== 'string') {
+                    return;
+                  }
+
+                  field.onChange(nextValue);
+                  setSelectedValues((current) => ({
+                    ...current,
+                    [questionId]: nextValue,
+                  }));
+                }}
+                displayEmpty
+              >
+                {question.choices?.map((choice, index) => (
+                  <MenuItem
+                    key={`q-${questionId}.a-${index}`}
+                    value={choice.label}
+                  >
+                    {choice.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            )}
+          />
         </FormControl>
       );
     case 'MultipleChoice':
@@ -114,7 +132,7 @@ const QuestionFieldRenderer = ({
             ))}
           </Grid>
           {errors[questionId] && (
-            <FormHelperText sx={{ color: 'red' }}>
+            <FormHelperText sx={{ color: 'error.main' }}>
               {errors[questionId]?.message}
             </FormHelperText>
           )}

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/answerFormTypes.ts
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/answerFormTypes.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import type { GetQuestionsResponse } from '@/lib/api-types';
+import type { NonEmptyArray } from '@/generic/Types';
+
+/**
+ * 回答フォーム内部で扱う入力値。
+ * 質問タイプごとの違いを吸収して submit 前の共通形にしている。
+ */
+export interface AnswerFormInput {
+  [key: string]: string | NonEmptyArray<string> | boolean;
+}
+
+export type AnswerQuestion = GetQuestionsResponse[number];

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import type { paths } from '@/generated/api-types';
+import { errorResponseSchema } from '@/lib/api/errors';
+import { proxyClient } from '@/lib/proxyClient';
+import type { AnswerFormInput } from './answerFormTypes';
+
+type AnswerCreateBody =
+  paths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
+
+type SubmissionErrorCode = 'OUT_OF_PERIOD';
+
+const toAnswerCreateBody = (data: AnswerFormInput): AnswerCreateBody => ({
+  contents: Object.entries(data).flatMap(([key, values]) => {
+    if (typeof values === 'string') {
+      return {
+        question_id: key,
+        answer: values,
+      };
+    }
+
+    if (typeof values === 'boolean') {
+      return [
+        {
+          question_id: key,
+          answer: '',
+        },
+      ];
+    }
+
+    return values.map((value) => ({
+      question_id: key,
+      answer: value,
+    }));
+  }),
+});
+
+const parseSubmissionErrorCode = (
+  error: unknown
+): SubmissionErrorCode | null => {
+  const parsed = errorResponseSchema.safeParse(error);
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  if (parsed.data.errorCode === 'OUT_OF_PERIOD') {
+    return 'OUT_OF_PERIOD';
+  }
+
+  return null;
+};
+
+/**
+ * 回答送信の state と API interaction を UI から分離する hook。
+ * payload 変換と API エラー解釈はここを正本にする。
+ */
+export const useAnswerSubmission = (formId: string) => {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [submissionErrorCode, setSubmissionErrorCode] =
+    useState<SubmissionErrorCode | null>(null);
+
+  const submitAnswers = async (data: AnswerFormInput) => {
+    const { response, error } = await proxyClient.POST('/forms/{id}/answers', {
+      params: {
+        path: {
+          id: formId,
+        },
+      },
+      body: toAnswerCreateBody(data),
+    });
+
+    if (response.ok) {
+      setIsSubmitted(true);
+      setSubmissionErrorCode(null);
+      return { ok: true as const };
+    }
+
+    const errorCode = parseSubmissionErrorCode(error);
+    setSubmissionErrorCode(errorCode);
+
+    return { ok: false as const, errorCode };
+  };
+
+  const resetSubmissionState = () => {
+    setIsSubmitted(false);
+    setSubmissionErrorCode(null);
+  };
+
+  return {
+    isSubmitted,
+    submissionErrorCode,
+    submitAnswers,
+    resetSubmissionState,
+  };
+};

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -9,7 +9,7 @@ import type { AnswerFormInput } from './answerFormTypes';
 type AnswerCreateBody =
   paths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
 
-type SubmissionErrorCode = 'OUT_OF_PERIOD';
+type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'UNKNOWN';
 
 const toAnswerCreateBody = (data: AnswerFormInput): AnswerCreateBody => ({
   contents: Object.entries(data).flatMap(([key, values]) => {
@@ -77,7 +77,7 @@ export const useAnswerSubmission = (formId: string) => {
       return { ok: true as const };
     }
 
-    const errorCode = parseSubmissionErrorCode(error);
+    const errorCode = parseSubmissionErrorCode(error) ?? 'UNKNOWN';
     setSubmissionErrorCode(errorCode);
 
     return { ok: false as const, errorCode };

--- a/src/app/(authed)/_components/Comments.tsx
+++ b/src/app/(authed)/_components/Comments.tsx
@@ -1,268 +1,82 @@
 'use client';
 
-import CloseIcon from '@mui/icons-material/Close';
-import DeleteIcon from '@mui/icons-material/Delete';
-import SendIcon from '@mui/icons-material/Send';
-import {
-  Avatar,
-  Box,
-  Button,
-  Chip,
-  Drawer,
-  IconButton,
-  Paper,
-  Stack,
-  TextField,
-  Toolbar,
-  Typography,
-} from '@mui/material';
-import { alpha } from '@mui/material/styles';
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useCommentActions } from '@/hooks/useCommentActions';
-import { formatString } from '@/generic/DateFormatter';
+import { Box, Typography } from '@mui/material';
 import type { AnswerCommentType } from '@/lib/api-types';
-
-type Comment = AnswerCommentType;
-
-type SendCommentSchema = {
-  answer_id: string;
-  content: string;
-};
-
-type DeleteCommentSchema = {
-  comment_id: string;
-};
-
-const CommentItem = (props: {
-  comment: Comment;
-  formId: string;
-  answerId: string;
-  currentUserId: string | undefined;
-  showDeleteButton: boolean;
-}) => {
-  const { register, handleSubmit } = useForm<DeleteCommentSchema>();
-  const { deleteComment } = useCommentActions(props.formId, props.answerId);
-
-  const onDelete = async (data: DeleteCommentSchema) => {
-    await deleteComment(data.comment_id);
-  };
-
-  const canDelete =
-    props.showDeleteButton ||
-    (props.currentUserId !== undefined &&
-      props.comment.commented_by.uuid === props.currentUserId);
-
-  const isAdmin = props.comment.commented_by.role === 'ADMINISTRATOR';
-
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        gap: 1.5,
-        alignItems: 'flex-start',
-      }}
-    >
-      <Avatar
-        alt="PlayerHead"
-        src={`https://mc-heads.net/avatar/${props.comment.commented_by.name}`}
-        sx={{
-          width: 36,
-          height: 36,
-          mt: 0.5,
-          border: isAdmin ? 2 : 0,
-          borderColor: 'success.main',
-        }}
-      />
-      <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            mb: 0.5,
-          }}
-        >
-          <Typography variant="subtitle2" noWrap>
-            {props.comment.commented_by.name}
-          </Typography>
-          {isAdmin && (
-            <Chip
-              avatar={
-                <Avatar src="/server-icon.png" sx={{ width: 18, height: 18 }} />
-              }
-              label="運営"
-              color="success"
-              size="small"
-              sx={{ height: 20 }}
-            />
-          )}
-          <Typography variant="caption" color="text.secondary">
-            {formatString(props.comment.timestamp)}
-          </Typography>
-          {canDelete && (
-            <Box
-              component="form"
-              onSubmit={handleSubmit(onDelete)}
-              sx={{ ml: 'auto' }}
-            >
-              <input
-                {...register('comment_id')}
-                value={props.comment.comment_id}
-                type="hidden"
-              />
-              <IconButton
-                type="submit"
-                size="small"
-                color="error"
-                aria-label="delete"
-                sx={{ p: 0.5 }}
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          )}
-        </Box>
-        <Paper
-          variant="outlined"
-          sx={(theme) => ({
-            p: 1.5,
-            backgroundColor: isAdmin
-              ? alpha(theme.palette.success.main, 0.08)
-              : theme.palette.grey[50],
-            borderRadius: 2,
-          })}
-        >
-          <Typography
-            variant="body2"
-            sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-          >
-            {props.comment.content}
-          </Typography>
-        </Paper>
-      </Box>
-    </Box>
-  );
-};
-
-const SendCommentForm = (props: { formId: string; answerId: string }) => {
-  const { register, handleSubmit, reset } = useForm<SendCommentSchema>();
-  const { sendComment } = useCommentActions(props.formId, props.answerId);
-
-  const onSubmit = async (data: SendCommentSchema) => {
-    await sendComment(data.content);
-    reset();
-  };
-
-  return (
-    <Box
-      component="form"
-      onSubmit={handleSubmit(onSubmit)}
-      sx={{
-        p: 2,
-        borderTop: 1,
-        borderColor: 'divider',
-        backgroundColor: 'background.paper',
-      }}
-    >
-      <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-end' }}>
-        <input
-          {...register('answer_id')}
-          value={props.answerId}
-          type="hidden"
-        />
-        <TextField
-          {...register('content')}
-          placeholder="コメントを入力..."
-          size="small"
-          fullWidth
-          required
-          multiline
-          maxRows={4}
-        />
-        <IconButton type="submit" color="primary" aria-label="send">
-          <SendIcon />
-        </IconButton>
-      </Stack>
-    </Box>
-  );
-};
+import ConversationComposer from './ConversationComposer';
+import ConversationSurface from './ConversationSurface';
+import type {
+  ConversationCapabilities,
+  ConversationEntryViewModel,
+} from './conversationTypes';
+import { useCommentConversationActions } from './useConversationActions';
 
 const Comments = (props: {
-  comments: Comment[];
+  comments: AnswerCommentType[];
   formId: string;
   answerId: string;
   currentUserId: string | undefined;
   showDeleteButton: boolean | undefined;
 }) => {
-  const [open, setOpen] = useState(false);
+  const actions = useCommentConversationActions(props.formId, props.answerId);
+
+  const entries: ConversationEntryViewModel[] = props.comments.map(
+    (comment) => ({
+      id:
+        comment.comment_id ??
+        `${comment.commented_by.name}-${comment.timestamp}`,
+      body: comment.content,
+      authorName: comment.commented_by.name,
+      authorId: comment.commented_by.uuid,
+      authorRole: comment.commented_by.role,
+      timestamp: comment.timestamp,
+      renderMode: 'plain',
+      canDelete:
+        (props.showDeleteButton ?? false) ||
+        (props.currentUserId !== undefined &&
+          comment.commented_by.uuid === props.currentUserId),
+      canEdit: false,
+    })
+  );
+
+  const capabilities: ConversationCapabilities = {
+    canCompose: true,
+    composeLabel: 'コメントを入力...',
+    composeHelperText: '',
+    emptyMessage: 'コメントはまだありません',
+    adminLabel: '運営',
+    actionTrigger: 'icon',
+  };
 
   return (
-    <>
-      <Button
-        variant="outlined"
-        onClick={() => setOpen(true)}
-        startIcon={<Typography component="span">💬</Typography>}
-      >
-        コメント ({props.comments.length})
-      </Button>
-
-      <Drawer
-        anchor="right"
-        open={open}
-        onClose={() => setOpen(false)}
-        slotProps={{
-          paper: { sx: { width: { xs: '100%', sm: 400 } } },
-        }}
-      >
-        <Toolbar
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            borderBottom: 1,
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="h6">コメント</Typography>
-          <IconButton onClick={() => setOpen(false)}>
-            <CloseIcon />
-          </IconButton>
-        </Toolbar>
-
-        <Box
-          sx={{
-            flex: 1,
-            overflowY: 'auto',
-            p: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        >
-          {props.comments.length === 0 && (
-            <Typography color="text.secondary" align="center" sx={{ mt: 4 }}>
-              コメントはまだありません
-            </Typography>
-          )}
-          {props.comments.map((comment) => (
-            <CommentItem
-              key={
-                comment.comment_id ??
-                `${comment.commented_by.name}-${comment.timestamp}`
-              }
-              comment={comment}
-              formId={props.formId}
-              answerId={props.answerId}
-              currentUserId={props.currentUserId}
-              showDeleteButton={props.showDeleteButton ?? false}
-            />
-          ))}
-        </Box>
-
-        <SendCommentForm formId={props.formId} answerId={props.answerId} />
-      </Drawer>
-    </>
+    <Box>
+      <ConversationSurface
+        variant="drawer"
+        title="コメント"
+        triggerLabel={`コメント (${entries.length})`}
+        triggerStartIcon={<Typography component="span">💬</Typography>}
+        entries={entries}
+        capabilities={capabilities}
+        composer={
+          capabilities.canCompose ? (
+            <Box
+              sx={{
+                p: 2,
+                borderTop: 1,
+                borderColor: 'divider',
+                backgroundColor: 'background.paper',
+              }}
+            >
+              <ConversationComposer
+                label={capabilities.composeLabel}
+                helperText={capabilities.composeHelperText}
+                onSend={actions.send}
+              />
+            </Box>
+          ) : null
+        }
+        onDelete={actions.deleteEntry}
+      />
+    </Box>
   );
 };
 

--- a/src/app/(authed)/_components/ConversationComposer.tsx
+++ b/src/app/(authed)/_components/ConversationComposer.tsx
@@ -51,14 +51,18 @@ const ConversationComposer = ({
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Grid container>
-        <Grid size={11}>
+        <Grid size={{ xs: 12, sm: 11 }}>
           <TextField
             {...register('body')}
             label={label}
             helperText={helperText}
             sx={{ width: '100%', ...textFieldSx }}
             onKeyDown={async (event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
+              if (
+                event.key === 'Enter' &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing
+              ) {
                 event.preventDefault();
                 await handleSubmit(onSubmit)();
               }
@@ -69,7 +73,7 @@ const ConversationComposer = ({
         </Grid>
         <Grid
           container
-          size={1}
+          size={{ xs: 12, sm: 1 }}
           sx={{ alignItems: 'center', justifyContent: 'center' }}
         >
           <Button variant="contained" endIcon={<SendIcon />} type="submit">

--- a/src/app/(authed)/_components/ConversationComposer.tsx
+++ b/src/app/(authed)/_components/ConversationComposer.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import SendIcon from '@mui/icons-material/Send';
+import { Button, Grid, TextField, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import type { ConversationActionResult } from './conversationTypes';
+
+type ComposerForm = {
+  body: string;
+};
+
+type Props = {
+  label: string;
+  helperText: string;
+  onSend: (body: string) => Promise<ConversationActionResult>;
+  textFieldSx?: SxProps<Theme>;
+};
+
+/**
+ * 投稿入力欄を共通化する composer。
+ * Enter / Shift+Enter の送信体験と送信エラー表示をここで統一する。
+ */
+const ConversationComposer = ({
+  label,
+  helperText,
+  onSend,
+  textFieldSx,
+}: Props) => {
+  const { handleSubmit, register, reset } = useForm<ComposerForm>();
+  const [submitError, setSubmitError] = useState<string>();
+
+  const onSubmit = async (data: ComposerForm) => {
+    if (data.body === '') {
+      return;
+    }
+
+    const result = await onSend(data.body);
+
+    if (result.success) {
+      reset({ body: '' });
+      setSubmitError(undefined);
+    } else if (result.forbidden) {
+      setSubmitError('このメッセージを送信する権限がありません。');
+    } else {
+      setSubmitError('送信に失敗しました');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Grid container>
+        <Grid size={11}>
+          <TextField
+            {...register('body')}
+            label={label}
+            helperText={helperText}
+            sx={{ width: '100%', ...textFieldSx }}
+            onKeyDown={async (event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                await handleSubmit(onSubmit)();
+              }
+            }}
+            multiline
+            required
+          />
+        </Grid>
+        <Grid
+          container
+          size={1}
+          sx={{ alignItems: 'center', justifyContent: 'center' }}
+        >
+          <Button variant="contained" endIcon={<SendIcon />} type="submit">
+            送信
+          </Button>
+        </Grid>
+        {submitError && (
+          <Grid size={12}>
+            <Typography sx={{ fontSize: '12px', marginTop: '10px' }}>
+              {submitError}
+            </Typography>
+          </Grid>
+        )}
+      </Grid>
+    </form>
+  );
+};
+
+export default ConversationComposer;

--- a/src/app/(authed)/_components/ConversationEntry.tsx
+++ b/src/app/(authed)/_components/ConversationEntry.tsx
@@ -157,6 +157,7 @@ const ConversationEntry = ({
         <Grid size={2}>
           <IconButton
             color="primary"
+            aria-label="その他の操作"
             onClick={(event: MouseEvent<HTMLElement>) =>
               setAnchorEl(event.currentTarget)
             }
@@ -195,7 +196,11 @@ const ConversationEntry = ({
             fullWidth
             onChange={(event) => setDraftBody(event.target.value)}
             onKeyDown={async (event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
+              if (
+                event.key === 'Enter' &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing
+              ) {
                 event.preventDefault();
                 await handleUpdate();
               } else if (event.key === 'Escape') {
@@ -240,7 +245,9 @@ const ConversationEntry = ({
           <Grid size={1}></Grid>
           <Grid size={11}>
             <Typography
-              sx={{ color: '#FF2D2D', fontSize: '12px', marginTop: '10px' }}
+              variant="caption"
+              component="p"
+              sx={{ color: 'error.main', marginTop: '10px' }}
             >
               {operationResultMessage}
             </Typography>

--- a/src/app/(authed)/_components/ConversationEntry.tsx
+++ b/src/app/(authed)/_components/ConversationEntry.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { MoreVert } from '@mui/icons-material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  Avatar,
+  Box,
+  Chip,
+  Grid,
+  IconButton,
+  Menu,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import type { MouseEvent } from 'react';
+import { useState } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { formatString } from '@/generic/DateFormatter';
+import type {
+  ConversationActionResult,
+  ConversationCapabilities,
+  ConversationEntryViewModel,
+} from './conversationTypes';
+
+type Props = {
+  entry: ConversationEntryViewModel;
+  capabilities: ConversationCapabilities;
+  onUpdate?: (
+    entryId: string,
+    body: string
+  ) => Promise<ConversationActionResult>;
+  onDelete?: (entryId: string) => Promise<ConversationActionResult>;
+};
+
+/**
+ * 投稿 1 件表示を共通化する component。
+ * entry と capabilities だけを見て描画し、API 差分は持ち込まない。
+ */
+const ConversationEntry = ({
+  entry,
+  capabilities,
+  onUpdate,
+  onDelete,
+}: Props) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+  const [draftBody, setDraftBody] = useState(entry.body);
+  const [isEditing, setIsEditing] = useState(false);
+  const [operationResultMessage, setOperationResultMessage] =
+    useState<string>();
+
+  const isAdmin = entry.authorRole === 'ADMINISTRATOR';
+  const showMenuTrigger =
+    capabilities.actionTrigger === 'menu' && (entry.canEdit || entry.canDelete);
+  const showDeleteTrigger =
+    capabilities.actionTrigger === 'icon' && entry.canDelete;
+
+  const handleDelete = async () => {
+    if (!onDelete) {
+      return;
+    }
+
+    const result = await onDelete(entry.id);
+    if (result.forbidden) {
+      setOperationResultMessage('このメッセージを削除する権限がありません。');
+    } else if (!result.success) {
+      setOperationResultMessage(
+        '不明なエラーが発生しました。もう一度お試しください。'
+      );
+    }
+    setAnchorEl(undefined);
+  };
+
+  const handleUpdate = async () => {
+    if (!onUpdate || draftBody === '') {
+      return;
+    }
+
+    const result = await onUpdate(entry.id, draftBody);
+    if (result.forbidden) {
+      setOperationResultMessage('このメッセージを編集する権限がありません。');
+      return;
+    }
+
+    if (!result.success) {
+      setOperationResultMessage(
+        '不明なエラーが発生しました。もう一度お試しください。'
+      );
+      return;
+    }
+
+    setOperationResultMessage(undefined);
+    setIsEditing(false);
+  };
+
+  return (
+    <Grid container spacing={2}>
+      <Grid size={1}>
+        <Avatar
+          alt="PlayerHead"
+          src={`https://mc-heads.net/avatar/${entry.authorName}`}
+          sx={{
+            width: 36,
+            height: 36,
+            mt: 0.5,
+            border: isAdmin ? 2 : 0,
+            borderColor: 'success.main',
+          }}
+        />
+      </Grid>
+      <Grid size={showMenuTrigger ? 9 : 11}>
+        <Stack>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ display: 'flex', alignItems: 'center' }}
+          >
+            <Typography variant="subtitle2" noWrap>
+              {entry.authorName}
+            </Typography>
+            {isAdmin && (
+              <Chip
+                avatar={
+                  <Avatar
+                    src="/server-icon.png"
+                    sx={{ width: 18, height: 18 }}
+                  />
+                }
+                label={capabilities.adminLabel}
+                color="success"
+                size="small"
+                sx={{ height: 20 }}
+              />
+            )}
+            <Typography variant="caption" color="text.secondary">
+              {formatString(entry.timestamp)}
+            </Typography>
+            {showDeleteTrigger && (
+              <IconButton
+                size="small"
+                color="error"
+                aria-label="delete"
+                sx={{ p: 0.5, ml: 'auto' }}
+                onClick={handleDelete}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Stack>
+        </Stack>
+      </Grid>
+      {showMenuTrigger && (
+        <Grid size={2}>
+          <IconButton
+            color="primary"
+            onClick={(event: MouseEvent<HTMLElement>) =>
+              setAnchorEl(event.currentTarget)
+            }
+          >
+            <MoreVert />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={anchorEl !== undefined}
+            onClose={() => setAnchorEl(undefined)}
+          >
+            {entry.canEdit && (
+              <MenuItem
+                onClick={() => {
+                  setOperationResultMessage(undefined);
+                  setIsEditing(true);
+                  setAnchorEl(undefined);
+                }}
+              >
+                編集
+              </MenuItem>
+            )}
+            {entry.canDelete && (
+              <MenuItem onClick={handleDelete}>削除</MenuItem>
+            )}
+          </Menu>
+        </Grid>
+      )}
+      <Grid size={1}></Grid>
+      <Grid size={11}>
+        {isEditing ? (
+          <TextField
+            defaultValue={entry.body}
+            helperText="編集を確定するには Enter キー、キャンセルするには Esc キーを入力してください。"
+            multiline
+            fullWidth
+            onChange={(event) => setDraftBody(event.target.value)}
+            onKeyDown={async (event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                await handleUpdate();
+              } else if (event.key === 'Escape') {
+                setDraftBody(entry.body);
+                setOperationResultMessage(undefined);
+                setIsEditing(false);
+              }
+            }}
+          />
+        ) : (
+          <Paper
+            variant={entry.renderMode === 'plain' ? 'outlined' : undefined}
+            sx={(theme) => ({
+              p: entry.renderMode === 'plain' ? 1.5 : 0,
+              backgroundColor:
+                entry.renderMode === 'plain'
+                  ? isAdmin
+                    ? alpha(theme.palette.success.main, 0.08)
+                    : theme.palette.grey[50]
+                  : 'transparent',
+              borderRadius: entry.renderMode === 'plain' ? 2 : 0,
+              boxShadow: 'none',
+            })}
+          >
+            {entry.renderMode === 'markdown' ? (
+              <Box sx={{ whiteSpace: 'pre-wrap' }}>
+                <Markdown remarkPlugins={[remarkGfm]}>{entry.body}</Markdown>
+              </Box>
+            ) : (
+              <Typography
+                variant="body2"
+                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+              >
+                {entry.body}
+              </Typography>
+            )}
+          </Paper>
+        )}
+      </Grid>
+      {operationResultMessage && (
+        <Grid container size={12}>
+          <Grid size={1}></Grid>
+          <Grid size={11}>
+            <Typography
+              sx={{ color: '#FF2D2D', fontSize: '12px', marginTop: '10px' }}
+            >
+              {operationResultMessage}
+            </Typography>
+          </Grid>
+        </Grid>
+      )}
+    </Grid>
+  );
+};
+
+export default ConversationEntry;

--- a/src/app/(authed)/_components/ConversationSurface.tsx
+++ b/src/app/(authed)/_components/ConversationSurface.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  IconButton,
+  Stack,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import ConversationEntry from './ConversationEntry';
+import type {
+  ConversationActionResult,
+  ConversationCapabilities,
+  ConversationEntryViewModel,
+} from './conversationTypes';
+
+type Props = {
+  variant: 'drawer' | 'inline';
+  title?: string;
+  triggerLabel?: string;
+  triggerStartIcon?: ReactNode;
+  entries: ConversationEntryViewModel[];
+  capabilities: ConversationCapabilities;
+  composer?: ReactNode;
+  onUpdate?: (
+    entryId: string,
+    body: string
+  ) => Promise<ConversationActionResult>;
+  onDelete?: (entryId: string) => Promise<ConversationActionResult>;
+};
+
+/**
+ * 投稿一覧系 UI の配置責務を持つ上位 component。
+ * drawer / inline のレイアウト差分と空状態、composer の配置をここへ集約する。
+ */
+const ConversationList = ({
+  entries,
+  capabilities,
+  onUpdate,
+  onDelete,
+}: {
+  entries: ConversationEntryViewModel[];
+  capabilities: ConversationCapabilities;
+  onUpdate?: (
+    entryId: string,
+    body: string
+  ) => Promise<ConversationActionResult>;
+  onDelete?: (entryId: string) => Promise<ConversationActionResult>;
+}) => (
+  <Stack spacing={2}>
+    {entries.length === 0 && (
+      <Typography color="text.secondary" align="center" sx={{ mt: 4 }}>
+        {capabilities.emptyMessage}
+      </Typography>
+    )}
+    {entries.map((entry) => (
+      <Stack key={entry.id} spacing={2}>
+        <ConversationEntry
+          entry={entry}
+          capabilities={capabilities}
+          {...(onUpdate ? { onUpdate } : {})}
+          {...(onDelete ? { onDelete } : {})}
+        />
+        <Divider />
+      </Stack>
+    ))}
+  </Stack>
+);
+
+/**
+ * 共通化した投稿表示を、画面用途に応じたサーフェスへ載せる entry point。
+ */
+const ConversationSurface = ({
+  variant,
+  title,
+  triggerLabel,
+  triggerStartIcon,
+  entries,
+  capabilities,
+  composer,
+  onUpdate,
+  onDelete,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+
+  if (variant === 'inline') {
+    return (
+      <ConversationList
+        entries={entries}
+        capabilities={capabilities}
+        {...(onUpdate ? { onUpdate } : {})}
+        {...(onDelete ? { onDelete } : {})}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        onClick={() => setOpen(true)}
+        startIcon={triggerStartIcon}
+      >
+        {triggerLabel}
+      </Button>
+
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={() => setOpen(false)}
+        slotProps={{
+          paper: { sx: { width: { xs: '100%', sm: 400 } } },
+        }}
+      >
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="h6">{title}</Typography>
+          <IconButton onClick={() => setOpen(false)}>
+            <CloseIcon />
+          </IconButton>
+        </Toolbar>
+
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            p: 2,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <ConversationList
+            entries={entries}
+            capabilities={capabilities}
+            {...(onUpdate ? { onUpdate } : {})}
+            {...(onDelete ? { onDelete } : {})}
+          />
+        </Box>
+
+        {composer}
+      </Drawer>
+    </>
+  );
+};
+
+export default ConversationSurface;

--- a/src/app/(authed)/_components/ConversationSurface.tsx
+++ b/src/app/(authed)/_components/ConversationSurface.tsx
@@ -127,7 +127,9 @@ const ConversationSurface = ({
             borderColor: 'divider',
           }}
         >
-          <Typography variant="h6">{title}</Typography>
+          <Typography variant="h6" component="h2">
+            {title}
+          </Typography>
           <IconButton onClick={() => setOpen(false)}>
             <CloseIcon />
           </IconButton>

--- a/src/app/(authed)/_components/InputMessageField.tsx
+++ b/src/app/(authed)/_components/InputMessageField.tsx
@@ -1,79 +1,25 @@
 'use client';
 
-import SendIcon from '@mui/icons-material/Send';
-import { Button, Container, Grid, TextField, Typography } from '@mui/material';
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useSendMessage } from '@/hooks/useSendMessage';
-
-type SendMessageSchema = {
-  body: string;
-};
+import { Container } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import ConversationComposer from './ConversationComposer';
+import { useMessageConversationActions } from './useConversationActions';
 
 const InputMessageField = (props: {
   form_id: string;
   answer_id: string;
-  textFieldSx?: object;
+  textFieldSx?: SxProps<Theme>;
 }) => {
-  const { handleSubmit, register, reset } = useForm<SendMessageSchema>();
-  const [sendFailedMessage, setSendFailedMessage] = useState<
-    string | undefined
-  >(undefined);
-  const { sendMessage } = useSendMessage(props.form_id, props.answer_id);
-
-  const onSubmit = async (data: SendMessageSchema) => {
-    if (data.body === '') {
-      return;
-    }
-
-    const result = await sendMessage(data.body);
-
-    if (result.success) {
-      reset({ body: '' });
-      setSendFailedMessage(undefined);
-    } else if (result.forbidden) {
-      setSendFailedMessage('このメッセージを送信する権限がありません。');
-    } else {
-      setSendFailedMessage('送信に失敗しました');
-    }
-  };
+  const actions = useMessageConversationActions(props.form_id, props.answer_id);
 
   return (
-    <Container component="form" onSubmit={handleSubmit(onSubmit)}>
-      <Grid container>
-        <Grid size={11}>
-          <TextField
-            {...register('body')}
-            label="メッセージを入力してください"
-            helperText="Shift + Enter で改行、Enter で送信することができます。"
-            sx={{ width: '100%', ...props.textFieldSx }}
-            onKeyDown={async (e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                await handleSubmit(onSubmit)();
-              }
-            }}
-            multiline
-            required
-          />
-        </Grid>
-        <Grid
-          container
-          size={1}
-          sx={{ alignItems: 'center', justifyContent: 'center' }}
-        >
-          <Button variant="contained" endIcon={<SendIcon />} type="submit">
-            送信
-          </Button>
-        </Grid>
-        {sendFailedMessage && (
-          <Grid size={12}>
-            <Typography sx={{ fontSize: '12px', marginTop: '10px' }}>
-              {sendFailedMessage}
-            </Typography>
-          </Grid>
-        )}
-      </Grid>
+    <Container>
+      <ConversationComposer
+        label="メッセージを入力してください"
+        helperText="Shift + Enter で改行、Enter で送信することができます。"
+        onSend={actions.send}
+        {...(props.textFieldSx ? { textFieldSx: props.textFieldSx } : {})}
+      />
     </Container>
   );
 };

--- a/src/app/(authed)/_components/Messages.tsx
+++ b/src/app/(authed)/_components/Messages.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-import { MoreVert } from '@mui/icons-material';
-import {
-  Avatar,
-  Box,
-  Chip,
-  Divider,
-  Grid,
-  IconButton,
-  Menu,
-  MenuItem,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
-import { useState } from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { useMessageActions } from '@/hooks/useMessageActions';
-import { formatString } from '@/generic/DateFormatter';
+import ConversationSurface from './ConversationSurface';
+import type {
+  ConversationCapabilities,
+  ConversationEntryViewModel,
+} from './conversationTypes';
+import { useMessageConversationActions } from './useConversationActions';
 
 type Message = {
   id: string;
@@ -31,169 +18,44 @@ type Message = {
   timestamp: string;
 };
 
-const MessageItem = (props: {
-  message: Message;
-  formId: string;
-  answerId: string;
-  edittingMessageId: string | undefined;
-  handleEdit: () => void;
-  handleCancelEditting: () => void;
-}) => {
-  const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
-  const [edittingMessage, setEdittingMessage] = useState<string>();
-  const [operationResultMessage, setOperationResultMessage] = useState<
-    string | undefined
-  >(undefined);
-
-  const { updateMessage, deleteMessage } = useMessageActions(
-    props.formId,
-    props.answerId
-  );
-
-  const handleDelete = async () => {
-    const result = await deleteMessage(props.message.id);
-    if (result.forbidden) {
-      setOperationResultMessage('このメッセージを削除する権限がありません。');
-    } else if (!result.success) {
-      setOperationResultMessage(
-        '不明なエラーが発生しました。もう一度お試しください。'
-      );
-    }
-  };
-
-  return (
-    <Grid container spacing={2}>
-      <Grid size={1}>
-        <Avatar
-          alt="PlayerHead"
-          src={`https://mc-heads.net/avatar/${props.message.sender.name}`}
-        />
-      </Grid>
-      <Grid size={9}>
-        <Stack>
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            {props.message.sender.role === 'ADMINISTRATOR' ? (
-              <Chip
-                avatar={<Avatar src="/server-icon.png" />}
-                label="運営チーム"
-                color="success"
-              />
-            ) : null}
-            <Typography>{props.message.sender.name}</Typography>
-          </Stack>
-          <Typography>{formatString(props.message.timestamp)}</Typography>
-        </Stack>
-      </Grid>
-      <Grid size={2}>
-        <IconButton
-          color="primary"
-          onClick={(event: React.MouseEvent<HTMLElement>) =>
-            setAnchorEl(event.currentTarget)
-          }
-        >
-          <MoreVert />
-        </IconButton>
-      </Grid>
-      <Menu
-        anchorEl={anchorEl}
-        open={anchorEl !== undefined}
-        onClose={() => setAnchorEl(undefined)}
-      >
-        <MenuItem onClick={() => props.handleEdit()}>編集</MenuItem>
-        <MenuItem onClick={handleDelete}>削除</MenuItem>
-      </Menu>
-      <Grid size={1}></Grid>
-      <Grid size={11}>
-        {props.edittingMessageId === props.message.id ? (
-          <TextField
-            defaultValue={props.message.body}
-            helperText="編集を確定するには Enter キー、キャンセルするには Esc キーを入力してください。"
-            multiline
-            onChange={(event) => setEdittingMessage(event.target.value)}
-            onKeyDown={async (event) => {
-              if (
-                event.key === 'Enter' &&
-                edittingMessage !== undefined &&
-                edittingMessage !== ''
-              ) {
-                const result = await updateMessage(
-                  props.message.id,
-                  edittingMessage
-                );
-
-                if (result.forbidden) {
-                  setOperationResultMessage(
-                    'このメッセージを編集する権限がありません。'
-                  );
-                } else if (result.success) {
-                  props.handleCancelEditting();
-                } else {
-                  setOperationResultMessage(
-                    '不明なエラーが発生しました。もう一度お試しください。'
-                  );
-                }
-              } else if (event.key === 'Escape') {
-                setOperationResultMessage(undefined);
-                props.handleCancelEditting();
-              }
-            }}
-          />
-        ) : (
-          <Box sx={{ whiteSpace: 'pre-wrap' }}>
-            <Markdown remarkPlugins={[remarkGfm]}>
-              {props.message.body}
-            </Markdown>
-          </Box>
-        )}
-      </Grid>
-      {operationResultMessage === undefined ? null : (
-        <Box sx={{ width: '100%' }}>
-          <Grid size={1}></Grid>
-          <Grid size={11}>
-            <Typography
-              sx={{ color: '#FF2D2D', fontSize: '12px', marginTop: '10px' }}
-            >
-              {operationResultMessage}
-            </Typography>
-          </Grid>
-        </Box>
-      )}
-    </Grid>
-  );
-};
-
 const Messages = (props: {
   messages: Message[];
   formId: string;
   answerId: string;
 }) => {
-  const [edittingMessageId, setEdittingMessageId] = useState<
-    string | undefined
-  >(undefined);
+  const actions = useMessageConversationActions(props.formId, props.answerId);
+
+  const entries: ConversationEntryViewModel[] = props.messages.map(
+    (message) => ({
+      id: message.id,
+      body: message.body,
+      authorName: message.sender.name,
+      authorId: message.sender.uuid,
+      authorRole: message.sender.role,
+      timestamp: message.timestamp,
+      renderMode: 'markdown',
+      canDelete: true,
+      canEdit: true,
+    })
+  );
+
+  const capabilities: ConversationCapabilities = {
+    canCompose: false,
+    composeLabel: 'メッセージを入力してください',
+    composeHelperText: 'Shift + Enter で改行、Enter で送信することができます。',
+    emptyMessage: 'メッセージはまだありません',
+    adminLabel: '運営チーム',
+    actionTrigger: 'menu',
+  };
 
   return (
-    <Stack spacing={2}>
-      {props.messages.map((message) => (
-        <Stack key={message.id} spacing={2}>
-          <MessageItem
-            message={message}
-            formId={props.formId}
-            answerId={props.answerId}
-            edittingMessageId={edittingMessageId}
-            handleEdit={() => setEdittingMessageId(message.id)}
-            handleCancelEditting={() => setEdittingMessageId(undefined)}
-          />
-          <Divider />
-        </Stack>
-      ))}
-    </Stack>
+    <ConversationSurface
+      variant="inline"
+      entries={entries}
+      capabilities={capabilities}
+      onUpdate={actions.update}
+      onDelete={actions.deleteEntry}
+    />
   );
 };
 

--- a/src/app/(authed)/_components/conversationTypes.ts
+++ b/src/app/(authed)/_components/conversationTypes.ts
@@ -1,0 +1,35 @@
+'use client';
+
+export type ConversationActionResult = {
+  success: boolean;
+  forbidden?: boolean;
+};
+
+/**
+ * 投稿一覧系 UI が受け取る共通表示モデル。
+ * API response は画面側でこの形へ写像してから渡す。
+ */
+export type ConversationEntryViewModel = {
+  id: string;
+  body: string;
+  authorName: string;
+  authorId?: string;
+  authorRole: string;
+  timestamp: string;
+  renderMode: 'plain' | 'markdown';
+  canDelete: boolean;
+  canEdit: boolean;
+};
+
+/**
+ * 投稿一覧系 UI の振る舞い差分を props で表現するための設定。
+ * 見た目ではなく操作体験の違いをここへ閉じ込める。
+ */
+export type ConversationCapabilities = {
+  canCompose: boolean;
+  composeLabel: string;
+  composeHelperText: string;
+  emptyMessage: string;
+  adminLabel: string;
+  actionTrigger: 'menu' | 'icon';
+};

--- a/src/app/(authed)/_components/useConversationActions.ts
+++ b/src/app/(authed)/_components/useConversationActions.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCommentActions } from '@/hooks/useCommentActions';
+import { useMessageActions } from '@/hooks/useMessageActions';
+import { useSendMessage } from '@/hooks/useSendMessage';
+import type { ConversationActionResult } from './conversationTypes';
+
+/**
+ * コメント API を、投稿一覧系 UI が扱う action interface へ寄せる adapter。
+ */
+export const useCommentConversationActions = (
+  formId: string,
+  answerId: string
+) => {
+  const { sendComment, deleteComment } = useCommentActions(formId, answerId);
+
+  return {
+    send: async (body: string): Promise<ConversationActionResult> => {
+      const result = await sendComment(body);
+      return { success: result.ok };
+    },
+    deleteEntry: async (entryId: string): Promise<ConversationActionResult> => {
+      const result = await deleteComment(entryId);
+      return { success: result.ok };
+    },
+  };
+};
+
+/**
+ * メッセージ API を、投稿一覧系 UI が扱う action interface へ寄せる adapter。
+ */
+export const useMessageConversationActions = (
+  formId: string,
+  answerId: string
+) => {
+  const { sendMessage } = useSendMessage(formId, answerId);
+  const { updateMessage, deleteMessage } = useMessageActions(formId, answerId);
+
+  return {
+    send: (body: string) => sendMessage(body),
+    update: (entryId: string, body: string) => updateMessage(entryId, body),
+    deleteEntry: (entryId: string) => deleteMessage(entryId),
+  };
+};

--- a/src/app/(authed)/_components/useConversationActions.ts
+++ b/src/app/(authed)/_components/useConversationActions.ts
@@ -17,11 +17,17 @@ export const useCommentConversationActions = (
   return {
     send: async (body: string): Promise<ConversationActionResult> => {
       const result = await sendComment(body);
-      return { success: result.ok };
+      return {
+        success: result.ok,
+        ...(result.forbidden ? { forbidden: true } : {}),
+      };
     },
     deleteEntry: async (entryId: string): Promise<ConversationActionResult> => {
       const result = await deleteComment(entryId);
-      return { success: result.ok };
+      return {
+        success: result.ok,
+        ...(result.forbidden ? { forbidden: true } : {}),
+      };
     },
   };
 };

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -3,8 +3,10 @@
 import { proxyClient } from '@/lib/proxyClient';
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 
+type CommentActionResult = { ok: boolean; forbidden?: boolean };
+
 export const useCommentActions = (formId: string, answerId: string) => {
-  const sendComment = async (content: string): Promise<{ ok: boolean }> => {
+  const sendComment = async (content: string): Promise<CommentActionResult> => {
     const { data, error, response } = await proxyClient.POST(
       '/forms/{form_id}/answers/{answer_id}/comments',
       {
@@ -15,10 +17,16 @@ export const useCommentActions = (formId: string, answerId: string) => {
       }
     );
     const result = handleMutationResponse(response, data, error);
-    return { ok: result.success };
+    if (result.success) {
+      return { ok: true };
+    }
+
+    return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
-  const deleteComment = async (commentId: string): Promise<{ ok: boolean }> => {
+  const deleteComment = async (
+    commentId: string
+  ): Promise<CommentActionResult> => {
     const { data, error, response } = await proxyClient.DELETE(
       '/forms/{form_id}/answers/{answer_id}/comments/{comment_id}',
       {
@@ -32,7 +40,11 @@ export const useCommentActions = (formId: string, answerId: string) => {
       }
     );
     const result = handleMutationResponse(response, data, error);
-    return { ok: result.success };
+    if (result.success) {
+      return { ok: true };
+    }
+
+    return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
   return { sendComment, deleteComment };


### PR DESCRIPTION
## 概要
- 肥大化していた回答フォームを、送信状態管理・質問描画・質問タイプ別入力 UI に分離し、責務ごとに再利用しやすくしました。
- コメントとメッセージの表示・入力・操作導線を、投稿一覧系 UI として共通化し、view model と action adapter を介して扱えるようにしました。
- 追加した再利用コンポーネントと hook に、責務境界が追えるコード内ドキュメントを補いました。

## 確認事項
- `pnpm type-check` を実行し、型エラーなく通ることを確認しました。
- pre-commit hook 経由で `lint` `type-check` `fmt` が実行され、すべて成功する状態でコミットしました。
- 画面の手動確認や E2E は未実施です。主に責務分離と共通化の変更なので、表示差分や操作感はレビュー時に見てほしいです。

## 補足
- `Conversation*` 系の命名は維持しつつ、コード内ドキュメントでは用途例を固定せず「投稿一覧系 UI」として説明しています。

🤖 Generated with Codex
