### PR TITLE
refactor: ConversationEntry の責務を分離する

### DIFF
--- a/src/app/(authed)/_components/ConversationEntry.tsx
+++ b/src/app/(authed)/_components/ConversationEntry.tsx
@@ -1,30 +1,16 @@
 'use client';
 
-import { MoreVert } from '@mui/icons-material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import {
-  Avatar,
-  Box,
-  Chip,
-  IconButton,
-  Menu,
-  MenuItem,
-  Paper,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { Box, Typography } from '@mui/material';
 import type { MouseEvent } from 'react';
 import { useState } from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { formatString } from '@/generic/DateFormatter';
 import type {
   ConversationActionResult,
   ConversationCapabilities,
   ConversationEntryViewModel,
 } from './conversationTypes';
+import ConversationEntryBody from './ConversationEntryBody';
+import ConversationEntryEditor from './ConversationEntryEditor';
+import ConversationEntryHeader from './ConversationEntryHeader';
 
 type Props = {
   entry: ConversationEntryViewModel;
@@ -52,11 +38,19 @@ const ConversationEntry = ({
   const [operationResultMessage, setOperationResultMessage] =
     useState<string>();
 
-  const isAdmin = entry.authorRole === 'ADMINISTRATOR';
-  const showMenuTrigger =
-    capabilities.actionTrigger === 'menu' && (entry.canEdit || entry.canDelete);
-  const showDeleteTrigger =
-    capabilities.actionTrigger === 'icon' && entry.canDelete;
+  const handleOpenMenu = (event: MouseEvent<HTMLElement>) =>
+    setAnchorEl(event.currentTarget);
+  const handleCloseMenu = () => setAnchorEl(undefined);
+  const handleStartEditing = () => {
+    setOperationResultMessage(undefined);
+    setIsEditing(true);
+    setAnchorEl(undefined);
+  };
+  const handleCancelEditing = () => {
+    setDraftBody(entry.body);
+    setOperationResultMessage(undefined);
+    setIsEditing(false);
+  };
 
   const handleDelete = async () => {
     if (!onDelete) {
@@ -71,7 +65,7 @@ const ConversationEntry = ({
         '不明なエラーが発生しました。もう一度お試しください。'
       );
     }
-    setAnchorEl(undefined);
+    handleCloseMenu();
   };
 
   const handleUpdate = async () => {
@@ -98,140 +92,26 @@ const ConversationEntry = ({
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-        <Avatar
-          alt="PlayerHead"
-          src={`https://mc-heads.net/avatar/${entry.authorName}`}
-          sx={{
-            width: 36,
-            height: 36,
-            mt: 0.5,
-            flexShrink: 0,
-            border: isAdmin ? 2 : 0,
-            borderColor: 'success.main',
-          }}
-        />
-        <Stack sx={{ flex: 1 }} spacing={0.25}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-              {entry.authorName}
-            </Typography>
-            {isAdmin && (
-              <Chip
-                avatar={
-                  <Avatar
-                    src="/server-icon.png"
-                    sx={{ width: 18, height: 18 }}
-                  />
-                }
-                label={capabilities.adminLabel}
-                color="success"
-                size="small"
-                sx={{ height: 20 }}
-              />
-            )}
-            {showDeleteTrigger && (
-              <IconButton
-                size="small"
-                color="error"
-                aria-label="delete"
-                sx={{ p: 0.5, ml: 'auto' }}
-                onClick={handleDelete}
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            )}
-          </Stack>
-          <Typography variant="caption" color="text.secondary">
-            {formatString(entry.timestamp)}
-          </Typography>
-        </Stack>
-        {showMenuTrigger && (
-          <>
-            <IconButton
-              color="primary"
-              aria-label="その他の操作"
-              onClick={(event: MouseEvent<HTMLElement>) =>
-                setAnchorEl(event.currentTarget)
-              }
-            >
-              <MoreVert />
-            </IconButton>
-            <Menu
-              anchorEl={anchorEl}
-              open={anchorEl !== undefined}
-              onClose={() => setAnchorEl(undefined)}
-            >
-              {entry.canEdit && (
-                <MenuItem
-                  onClick={() => {
-                    setOperationResultMessage(undefined);
-                    setIsEditing(true);
-                    setAnchorEl(undefined);
-                  }}
-                >
-                  編集
-                </MenuItem>
-              )}
-              {entry.canDelete && (
-                <MenuItem onClick={handleDelete}>削除</MenuItem>
-              )}
-            </Menu>
-          </>
-        )}
-      </Stack>
+      <ConversationEntryHeader
+        entry={entry}
+        capabilities={capabilities}
+        anchorEl={anchorEl}
+        onOpenMenu={handleOpenMenu}
+        onCloseMenu={handleCloseMenu}
+        onStartEditing={handleStartEditing}
+        onDelete={handleDelete}
+      />
 
       <Box sx={{ pl: '44px', mt: 0.5 }}>
         {isEditing ? (
-          <TextField
+          <ConversationEntryEditor
             defaultValue={entry.body}
-            helperText="編集を確定するには Enter キー、キャンセルするには Esc キーを入力してください。"
-            multiline
-            fullWidth
-            onChange={(event) => setDraftBody(event.target.value)}
-            onKeyDown={async (event) => {
-              if (
-                event.key === 'Enter' &&
-                !event.shiftKey &&
-                !event.nativeEvent.isComposing
-              ) {
-                event.preventDefault();
-                await handleUpdate();
-              } else if (event.key === 'Escape') {
-                setDraftBody(entry.body);
-                setOperationResultMessage(undefined);
-                setIsEditing(false);
-              }
-            }}
+            onChange={setDraftBody}
+            onSubmit={handleUpdate}
+            onCancel={handleCancelEditing}
           />
         ) : (
-          <Paper
-            variant={entry.renderMode === 'plain' ? 'outlined' : undefined}
-            sx={(theme) => ({
-              p: entry.renderMode === 'plain' ? 1.5 : 0,
-              backgroundColor:
-                entry.renderMode === 'plain'
-                  ? isAdmin
-                    ? alpha(theme.palette.success.main, 0.08)
-                    : theme.palette.grey[50]
-                  : 'transparent',
-              borderRadius: entry.renderMode === 'plain' ? 2 : 0,
-              boxShadow: 'none',
-            })}
-          >
-            {entry.renderMode === 'markdown' ? (
-              <Box sx={{ whiteSpace: 'pre-wrap' }}>
-                <Markdown remarkPlugins={[remarkGfm]}>{entry.body}</Markdown>
-              </Box>
-            ) : (
-              <Typography
-                variant="body2"
-                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-              >
-                {entry.body}
-              </Typography>
-            )}
-          </Paper>
+          <ConversationEntryBody entry={entry} />
         )}
         {operationResultMessage && (
           <Typography

--- a/src/app/(authed)/_components/ConversationEntryBody.tsx
+++ b/src/app/(authed)/_components/ConversationEntryBody.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Box, Paper, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { ConversationEntryViewModel } from './conversationTypes';
+
+type Props = {
+  entry: ConversationEntryViewModel;
+};
+
+const ConversationEntryBody = ({ entry }: Props) => {
+  const isAdmin = entry.authorRole === 'ADMINISTRATOR';
+
+  return (
+    <Paper
+      variant={entry.renderMode === 'plain' ? 'outlined' : undefined}
+      sx={(theme) => ({
+        p: entry.renderMode === 'plain' ? 1.5 : 0,
+        backgroundColor:
+          entry.renderMode === 'plain'
+            ? isAdmin
+              ? alpha(theme.palette.success.main, 0.08)
+              : theme.palette.grey[50]
+            : 'transparent',
+        borderRadius: entry.renderMode === 'plain' ? 2 : 0,
+        boxShadow: 'none',
+      })}
+    >
+      {entry.renderMode === 'markdown' ? (
+        <Box sx={{ whiteSpace: 'pre-wrap' }}>
+          <Markdown remarkPlugins={[remarkGfm]}>{entry.body}</Markdown>
+        </Box>
+      ) : (
+        <Typography
+          variant="body2"
+          sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+        >
+          {entry.body}
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default ConversationEntryBody;

--- a/src/app/(authed)/_components/ConversationEntryEditor.tsx
+++ b/src/app/(authed)/_components/ConversationEntryEditor.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { TextField } from '@mui/material';
+
+type Props = {
+  defaultValue: string;
+  onChange: (value: string) => void;
+  onSubmit: () => Promise<void>;
+  onCancel: () => void;
+};
+
+const ConversationEntryEditor = ({
+  defaultValue,
+  onChange,
+  onSubmit,
+  onCancel,
+}: Props) => (
+  <TextField
+    defaultValue={defaultValue}
+    helperText="編集を確定するには Enter キー、キャンセルするには Esc キーを入力してください。"
+    multiline
+    fullWidth
+    onChange={(event) => onChange(event.target.value)}
+    onKeyDown={async (event) => {
+      if (
+        event.key === 'Enter' &&
+        !event.shiftKey &&
+        !event.nativeEvent.isComposing
+      ) {
+        event.preventDefault();
+        await onSubmit();
+      } else if (event.key === 'Escape') {
+        onCancel();
+      }
+    }}
+  />
+);
+
+export default ConversationEntryEditor;

--- a/src/app/(authed)/_components/ConversationEntryHeader.tsx
+++ b/src/app/(authed)/_components/ConversationEntryHeader.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { MoreVert } from '@mui/icons-material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  Avatar,
+  Chip,
+  IconButton,
+  Menu,
+  MenuItem,
+  Stack,
+  Typography,
+} from '@mui/material';
+import type { MouseEvent } from 'react';
+import { formatString } from '@/generic/DateFormatter';
+import type {
+  ConversationCapabilities,
+  ConversationEntryViewModel,
+} from './conversationTypes';
+
+type Props = {
+  entry: ConversationEntryViewModel;
+  capabilities: ConversationCapabilities;
+  anchorEl: HTMLElement | undefined;
+  onOpenMenu: (event: MouseEvent<HTMLElement>) => void;
+  onCloseMenu: () => void;
+  onStartEditing: () => void;
+  onDelete: () => Promise<void>;
+};
+
+const ConversationEntryHeader = ({
+  entry,
+  capabilities,
+  anchorEl,
+  onOpenMenu,
+  onCloseMenu,
+  onStartEditing,
+  onDelete,
+}: Props) => {
+  const isAdmin = entry.authorRole === 'ADMINISTRATOR';
+  const showMenuTrigger =
+    capabilities.actionTrigger === 'menu' && (entry.canEdit || entry.canDelete);
+  const showDeleteTrigger =
+    capabilities.actionTrigger === 'icon' && entry.canDelete;
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+      <Avatar
+        alt="PlayerHead"
+        src={`https://mc-heads.net/avatar/${entry.authorName}`}
+        sx={{
+          width: 36,
+          height: 36,
+          mt: 0.5,
+          flexShrink: 0,
+          border: isAdmin ? 2 : 0,
+          borderColor: 'success.main',
+        }}
+      />
+      <Stack sx={{ flex: 1 }} spacing={0.25}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <Typography
+            variant="subtitle2"
+            component="span"
+            sx={{ fontWeight: 600 }}
+          >
+            {entry.authorName}
+          </Typography>
+          {isAdmin && (
+            <Chip
+              avatar={
+                <Avatar src="/server-icon.png" sx={{ width: 18, height: 18 }} />
+              }
+              label={capabilities.adminLabel}
+              color="success"
+              size="small"
+              sx={{ height: 20 }}
+            />
+          )}
+          {showDeleteTrigger && (
+            <IconButton
+              size="small"
+              color="error"
+              aria-label="delete"
+              sx={{ p: 0.5, ml: 'auto' }}
+              onClick={() => void onDelete()}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          )}
+        </Stack>
+        <Typography variant="caption" component="span" color="text.secondary">
+          {formatString(entry.timestamp)}
+        </Typography>
+      </Stack>
+      {showMenuTrigger && (
+        <>
+          <IconButton
+            color="primary"
+            aria-label="その他の操作"
+            onClick={onOpenMenu}
+          >
+            <MoreVert />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={anchorEl !== undefined}
+            onClose={onCloseMenu}
+          >
+            {entry.canEdit && (
+              <MenuItem onClick={onStartEditing}>編集</MenuItem>
+            )}
+            {entry.canDelete && (
+              <MenuItem onClick={() => void onDelete()}>削除</MenuItem>
+            )}
+          </Menu>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default ConversationEntryHeader;


### PR DESCRIPTION
## 概要
- `ConversationEntry` に集まっていたヘッダー表示、本文描画、編集 UI の責務を分割し、表示ロジックを読みやすく整理
- `ConversationEntryHeader` `ConversationEntryBody` `ConversationEntryEditor` を追加し、親コンポーネントは状態管理と更新・削除ハンドラに責務を寄せた
- `main` の現行挙動を維持し、エラー表示や編集開始・キャンセル時のメッセージ制御は既存仕様のまま残した

## 確認事項
- 変更対象 4 ファイルに対して ESLint を実行し、静的解析エラーがないことを確認
- `pnpm type-check` を実行し、型エラーなく通過することを確認
- Prettier チェックと pre-commit hook が通過し、整形崩れがないことを確認

🤖 Generated with Codex
