### PR TITLE
feat: 管理者ユーザーに Admin/通常ページ切り替えリンクを追加

### DIFF
--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -2,6 +2,8 @@
 
 import PersonIcon from '@mui/icons-material/Person';
 import LogoutIcon from '@mui/icons-material/Logout';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import HomeIcon from '@mui/icons-material/Home';
 import {
   Box,
   AppBar,
@@ -30,9 +32,10 @@ import ThemeModeToggle from '@/app/(authed)/_components/ThemeModeToggle';
 
 type UserMenuProps = {
   user: NonNullable<ReturnType<typeof useOptionalCurrentUser>>;
+  isAdminPage: boolean;
 };
 
-const UserMenu = ({ user }: UserMenuProps) => {
+const UserMenu = ({ user, isAdminPage }: UserMenuProps) => {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -117,6 +120,24 @@ const UserMenu = ({ user }: UserMenuProps) => {
           </ListItemIcon>
           <ListItemText>ユーザー情報・設定変更</ListItemText>
         </MenuItem>
+        {user.role === 'ADMINISTRATOR' && (
+          <MenuItem
+            component={NextLink}
+            href={isAdminPage ? '/' : '/admin'}
+            onClick={() => setAnchorEl(null)}
+          >
+            <ListItemIcon>
+              {isAdminPage ? (
+                <HomeIcon fontSize="small" />
+              ) : (
+                <AdminPanelSettingsIcon fontSize="small" />
+              )}
+            </ListItemIcon>
+            <ListItemText>
+              {isAdminPage ? '通常ページへ' : '管理者ページへ'}
+            </ListItemText>
+          </MenuItem>
+        )}
         <MenuItem onClick={handleSignout} disabled={isSigningOut}>
           <ListItemIcon>
             <LogoutIcon fontSize="small" />
@@ -170,7 +191,11 @@ const NavBar = ({
           </Typography>
           {searchSlot}
           <ThemeModeToggle />
-          {!user ? <SigninButton /> : <UserMenu user={user} />}
+          {!user ? (
+            <SigninButton />
+          ) : (
+            <UserMenu user={user} isAdminPage={homeHref === '/admin'} />
+          )}
         </Toolbar>
       </AppBar>
     </Box>


### PR DESCRIPTION
## 概要

- URL 直打ち以外に Admin ページと通常ページを行き来する手段がなかったため、UserMenu ドロップダウンに遷移リンクを追加した
- `role === 'ADMINISTRATOR'` のユーザーにのみ表示され、現在地（admin/通常）に応じてリンク先・ラベル・アイコンを切り替える
- NavBar はすでに `homeHref` prop で admin/通常を区別しているため、それを `isAdminPage` として `UserMenu` に渡すだけで対応できた（既存構造の変更は最小限）

## 確認事項

- `pnpm tsc --noEmit`・`pnpm eslint`・pre-commit フック（lint / type-check / fmt）・pre-push フック（unit-test）がすべてパスすることを確認
- 通常ユーザー（role ≠ ADMINISTRATOR）にはメニュー項目が表示されないことをコードレベルで確認（`user.role === 'ADMINISTRATOR'` の条件分岐）
- 実環境での表示確認は未実施（ローカルで MSAL 認証を通す環境がないため）。レビュアーに動作確認をお願いしたい

## 補足

- 管理者ページ側から通常ページへ戻るリンクの遷移先は `/`（ホーム）としている。別のページが適切であればご指摘ください

🤖 Generated with Claude Code