### PR TITLE
ci: CI を分割して E2E をマージブロックから外す

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,16 @@
+name: Setup
+description: Checkout 後に Node.js (mise) と pnpm をセットアップし、依存をインストールする共通ステップ
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: jdx/mise-action@v4
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,23 +9,43 @@ on:
       - main
 
 jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Lint
+        run: pnpm run lint
+      - name: Format
+        run: pnpm run fmt
+
+  type-check:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Type check
+        run: pnpm run type-check
+
+  unit-test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Unit test
+        run: pnpm run test:unit
+
   build:
+    name: Build
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_DEBUG_MODE: 'false'
     steps:
       - uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: jdx/mise-action@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          cache: true
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Cache Next.js build
         uses: actions/cache@v5
@@ -35,24 +55,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-nextjs-
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Format
-        run: pnpm run fmt
-
-      - name: Type check
-        run: pnpm run type-check
-
-      - name: Unit test
-        run: pnpm run test:unit
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: E2E test
-        run: pnpm run test:e2e
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,31 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E test
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_DEBUG_MODE: 'false'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E test
+        run: pnpm run test:e2e


### PR DESCRIPTION
## 概要
- 単一ジョブで lint / 型 / 単体 / E2E / build を直列実行していたため、Playwright のダウンロード失敗や E2E の所要時間が無関係な PR のマージを阻害していた問題に対処
- `lint` / `type-check` / `unit-test` / `build` を独立ジョブに分割して並列化し、共通セットアップを composite action (`.github/actions/setup`) に集約
- E2E は別 workflow (`.github/workflows/e2e.yaml`) に切り出し、`main` への push と `workflow_dispatch` のみで実行する構成へ変更（Playwright ブラウザは `~/.cache/ms-playwright` にキャッシュしてフレークを抑止）

## 確認事項
- pre-commit (type-check / fmt) と pre-push (unit-test) はローカルで成功
- 実際の workflow 動作はマージ前にこの PR の Checks タブで確認したい。`Lint & Format` / `Type check` / `Unit test` / `Build` の 4 ジョブが並列で走ること、E2E ジョブが PR では発火しないことをレビュー時に確認してほしい
- マージ後に **Branch Protection の required status checks を `build` 単独から `Lint & Format` / `Type check` / `Unit test` / `Build` の 4 つへ差し替える作業が必要**（この PR では行えないため別途対応）

## 補足
- E2E をリグレッション検証で任意に走らせたい場合は Actions タブから `E2E` workflow を `workflow_dispatch` で起動できる
- 将来 E2E が安定したら、`pull_request` トリガーを足して必須化に戻すことも容易

🤖 Generated with Claude Code