### PR TITLE
refactor: Admin NavBar と通常 NavBar を単一コンポーネントに統合する

### DIFF
--- a/src/app/(authed)/admin/_components/SearchField.tsx
+++ b/src/app/(authed)/admin/_components/SearchField.tsx
@@ -1,24 +1,10 @@
 'use client';
 
 import SearchIcon from '@mui/icons-material/Search';
-import {
-  Typography,
-  Box,
-  AppBar,
-  Toolbar,
-  Link,
-  Paper,
-  IconButton,
-  InputBase,
-  Avatar,
-} from '@mui/material';
+import { Paper, IconButton, InputBase } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import Image from 'next/image';
-import NextLink from 'next/link';
 import { useState } from 'react';
-import ThemeModeToggle from '@/app/(authed)/_components/ThemeModeToggle';
 import SearchResult from './SearchResult';
-import type { CurrentUser } from '@/lib/currentUser';
 
 const SearchField = () => {
   const [openSearchResultModal, setOpenSearchResultModal] = useState(false);
@@ -71,48 +57,4 @@ const SearchField = () => {
   );
 };
 
-const NavBar = ({ currentUser }: { currentUser: CurrentUser }) => {
-  return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar
-        position="fixed"
-        sx={{
-          zIndex: (theme) => theme.zIndex.drawer + 1,
-          backgroundColor: (theme) => theme.palette.secondary.main,
-        }}
-      >
-        <Toolbar>
-          <Image
-            src="/favicon.ico"
-            width={48}
-            height={48}
-            alt={'seichi-portal logo'}
-          />
-          <Typography
-            variant="h6"
-            component="div"
-            sx={{ flexGrow: 1, paddingLeft: '10px' }}
-          >
-            <Link
-              component={NextLink}
-              href="/admin"
-              color="inherit"
-              sx={{ textDecoration: 'none' }}
-            >
-              Seichi Portal Admin
-            </Link>
-          </Typography>
-          <SearchField />
-          <ThemeModeToggle />
-          <Avatar
-            alt="PlayerHead"
-            src={`https://mc-heads.net/avatar/${currentUser.id}`}
-            sx={{ marginLeft: '20px' }}
-          />
-        </Toolbar>
-      </AppBar>
-    </Box>
-  );
-};
-
-export default NavBar;
+export default SearchField;

--- a/src/app/(authed)/admin/layout.tsx
+++ b/src/app/(authed)/admin/layout.tsx
@@ -1,15 +1,16 @@
 import { requireAdmin } from '@/lib/server/session';
-import AdminNavigationBar from './_components/AdminNavigationBar';
+import NavBar from '@/app/_components/NavBar';
+import SearchField from './_components/SearchField';
 import DashboardMenu from './_components/DashboardMenu';
 import styles from '../../page.module.css';
 import type { ReactNode } from 'react';
 
 const RootLayout = async ({ children }: { children: ReactNode }) => {
-  const session = await requireAdmin();
+  await requireAdmin();
 
   return (
     <>
-      <AdminNavigationBar currentUser={session.user} />
+      <NavBar homeHref="/admin" searchSlot={<SearchField />} withDrawerZIndex />
       <main className={styles['main']}>
         <DashboardMenu />
         {children}

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import PersonIcon from '@mui/icons-material/Person';
+import LogoutIcon from '@mui/icons-material/Logout';
 import {
   Box,
   AppBar,
@@ -19,44 +21,12 @@ import {
 } from '@mui/material';
 import Image from 'next/image';
 import NextLink from 'next/link';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  useOptionalCurrentUser,
-  useOptionalThemeMode,
-} from '@/app/(authed)/theme/themeMode';
+import { useOptionalCurrentUser } from '@/app/(authed)/theme/themeMode';
 import { SigninButton } from './SigninButton';
 import { getMsalInstance } from './MsalProvider';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
-import LightModeIcon from '@mui/icons-material/LightMode';
-import PersonIcon from '@mui/icons-material/Person';
-import LogoutIcon from '@mui/icons-material/Logout';
-
-const ThemeModeToggle = () => {
-  const themeMode = useOptionalThemeMode();
-
-  if (!themeMode) {
-    return null;
-  }
-
-  const { mode, toggleMode } = themeMode;
-
-  return (
-    <Tooltip
-      title={
-        mode === 'light' ? 'ダークテーマに切り替え' : 'ライトテーマに切り替え'
-      }
-    >
-      <IconButton
-        color="inherit"
-        onClick={toggleMode}
-        aria-label="toggle theme"
-      >
-        {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
-      </IconButton>
-    </Tooltip>
-  );
-};
+import ThemeModeToggle from '@/app/(authed)/_components/ThemeModeToggle';
 
 type UserMenuProps = {
   user: NonNullable<ReturnType<typeof useOptionalCurrentUser>>;
@@ -158,12 +128,29 @@ const UserMenu = ({ user }: UserMenuProps) => {
   );
 };
 
-const NavBar = () => {
+type NavBarProps = {
+  homeHref?: string;
+  searchSlot?: ReactNode;
+  withDrawerZIndex?: boolean;
+};
+
+const NavBar = ({
+  homeHref = '/',
+  searchSlot,
+  withDrawerZIndex = false,
+}: NavBarProps) => {
   const user = useOptionalCurrentUser();
 
   return (
     <Box>
-      <AppBar position="fixed">
+      <AppBar
+        position="fixed"
+        sx={
+          withDrawerZIndex
+            ? { zIndex: (theme) => theme.zIndex.drawer + 1 }
+            : undefined
+        }
+      >
         <Toolbar>
           <Image
             src="/favicon.ico"
@@ -174,13 +161,14 @@ const NavBar = () => {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             <Link
               component={NextLink}
-              href="/"
+              href={homeHref}
               color="inherit"
               sx={{ textDecoration: 'none', pl: '10px' }}
             >
               Seichi Portal
             </Link>
           </Typography>
+          {searchSlot}
           <ThemeModeToggle />
           {!user ? <SigninButton /> : <UserMenu user={user} />}
         </Toolbar>


### PR DESCRIPTION
## 概要

- Admin 用 `AdminNavigationBar` と通常ユーザー向け `NavBar` が独立していたため、AppBar の背景色（primary vs secondary）とタイトル（"Seichi Portal" vs "Seichi Portal Admin"）に差異が生じていた
- `NavBar` を `homeHref` / `searchSlot` / `withDrawerZIndex` の 3 プロップで差異を吸収できる単一コンポーネントに統合し、Admin 専用の `AdminNavigationBar` を削除
- 検索フィールドは `SearchField.tsx` として独立ファイルに切り出し、Admin レイアウトから `searchSlot` 経由でインジェクションする形に変更。Admin 専用機能のまま維持
- Admin ページでもユーザーメニュー（アバタークリックでドロップダウン表示）を常に表示するよう統一

## 確認事項

- `pnpm build` でビルドエラーなし・TypeScript 型チェックパスを確認
- pre-commit フック（lint / type-check / format）および pre-push フック（unit-test）がすべてパスしたことを確認
- ローカルでの UI 動作確認は未実施（開発サーバー環境が利用できないため）。レビュー時に Admin ページと通常ページで AppBar の色・タイトル・検索フィールドの表示を確認いただけると助かります

## 補足

Closes #680

🤖 Generated with Claude Code