### PR TITLE
chore: CI の検証再現性を強化する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
         uses: actions/cache@v5
@@ -46,8 +46,14 @@ jobs:
       - name: Format
         run: pnpm run fmt
 
+      - name: Type check
+        run: pnpm run type-check
+
       - name: Unit test
         run: pnpm run test:unit
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: E2E test
         run: pnpm run test:e2e

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,3 +10,9 @@ pre-commit:
 
     - name: fmt
       run: pnpm fmt
+
+pre-push:
+  parallel: false
+  jobs:
+    - name: unit-test
+      run: pnpm test:unit


### PR DESCRIPTION
## 概要
- CI の依存インストールを `pnpm install --frozen-lockfile` に変更し、lockfile と manifest の不整合を検出できるようにしました
- Playwright 実行前に Chromium を明示的にインストールするようにして、E2E 実行環境の再現性を上げました
- hooks 側では `pre-push` に `test:unit` を追加し、push 前に最低限の回帰を止められるようにしました

## 確認事項
- `pnpm run type-check` を実行し、型チェックが成功することを確認しました
- `pnpm run test:unit` を実行し、8 tests passed で成功することを確認しました
- `test:e2e` と `build` は今回ローカル未実行です。変更が CI 設定と hook 設定中心で、最終確認は GitHub Actions 側で行う前提です

## 補足
- OpenAPI 生成物の整合性チェックは今回含めていません。別 Issue #667 で対応を切り出しています

🤖 Generated with Codex
