### PR TITLE
fix: NavBar のユーザーメニューの操作性とアクセシビリティを改善する

### DIFF
--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -12,6 +12,7 @@ import {
   ListItemText,
   ListItemIcon,
   ListItemAvatar,
+  ListItem,
   Divider,
   IconButton,
   Tooltip,
@@ -123,6 +124,7 @@ const NavBar = () => {
                   aria-expanded={anchorEl ? 'true' : undefined}
                   color="inherit"
                   sx={{ p: 0.5 }}
+                  disabled={isSigningOut}
                 >
                   <Avatar
                     alt="PlayerHead"
@@ -138,12 +140,22 @@ const NavBar = () => {
                 transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
               >
-                <MenuItem disabled sx={{ opacity: '1 !important' }}>
+                <ListItem sx={{ py: 1, px: 2 }}>
                   <ListItemAvatar>
                     <Avatar src={`https://mc-heads.net/avatar/${user.id}`} />
                   </ListItemAvatar>
-                  <ListItemText primary={user.name} />
-                </MenuItem>
+                  <ListItemText
+                    primary={user.name}
+                    slotProps={{
+                      primary: {
+                        variant: 'body2',
+                        noWrap: true,
+                        component: 'span',
+                        sx: { fontWeight: 'bold' },
+                      },
+                    }}
+                  />
+                </ListItem>
                 <Divider />
                 <MenuItem
                   component={NextLink}

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -10,20 +10,26 @@ import {
   Menu,
   MenuItem,
   ListItemText,
+  ListItemIcon,
+  ListItemAvatar,
+  Divider,
   IconButton,
   Tooltip,
 } from '@mui/material';
 import Image from 'next/image';
 import NextLink from 'next/link';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   useOptionalCurrentUser,
   useOptionalThemeMode,
 } from '@/app/(authed)/theme/themeMode';
 import { SigninButton } from './SigninButton';
-import { SignoutButton } from './SignoutButton';
+import { getMsalInstance } from './MsalProvider';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
+import PersonIcon from '@mui/icons-material/Person';
+import LogoutIcon from '@mui/icons-material/Logout';
 
 const ThemeModeToggle = () => {
   const themeMode = useOptionalThemeMode();
@@ -53,7 +59,36 @@ const ThemeModeToggle = () => {
 
 const NavBar = () => {
   const user = useOptionalCurrentUser();
-  const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
+  const router = useRouter();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const handleSignout = async () => {
+    if (isSigningOut) return;
+    setAnchorEl(null);
+    setIsSigningOut(true);
+
+    try {
+      await fetch('/api/logout', { method: 'DELETE' });
+
+      const msalInstance = getMsalInstance();
+      await msalInstance.initialize();
+      const [account] = msalInstance.getAllAccounts();
+
+      if (account) {
+        await msalInstance.logoutRedirect({
+          account,
+          postLogoutRedirectUri: '/',
+        });
+        return;
+      }
+
+      router.push('/');
+    } catch (e) {
+      console.error('Failed to sign out:', e);
+      setIsSigningOut(false);
+    }
+  };
 
   return (
     <Box>
@@ -79,32 +114,52 @@ const NavBar = () => {
           {!user ? (
             <SigninButton />
           ) : (
-            <Box>
-              <Avatar
-                alt="PlayerHead"
-                src={`https://mc-heads.net/avatar/${user.id}`}
-                sx={{ marginLeft: '20px' }}
-                onClick={(event: React.MouseEvent<HTMLElement>) =>
-                  setAnchorEl(event.currentTarget)
-                }
-              />
+            <Box sx={{ ml: '20px' }}>
+              <Tooltip title="メニューを開く">
+                <IconButton
+                  onClick={(event) => setAnchorEl(event.currentTarget)}
+                  aria-controls={anchorEl ? 'user-menu' : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={anchorEl ? 'true' : undefined}
+                  color="inherit"
+                  sx={{ p: 0.5 }}
+                >
+                  <Avatar
+                    alt="PlayerHead"
+                    src={`https://mc-heads.net/avatar/${user.id}`}
+                  />
+                </IconButton>
+              </Tooltip>
               <Menu
+                id="user-menu"
                 anchorEl={anchorEl}
-                open={anchorEl !== undefined}
-                onClose={() => setAnchorEl(undefined)}
+                open={Boolean(anchorEl)}
+                onClose={() => setAnchorEl(null)}
+                transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
               >
-                <MenuItem>
-                  <SignoutButton />
+                <MenuItem disabled sx={{ opacity: '1 !important' }}>
+                  <ListItemAvatar>
+                    <Avatar src={`https://mc-heads.net/avatar/${user.id}`} />
+                  </ListItemAvatar>
+                  <ListItemText primary={user.name} />
                 </MenuItem>
-                <MenuItem>
-                  <Link
-                    component={NextLink}
-                    href={`/users/${user.id}`}
-                    color="inherit"
-                    sx={{ textDecoration: 'none' }}
-                  >
-                    <ListItemText>ユーザー情報・設定変更</ListItemText>
-                  </Link>
+                <Divider />
+                <MenuItem
+                  component={NextLink}
+                  href={`/users/${user.id}`}
+                  onClick={() => setAnchorEl(null)}
+                >
+                  <ListItemIcon>
+                    <PersonIcon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText>ユーザー情報・設定変更</ListItemText>
+                </MenuItem>
+                <MenuItem onClick={handleSignout} disabled={isSigningOut}>
+                  <ListItemIcon>
+                    <LogoutIcon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText>サインアウト</ListItemText>
                 </MenuItem>
               </Menu>
             </Box>

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -58,8 +58,11 @@ const ThemeModeToggle = () => {
   );
 };
 
-const NavBar = () => {
-  const user = useOptionalCurrentUser();
+type UserMenuProps = {
+  user: NonNullable<ReturnType<typeof useOptionalCurrentUser>>;
+};
+
+const UserMenu = ({ user }: UserMenuProps) => {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -92,6 +95,73 @@ const NavBar = () => {
   };
 
   return (
+    <Box sx={{ ml: '20px' }}>
+      <Tooltip title="メニューを開く">
+        <IconButton
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+          aria-controls={anchorEl ? 'user-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={anchorEl ? 'true' : undefined}
+          color="inherit"
+          sx={{ p: 0.5 }}
+          disabled={isSigningOut}
+        >
+          <Avatar
+            alt="PlayerHead"
+            src={`https://mc-heads.net/avatar/${user.id}`}
+          />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id="user-menu"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+      >
+        <ListItem sx={{ py: 1, px: 2 }}>
+          <ListItemAvatar>
+            <Avatar src={`https://mc-heads.net/avatar/${user.id}`} />
+          </ListItemAvatar>
+          <ListItemText
+            primary={user.name}
+            slotProps={{
+              primary: {
+                variant: 'body2',
+                noWrap: true,
+                component: 'span',
+                sx: { fontWeight: 'bold' },
+              },
+            }}
+          />
+        </ListItem>
+        <Divider />
+        <MenuItem
+          component={NextLink}
+          href={`/users/${user.id}`}
+          onClick={() => setAnchorEl(null)}
+        >
+          <ListItemIcon>
+            <PersonIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>ユーザー情報・設定変更</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={handleSignout} disabled={isSigningOut}>
+          <ListItemIcon>
+            <LogoutIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>サインアウト</ListItemText>
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+};
+
+const NavBar = () => {
+  const user = useOptionalCurrentUser();
+
+  return (
     <Box>
       <AppBar position="fixed">
         <Toolbar>
@@ -112,70 +182,7 @@ const NavBar = () => {
             </Link>
           </Typography>
           <ThemeModeToggle />
-          {!user ? (
-            <SigninButton />
-          ) : (
-            <Box sx={{ ml: '20px' }}>
-              <Tooltip title="メニューを開く">
-                <IconButton
-                  onClick={(event) => setAnchorEl(event.currentTarget)}
-                  aria-controls={anchorEl ? 'user-menu' : undefined}
-                  aria-haspopup="true"
-                  aria-expanded={anchorEl ? 'true' : undefined}
-                  color="inherit"
-                  sx={{ p: 0.5 }}
-                  disabled={isSigningOut}
-                >
-                  <Avatar
-                    alt="PlayerHead"
-                    src={`https://mc-heads.net/avatar/${user.id}`}
-                  />
-                </IconButton>
-              </Tooltip>
-              <Menu
-                id="user-menu"
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={() => setAnchorEl(null)}
-                transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-              >
-                <ListItem sx={{ py: 1, px: 2 }}>
-                  <ListItemAvatar>
-                    <Avatar src={`https://mc-heads.net/avatar/${user.id}`} />
-                  </ListItemAvatar>
-                  <ListItemText
-                    primary={user.name}
-                    slotProps={{
-                      primary: {
-                        variant: 'body2',
-                        noWrap: true,
-                        component: 'span',
-                        sx: { fontWeight: 'bold' },
-                      },
-                    }}
-                  />
-                </ListItem>
-                <Divider />
-                <MenuItem
-                  component={NextLink}
-                  href={`/users/${user.id}`}
-                  onClick={() => setAnchorEl(null)}
-                >
-                  <ListItemIcon>
-                    <PersonIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText>ユーザー情報・設定変更</ListItemText>
-                </MenuItem>
-                <MenuItem onClick={handleSignout} disabled={isSigningOut}>
-                  <ListItemIcon>
-                    <LogoutIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText>サインアウト</ListItemText>
-                </MenuItem>
-              </Menu>
-            </Box>
-          )}
+          {!user ? <SigninButton /> : <UserMenu user={user} />}
         </Toolbar>
       </AppBar>
     </Box>


### PR DESCRIPTION
## 概要

- `Avatar` を直接クリックしていたためクリック領域が狭く、クリックする場所によっては反応しない問題を修正
- `IconButton` でラップすることで ripple・hover・focus リングを付与し、操作可能であることが視覚的に明確になった
- メニュー先頭にログインユーザー名のヘッダーを追加し、誰としてログインしているか確認できるようにした
- メニュー項目をアイコン付き・統一スタイルに変更し、順序を「ユーザー情報・設定変更 → サインアウト」に修正

## 確認事項

- `pnpm tsc --noEmit`・`pnpm lint` でエラーなしを確認済み
- pre-commit フック（lint / type-check / fmt）および pre-push フック（unit-test）がすべてパスしたことを確認済み
- 実ブラウザでの動作確認は未実施。レビュアーにはメニューの展開・各項目のクリック・サインアウト動作を重点的に確認いただきたい

## 補足

- `SignoutButton` コンポーネント自体は変更していない（他箇所での利用に影響しない）
- `aria-controls` / `aria-haspopup` / `aria-expanded` を `IconButton` に付与しアクセシビリティを改善済み

🤖 Generated with Claude Code