### PR TITLE
fix: ライトモードの Admin SearchField の視認性を改善する

### DIFF
--- a/src/app/(authed)/admin/_components/SearchField.tsx
+++ b/src/app/(authed)/admin/_components/SearchField.tsx
@@ -19,13 +19,14 @@ const SearchField = () => {
         alignItems: 'center',
         width: 400,
         backgroundColor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? alpha(theme.palette.common.white, 0.15)
-            : alpha(theme.palette.common.white, 0.85),
+          alpha(
+            theme.palette.common.white,
+            theme.palette.mode === 'dark' ? 0.15 : 0.85
+          ),
         border: (theme) =>
           theme.palette.mode === 'dark'
             ? `1px solid ${alpha(theme.palette.common.white, 0.2)}`
-            : `1px solid ${alpha(theme.palette.common.white, 0.4)}`,
+            : `1px solid ${alpha(theme.palette.text.primary, 0.2)}`,
       }}
     >
       <IconButton

--- a/src/app/(authed)/admin/_components/SearchField.tsx
+++ b/src/app/(authed)/admin/_components/SearchField.tsx
@@ -19,12 +19,13 @@ const SearchField = () => {
         alignItems: 'center',
         width: 400,
         backgroundColor: (theme) =>
-          alpha(
-            theme.palette.mode === 'dark'
-              ? theme.palette.common.white
-              : theme.palette.common.black,
-            theme.palette.mode === 'dark' ? 0.15 : 0.06
-          ),
+          theme.palette.mode === 'dark'
+            ? alpha(theme.palette.common.white, 0.15)
+            : alpha(theme.palette.common.white, 0.85),
+        border: (theme) =>
+          theme.palette.mode === 'dark'
+            ? `1px solid ${alpha(theme.palette.common.white, 0.2)}`
+            : `1px solid ${alpha(theme.palette.common.white, 0.4)}`,
       }}
     >
       <IconButton


### PR DESCRIPTION
## 概要

- Admin ページの NavBar（AppBar）はライトモードで Primary 色（`#1976D2` 青）を背景に使う
- `SearchField` の背景が `alpha(black, 0.06)` だったため、青い AppBar 上でほぼ同色になり Search Bar が見えにくかった
- ライトモードの背景を `alpha(white, 0.85)` に変更し、AppBar に対して明確なコントラストを確保
- 両モード共通で `border` を追加し、色差が小さい環境でも輪郭を補助

## 確認事項

- ESLint・TypeScript 型チェック・Prettier・ユニットテストすべてパスを確認済み（pre-commit / pre-push フック通過）
- ライトモードでの実見：青い AppBar 上に薄い水色がかった白い Search Bar が明確に識別できることを期待した変更

## 補足

- ダークモードの背景値（`alpha(white, 0.15)`）は変更なし、border のみ追加

🤖 Generated with Claude Code