### PR TITLE
fix: Admin サイドバーのクリック可能エリアを行全体に拡張する

### DIFF
--- a/src/app/(authed)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(authed)/admin/_components/DashboardMenu.tsx
@@ -7,7 +7,6 @@ import {
   MenuItem,
   ListItemIcon,
   Divider,
-  Link,
 } from '@mui/material';
 import Drawer from '@mui/material/Drawer';
 import NextLink from 'next/link';
@@ -50,7 +49,12 @@ const DashboardMenu = () => {
           },
         ].map((value, index) => {
           return (
-            <MenuItem key={index} sx={{ color: 'text.primary' }}>
+            <MenuItem
+              key={index}
+              component={NextLink}
+              href={value.url}
+              sx={{ color: 'text.primary', textDecoration: 'none' }}
+            >
               <ListItemIcon
                 sx={{
                   color: 'text.secondary',
@@ -59,14 +63,7 @@ const DashboardMenu = () => {
               >
                 <Star />
               </ListItemIcon>
-              <Link
-                component={NextLink}
-                href={value.url}
-                color="inherit"
-                sx={{ textDecoration: 'none' }}
-              >
-                {value.label}
-              </Link>
+              {value.label}
             </MenuItem>
           );
         })}

--- a/src/app/(authed)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(authed)/admin/_components/DashboardMenu.tsx
@@ -47,10 +47,10 @@ const DashboardMenu = () => {
             label: 'Users',
             url: '/admin/users',
           },
-        ].map((value, index) => {
+        ].map((value) => {
           return (
             <MenuItem
-              key={index}
+              key={value.url}
               component={NextLink}
               href={value.url}
               sx={{ color: 'text.primary', textDecoration: 'none' }}


### PR DESCRIPTION
## 概要

- Admin サイドバーの各メニュー項目で、テキスト部分のみがクリック可能だった問題を修正
- `MenuItem` の中に `<Link>` をネストする構造から、`MenuItem` 自体に `component={NextLink}` を設定する構造へ変更
- アイコン・テキスト・行の余白を含む行全体がクリッカブルになった

## 確認事項

- `pnpm tsc --noEmit` でエラーなし
- pre-commit フック（lint / type-check / fmt）・pre-push フック（unit-test）がすべてパス
- 実際の動作確認は UI 上でアイコン・余白クリックによるページ遷移をレビュー時にご確認ください

🤖 Generated with Claude Code