### PR TITLE
ページタイトル管理を Next.js metadata に寄せる

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
@@ -1,45 +1,32 @@
-'use client';
-
 import { Box, Typography } from '@mui/material';
-import { use } from 'react';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerList from './_components/AnswerList';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireUser } from '@/lib/server/session';
+import type { GetFormAnswersResponse, GetFormResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = ({ params }: { params: Promise<{ formId: string }> }) => {
-  usePageTitle('回答一覧');
-  const { formId } = use(params);
-  const {
-    data: answers,
-    error: answersError,
-    isLoading: isLoadingAnswers,
-  } = useApiQuery('/forms/{id}/answers', {
-    path: { id: formId },
-  });
-  const {
-    data: forms,
-    error: formsError,
-    isLoading: isLoadingForms,
-  } = useApiQuery('/forms');
+export const metadata: Metadata = {
+  title: '回答一覧 | Seichi Portal',
+};
 
-  if (answersError || formsError) {
-    return <ErrorModal error={answersError ?? formsError} />;
-  }
-
-  if (isLoadingAnswers || isLoadingForms || !answers || !forms) {
-    return <LoadingCircular />;
-  }
-
-  const formTitle =
-    forms.find((form) => form.id === answers[0]?.form_id)?.title ??
-    'unknown form';
+const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
+  const session = await requireUser();
+  const { formId } = await params;
+  const [answers, form] = await Promise.all([
+    backendFetchJson<GetFormAnswersResponse>(`/forms/${formId}/answers`, {
+      method: 'GET',
+      token: session.token,
+    }),
+    backendFetchJson<GetFormResponse>(`/forms/${formId}`, {
+      method: 'GET',
+      token: session.token,
+    }),
+  ]);
 
   return (
     <Box sx={{ width: '100%' }}>
       <Typography variant="h5" sx={{ mb: 2 }}>
-        {formTitle}
+        {form.title}
       </Typography>
       <AnswerList answers={answers} />
     </Box>

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
@@ -25,7 +25,7 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Typography variant="h5" sx={{ mb: 2 }}>
+      <Typography variant="h5" component="h1" sx={{ mb: 2 }}>
         {form.title}
       </Typography>
       <AnswerList answers={answers} />

--- a/src/app/(authed)/(standard)/forms/[formId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/page.tsx
@@ -1,30 +1,20 @@
-'use client';
-
-import { use } from 'react';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import AnswerForm from './_components/AnswerForm';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireUser } from '@/lib/server/session';
+import type { GetFormResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = ({ params }: { params: Promise<{ formId: string }> }) => {
-  usePageTitle('フォーム回答');
-  const { formId } = use(params);
-  const {
-    data: form,
-    error,
-    isLoading,
-  } = useApiQuery('/forms/{id}', {
-    path: { id: formId },
+export const metadata: Metadata = {
+  title: 'フォーム回答 | Seichi Portal',
+};
+
+const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
+  const session = await requireUser();
+  const { formId } = await params;
+  const form = await backendFetchJson<GetFormResponse>(`/forms/${formId}`, {
+    method: 'GET',
+    token: session.token,
   });
-
-  if (error) {
-    return <ErrorModal error={error} />;
-  }
-
-  if (isLoading || !form) {
-    return <LoadingCircular />;
-  }
 
   return (
     <AnswerForm

--- a/src/app/(authed)/(standard)/page.tsx
+++ b/src/app/(authed)/(standard)/page.tsx
@@ -1,12 +1,10 @@
-'use client';
-
-import { usePageTitle } from '@/hooks/usePageTitle';
 import MainMenu from './_components/MainMenu';
+import type { Metadata } from 'next';
 
-const Home = () => {
-  usePageTitle('ホーム');
-
-  return <MainMenu />;
+export const metadata: Metadata = {
+  title: 'ホーム | Seichi Portal',
 };
+
+const Home = () => <MainMenu />;
 
 export default Home;

--- a/src/app/(authed)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(authed)/admin/forms/_components/FormsPageContent.tsx
@@ -21,7 +21,7 @@ const FormsPageContent = ({
     if (labelFilter.length === 0) return forms;
     return forms.filter((form) =>
       labelFilter.every((label) =>
-        form.labels.map((formLabel) => formLabel.id).includes(label.id)
+        form.labels.some((formLabel) => formLabel.id === label.id)
       )
     );
   }, [forms, labelFilter]);

--- a/src/app/(authed)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(authed)/admin/forms/_components/FormsPageContent.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Grid, Stack } from '@mui/material';
+import { useMemo, useState } from 'react';
+import { Forms } from './DashboardFormList';
+import FormCreateButton from './FormCreateButton';
+import FormLabelFilter from './FormLabelFilter';
+import ToManageFormLabelButton from './ToManageFormLabelButton';
+import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+
+const FormsPageContent = ({
+  forms,
+  labels,
+}: {
+  forms: GetFormsResponse;
+  labels: GetFormLabelsResponse;
+}) => {
+  const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
+
+  const filteredForms = useMemo(() => {
+    if (labelFilter.length === 0) return forms;
+    return forms.filter((form) =>
+      labelFilter.every((label) =>
+        form.labels.map((formLabel) => formLabel.id).includes(label.id)
+      )
+    );
+  }, [forms, labelFilter]);
+
+  return (
+    <Grid
+      container
+      spacing={4}
+      sx={{ flexDirection: 'column', justifyContent: 'flex-start' }}
+    >
+      <Grid>
+        <Grid
+          container
+          spacing={2}
+          direction="row"
+          sx={{ justifyContent: 'space-between' }}
+        >
+          <Grid size="auto">
+            <Stack direction="row">
+              <FormLabelFilter
+                labelOptions={labels}
+                setLabelFilter={setLabelFilter}
+              />
+              <ToManageFormLabelButton />
+            </Stack>
+          </Grid>
+          <Grid size={2}>
+            <FormCreateButton />
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid>
+        <Forms forms={filteredForms} />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default FormsPageContent;

--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -1,26 +1,22 @@
-'use client';
-
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormCreateForm from './_components/FormCreateForm';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireAdmin } from '@/lib/server/session';
+import type { GetFormLabelsResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = () => {
-  usePageTitle('フォーム作成');
-  const {
-    data: labels,
-    error,
-    isLoading: isLoadingLabels,
-  } = useApiQuery('/labels/forms');
+export const metadata: Metadata = {
+  title: 'フォーム作成 | Seichi Portal',
+};
 
-  if (error) {
-    return <ErrorModal />;
-  }
-
-  if (isLoadingLabels || !labels) {
-    return <LoadingCircular />;
-  }
+const Home = async () => {
+  const session = await requireAdmin();
+  const labels = await backendFetchJson<GetFormLabelsResponse>(
+    '/labels/forms',
+    {
+      method: 'GET',
+      token: session.token,
+    }
+  );
 
   return <FormCreateForm labelOptions={labels} />;
 };

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -1,35 +1,26 @@
-'use client';
-
-import { use } from 'react';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import FormEditForm from './_components/FormEditForm';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireAdmin } from '@/lib/server/session';
+import type { GetFormLabelsResponse, GetFormResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = ({ params }: { params: Promise<{ id: number }> }) => {
-  usePageTitle('フォーム編集');
-  const { id } = use(params);
-  const {
-    data: form,
-    error: formError,
-    isLoading: isLoadingForms,
-  } = useApiQuery('/forms/{id}', {
-    path: { id: String(id) },
-  });
-  const {
-    data: labels,
-    error: labelsError,
-    isLoading: isLoadingLabels,
-  } = useApiQuery('/labels/forms');
+export const metadata: Metadata = {
+  title: 'フォーム編集 | Seichi Portal',
+};
 
-  if (formError || labelsError) {
-    return <ErrorModal />;
-  }
-
-  if (isLoadingForms || isLoadingLabels || !form || !labels) {
-    return <LoadingCircular />;
-  }
+const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
+  const session = await requireAdmin();
+  const { id } = await params;
+  const [form, labels] = await Promise.all([
+    backendFetchJson<GetFormResponse>(`/forms/${id}`, {
+      method: 'GET',
+      token: session.token,
+    }),
+    backendFetchJson<GetFormLabelsResponse>('/labels/forms', {
+      method: 'GET',
+      token: session.token,
+    }),
+  ]);
 
   return <FormEditForm form={form} labelOptions={labels} />;
 };

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -1,81 +1,27 @@
-'use client';
+import FormsPageContent from './_components/FormsPageContent';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireAdmin } from '@/lib/server/session';
+import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-import { Grid, Stack } from '@mui/material';
-import { useMemo, useState } from 'react';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
-import { Forms } from './_components/DashboardFormList';
-import FormCreateButton from './_components/FormCreateButton';
-import FormLabelFilter from './_components/FormLabelFilter';
-import ToManageFormLabelButton from './_components/ToManageFormLabelButton';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import { usePageTitle } from '@/hooks/usePageTitle';
-import type { GetFormLabelsResponse } from '@/lib/api-types';
+export const metadata: Metadata = {
+  title: 'フォーム管理 | Seichi Portal',
+};
 
-const Home = () => {
-  usePageTitle('フォーム管理');
-  const {
-    data: forms,
-    error: formsError,
-    isLoading: isLoadingForms,
-  } = useApiQuery('/forms');
-  const {
-    data: labels,
-    error: labelsError,
-    isLoading: isLoadingLabels,
-  } = useApiQuery('/labels/forms');
-  const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
+const Home = async () => {
+  const session = await requireAdmin();
+  const [forms, labels] = await Promise.all([
+    backendFetchJson<GetFormsResponse>('/forms', {
+      method: 'GET',
+      token: session.token,
+    }),
+    backendFetchJson<GetFormLabelsResponse>('/labels/forms', {
+      method: 'GET',
+      token: session.token,
+    }),
+  ]);
 
-  const filteredForms = useMemo(() => {
-    if (!forms) return [];
-    if (labelFilter.length === 0) return forms;
-    return forms.filter((form) =>
-      labelFilter.every((label) =>
-        form.labels.map((l) => l.id).includes(label.id)
-      )
-    );
-  }, [labelFilter, forms]);
-
-  if (formsError || labelsError) {
-    return <ErrorModal />;
-  }
-
-  if (isLoadingForms || isLoadingLabels || !forms || !labels) {
-    return <LoadingCircular />;
-  }
-
-  return (
-    <Grid
-      container
-      spacing={4}
-      sx={{ flexDirection: 'column', justifyContent: 'flex-start' }}
-    >
-      <Grid>
-        <Grid
-          container
-          spacing={2}
-          direction="row"
-          sx={{ justifyContent: 'space-between' }}
-        >
-          <Grid size="auto">
-            <Stack direction="row">
-              <FormLabelFilter
-                labelOptions={labels}
-                setLabelFilter={setLabelFilter}
-              />
-              <ToManageFormLabelButton />
-            </Stack>
-          </Grid>
-          <Grid size={2}>
-            <FormCreateButton />
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid>
-        <Forms forms={filteredForms} />
-      </Grid>
-    </Grid>
-  );
+  return <FormsPageContent forms={forms} labels={labels} />;
 };
 
 export default Home;

--- a/src/app/(authed)/admin/labels/answers/page.tsx
+++ b/src/app/(authed)/admin/labels/answers/page.tsx
@@ -1,24 +1,24 @@
-'use client';
-
 import { Stack, Typography } from '@mui/material';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import CreateLabelField from '../_components/CreateLabelField';
 import Labels from '../_components/Labels';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireAdmin } from '@/lib/server/session';
+import type { GetAnswerLabelsResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = () => {
-  usePageTitle('回答設定用ラベル管理');
-  const { data, error, isLoading } = useApiQuery('/labels/answers');
+export const metadata: Metadata = {
+  title: '回答設定用ラベル管理 | Seichi Portal',
+};
 
-  if (error) {
-    return <ErrorModal />;
-  }
-
-  if (isLoading || !data) {
-    return <LoadingCircular />;
-  }
+const Home = async () => {
+  const session = await requireAdmin();
+  const labels = await backendFetchJson<GetAnswerLabelsResponse>(
+    '/labels/answers',
+    {
+      method: 'GET',
+      token: session.token,
+    }
+  );
 
   return (
     <Stack spacing={3} sx={{ width: '100%' }}>
@@ -30,7 +30,7 @@ const Home = () => {
         <Typography variant="h4">回答設定用ラベル管理</Typography>
         <CreateLabelField />
       </Stack>
-      <Labels labels={data} />
+      <Labels labels={labels} />
     </Stack>
   );
 };

--- a/src/app/(authed)/admin/labels/answers/page.tsx
+++ b/src/app/(authed)/admin/labels/answers/page.tsx
@@ -27,7 +27,9 @@ const Home = async () => {
         spacing={2}
         sx={{ justifyContent: 'space-between', alignItems: 'center' }}
       >
-        <Typography variant="h4">回答設定用ラベル管理</Typography>
+        <Typography variant="h4" component="h1">
+          回答設定用ラベル管理
+        </Typography>
         <CreateLabelField />
       </Stack>
       <Labels labels={labels} />

--- a/src/app/(authed)/admin/labels/forms/page.tsx
+++ b/src/app/(authed)/admin/labels/forms/page.tsx
@@ -1,24 +1,24 @@
-'use client';
-
 import { Stack, Typography } from '@mui/material';
-import { useApiQuery } from '@/app/_swr/useApiQuery';
-import ErrorModal from '@/app/_components/ErrorModal';
-import LoadingCircular from '@/app/_components/LoadingCircular';
 import CreateLabelField from './_components/CreateLabelField';
 import Labels from './_components/Labels';
-import { usePageTitle } from '@/hooks/usePageTitle';
+import { backendFetchJson } from '@/lib/server/backend';
+import { requireAdmin } from '@/lib/server/session';
+import type { GetFormLabelsResponse } from '@/lib/api-types';
+import type { Metadata } from 'next';
 
-const Home = () => {
-  usePageTitle('フォーム設定用ラベル管理');
-  const { data, error, isLoading } = useApiQuery('/labels/forms');
+export const metadata: Metadata = {
+  title: 'フォーム設定用ラベル管理 | Seichi Portal',
+};
 
-  if (error) {
-    return <ErrorModal />;
-  }
-
-  if (isLoading || !data) {
-    return <LoadingCircular />;
-  }
+const Home = async () => {
+  const session = await requireAdmin();
+  const labels = await backendFetchJson<GetFormLabelsResponse>(
+    '/labels/forms',
+    {
+      method: 'GET',
+      token: session.token,
+    }
+  );
 
   return (
     <Stack spacing={3} sx={{ width: '100%' }}>
@@ -30,7 +30,7 @@ const Home = () => {
         <Typography variant="h4">フォーム設定用ラベル管理</Typography>
         <CreateLabelField />
       </Stack>
-      <Labels labels={data} />
+      <Labels labels={labels} />
     </Stack>
   );
 };

--- a/src/app/(authed)/admin/labels/forms/page.tsx
+++ b/src/app/(authed)/admin/labels/forms/page.tsx
@@ -27,7 +27,9 @@ const Home = async () => {
         spacing={2}
         sx={{ justifyContent: 'space-between', alignItems: 'center' }}
       >
-        <Typography variant="h4">フォーム設定用ラベル管理</Typography>
+        <Typography variant="h4" component="h1">
+          フォーム設定用ラベル管理
+        </Typography>
         <CreateLabelField />
       </Stack>
       <Labels labels={labels} />


### PR DESCRIPTION
## 概要
- `usePageTitle` を使っていた 8 ページのうち、サーバー化しやすい画面を `metadata` ベースのタイトル管理へ移行しました。
- 各 `page.tsx` で初期データ取得をサーバー側へ寄せ、インタラクティブな責務だけを既存のクライアントコンポーネントへ残しました。
- `admin/forms/page.tsx` はラベルフィルタの state だけを新しいクライアントコンテナへ分離し、ページ本体はサーバーコンポーネントへ戻しました。

## 確認事項
- `pnpm lint` を実行し、対象ページの import・Hooks・Server/Client 境界で lint エラーが出ないことを確認しました。
- `pnpm type-check` を実行し、`metadata` 追加とサーバー取得への置き換え後も型エラーがないことを確認しました。
- `pnpm fmt` を実行し、Prettier の整形チェックを通過することを確認しました。

## 補足
- ログイン画面と回答詳細系の 2 画面は、クライアント依存やポーリング前提が強いため今回の移行対象から外しています。

🤖 Generated with Codex
