### PR TITLE
refactor: 回答詳細ページの UI を通常画面基準で共通化

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails.tsx
@@ -32,6 +32,7 @@ const AnswerDetails = (props: {
             <Paper key={key} variant="outlined" sx={{ p: 2 }}>
               <Typography
                 variant="subtitle1"
+                component="h2"
                 sx={{ fontWeight: 'bold', mb: 1 }}
               >
                 {answerWithQuestionTitle.questionTitle}

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails.tsx
@@ -1,21 +1,22 @@
 'use client';
 
 import { Paper, Stack, Typography } from '@mui/material';
+import { removeDuplicates } from '@/generic/ArrayExtra';
 import type { GetAnswerResponse, GetQuestionsResponse } from '@/lib/api-types';
 
 const AnswerDetails = (props: {
   answer: GetAnswerResponse;
   questions: GetQuestionsResponse;
 }) => {
-  const answerWithQuestionTitles = props.answer.answers.map((answer) => {
-    const question = props.questions.find(
-      (question) => question.id === answer.question_id
-    );
+  const answerWithQuestionTitles = removeDuplicates(
+    props.answer.answers.map((answer) => answer.question_id)
+  ).map((questionId) => {
+    const question = props.questions.find((item) => item.id === questionId);
 
     return {
       questionTitle: question?.title || '不明なタイトル',
       answers: props.answer.answers
-        .filter((answer) => answer.question_id === question?.id)
+        .filter((answer) => answer.question_id === questionId)
         .map((answer) => answer.answer)
         .join(', '),
     };
@@ -23,20 +24,27 @@ const AnswerDetails = (props: {
 
   return (
     <Stack spacing={2}>
-      {answerWithQuestionTitles.map((answerWithQuestionTitle, key) => {
-        return (
-          <Paper key={key} variant="outlined" sx={{ p: 2 }}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
-              {answerWithQuestionTitle.questionTitle}
-            </Typography>
-            <Typography
-              sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
-            >
-              {answerWithQuestionTitle.answers}
-            </Typography>
-          </Paper>
-        );
-      })}
+      {answerWithQuestionTitles.length === 0 ? (
+        <Typography>回答がありません</Typography>
+      ) : (
+        answerWithQuestionTitles.map((answerWithQuestionTitle, key) => {
+          return (
+            <Paper key={key} variant="outlined" sx={{ p: 2 }}>
+              <Typography
+                variant="subtitle1"
+                sx={{ fontWeight: 'bold', mb: 1 }}
+              >
+                {answerWithQuestionTitle.questionTitle}
+              </Typography>
+              <Typography
+                sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
+              >
+                {answerWithQuestionTitle.answers}
+              </Typography>
+            </Paper>
+          );
+        })
+      )}
     </Stack>
   );
 };

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerMeta.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerMeta.tsx
@@ -9,6 +9,8 @@ import type { GetAnswerResponse } from '@/lib/api-types';
 const AnswerMeta = (props: {
   answer: GetAnswerResponse;
   messageAction: ReactNode;
+  labelsSlot?: ReactNode;
+  extraActions?: ReactNode;
 }) => (
   <Paper variant="outlined" sx={{ p: 2 }}>
     <Grid container spacing={2}>
@@ -28,16 +30,20 @@ const AnswerMeta = (props: {
         <Typography variant="caption" color="text.secondary">
           ラベル
         </Typography>
-        <Box>
-          <AnswerLabels answers={props.answer} />
-        </Box>
+        <Box>{props.labelsSlot ?? <AnswerLabels answers={props.answer} />}</Box>
       </Grid>
       <Grid size={{ xs: 12, sm: 6 }}>
         <Stack
           direction="row"
           spacing={2}
-          sx={{ justifyContent: 'flex-start', alignItems: 'center' }}
+          useFlexGap
+          sx={{
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
         >
+          {props.extraActions}
           {props.messageAction}
         </Stack>
       </Grid>

--- a/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
@@ -5,30 +5,25 @@ import EditIcon from '@mui/icons-material/Edit';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
-import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAnswerActions } from '@/hooks/useAnswerActions';
-import { removeDuplicates } from '@/generic/ArrayExtra';
-import { formatString } from '@/generic/DateFormatter';
 import type {
   GetAnswerLabelsResponse,
   GetAnswerResponse,
-  GetQuestionsResponse,
 } from '@/lib/api-types';
 
-const AnswerTitleForm = (props: { answers: GetAnswerResponse }) => {
+export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
   const { handleSubmit, register } = useForm<{ title: string }>();
   const [isEditing, setIsEditing] = useState(false);
-  const [title, setTitle] = useState(props.answers.title);
+  const [title, setTitle] = useState(props.answer.title);
   const { updateTitle } = useAnswerActions(
-    props.answers.form_id,
-    props.answers.id
+    props.answer.form_id,
+    props.answer.id
   );
 
   const onSubmit = async (data: { title: string }) => {
@@ -43,10 +38,19 @@ const AnswerTitleForm = (props: { answers: GetAnswerResponse }) => {
     <Stack
       direction="row"
       spacing={2}
-      sx={{ justifyContent: 'space-between', alignItems: 'flex-start' }}
+      sx={{
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        flexWrap: 'wrap',
+      }}
     >
       {isEditing ? (
-        <TextField {...register('title')} defaultValue={title} required />
+        <TextField
+          {...register('title')}
+          defaultValue={title}
+          required
+          sx={{ minWidth: 280, flexGrow: 1 }}
+        />
       ) : (
         <Typography variant="h4">{title}</Typography>
       )}
@@ -71,13 +75,13 @@ const AnswerTitleForm = (props: { answers: GetAnswerResponse }) => {
   );
 };
 
-const AnswerLabels = (props: {
+export const AdminAnswerLabels = (props: {
   labelOptions: GetAnswerLabelsResponse;
-  answers: GetAnswerResponse;
+  answer: GetAnswerResponse;
 }) => {
   const { updateLabels } = useAnswerActions(
-    props.answers.form_id,
-    props.answers.id
+    props.answer.form_id,
+    props.answer.id
   );
 
   return (
@@ -86,7 +90,7 @@ const AnswerLabels = (props: {
       id="label"
       options={props.labelOptions.map((label) => label.name)}
       getOptionLabel={(option) => option}
-      defaultValue={props.answers.labels.map((label) => label.name)}
+      defaultValue={props.answer.labels.map((label) => label.name)}
       renderOption={(renderProps, option) => (
         <Box {...renderProps} key={option} component="span">
           {option}
@@ -109,91 +113,13 @@ const AnswerLabels = (props: {
   );
 };
 
-const AnswerMeta = (props: {
-  answers: GetAnswerResponse;
-  labels: GetAnswerLabelsResponse;
-  messageAction: ReactNode;
-}) => (
-  <Grid container spacing={2}>
-    <Grid size={6}>
-      <Typography sx={{ fontWeight: 'bold' }}>回答者</Typography>
-      {props.answers.user.name}
-    </Grid>
-    <Grid size={6}>
-      <Typography sx={{ fontWeight: 'bold' }}>回答日時</Typography>
-      {formatString(props.answers.timestamp)}
-    </Grid>
-    <Grid size={6}>
-      <Typography sx={{ fontWeight: 'bold' }}>ラベル</Typography>
-      <AnswerLabels labelOptions={props.labels} answers={props.answers} />
-    </Grid>
-    <Grid size={6}>
-      <Stack spacing={2} direction="row">
-        <Button
-          component={NextLink}
-          variant="contained"
-          href="/admin/labels/answers"
-          startIcon={<Label />}
-        >
-          ラベルの管理
-        </Button>
-        {props.messageAction}
-      </Stack>
-    </Grid>
-  </Grid>
+export const AdminAnswerLabelManagementButton = () => (
+  <Button
+    component={NextLink}
+    variant="contained"
+    href="/admin/labels/answers"
+    startIcon={<Label />}
+  >
+    ラベルの管理
+  </Button>
 );
-
-type AnswerWithQuestionInfo = {
-  questionTitle: string;
-  answers: string[];
-};
-
-const Answers = (props: { answers: AnswerWithQuestionInfo }) => (
-  <Stack>
-    <Typography sx={{ fontWeight: 'bold' }}>
-      {props.answers.questionTitle}
-    </Typography>
-    {props.answers.answers.join(', ')}
-  </Stack>
-);
-
-const AnswerDetails = (props: {
-  answers: GetAnswerResponse;
-  questions: GetQuestionsResponse;
-  labels: GetAnswerLabelsResponse;
-  messageAction: ReactNode;
-}) => {
-  const answerWithQuestionInfo = removeDuplicates(
-    props.answers.answers.map((answer) => answer.question_id)
-  ).map((questionId) => {
-    const info: AnswerWithQuestionInfo = {
-      questionTitle:
-        props.questions.find((question) => question.id == questionId)?.title ||
-        '',
-      answers: props.answers.answers
-        .filter((answer) => answer.question_id == questionId)
-        .map((answer) => answer.answer),
-    };
-    return info;
-  });
-
-  return (
-    <Stack spacing={2}>
-      <AnswerTitleForm answers={props.answers} />
-      <AnswerMeta
-        answers={props.answers}
-        labels={props.labels}
-        messageAction={props.messageAction}
-      />
-      {answerWithQuestionInfo.length === 0 ? (
-        <Typography>回答がありません</Typography>
-      ) : (
-        answerWithQuestionInfo.map((answer, index) => (
-          <Answers key={index} answers={answer} />
-        ))
-      )}
-    </Stack>
-  );
-};
-
-export default AnswerDetails;

--- a/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/_components/AnswerDetails.tsx
@@ -52,7 +52,9 @@ export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
           sx={{ minWidth: 280, flexGrow: 1 }}
         />
       ) : (
-        <Typography variant="h4">{title}</Typography>
+        <Typography variant="h4" component="h1">
+          {title}
+        </Typography>
       )}
       {isEditing ? (
         <Button

--- a/src/app/(authed)/admin/answer/[answerId]/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/page.tsx
@@ -6,8 +6,14 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 import ErrorModal from '@/app/_components/ErrorModal';
 import LoadingCircular from '@/app/_components/LoadingCircular';
 import Messages from '@/app/(authed)/_components/Messages';
-import AnswerDetails from './_components/AnswerDetails';
+import StandardAnswerDetails from '@/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails';
+import StandardAnswerMeta from '@/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerMeta';
 import Comments from './_components/Comments';
+import {
+  AdminAnswerLabelManagementButton,
+  AdminAnswerLabels,
+  AdminAnswerTitle,
+} from './_components/AnswerDetails';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import type { AnswerCommentType } from '@/lib/api-types';
 
@@ -82,10 +88,13 @@ const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
         alignItems: 'stretch',
       }}
     >
-      <AnswerDetails
-        answers={answers}
-        questions={form.questions}
-        labels={labels}
+      <AdminAnswerTitle answer={answers} />
+      <StandardAnswerMeta
+        answer={answers}
+        labelsSlot={
+          <AdminAnswerLabels labelOptions={labels} answer={answers} />
+        }
+        extraActions={<AdminAnswerLabelManagementButton />}
         messageAction={
           <Messages
             messages={messages}
@@ -96,6 +105,7 @@ const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
           />
         }
       />
+      <StandardAnswerDetails answer={answers} questions={form.questions} />
       <Comments
         comments={answers.comments as AnswerCommentType[]}
         formId={answers.form_id}


### PR DESCRIPTION
## 概要
- Admin 向け回答詳細ページが通常ユーザー向けと別実装になっていたため、通常側の `AnswerMeta` と `AnswerDetails` を基準に再利用する構成へ統一
- Admin 固有のタイトル編集、ラベル編集、ラベル管理導線は専用コンポーネントへ分離し、既存の管理機能は維持
- 通常側の回答本文表示も質問単位で重複なく描画するよう整理し、回答 0 件時の表示も共通化

## 確認事項
- `pnpm lint` を実行し、リポジトリ全体の ESLint が成功することを確認
- `pnpm type-check` を実行し、今回の共通化による型エラーがないことを確認
- `lefthook` の pre-commit で `lint` `type-check` `fmt` が通る状態でコミットできることを確認

## 補足
- Admin の `/admin/answer/[answerId]` ルートは維持し、内部実装だけを通常画面ベースの構成へ寄せています
- 画面の手動確認はこの環境では未実施です

🤖 Generated with Codex
