### PR TITLE
fix: AppBar の検索バーと右側アクションの間隔を調整する

### DIFF
--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -68,7 +68,7 @@ const UserMenu = ({ user, isAdminPage }: UserMenuProps) => {
   };
 
   return (
-    <Box sx={{ ml: '20px' }}>
+    <Box sx={{ ml: 2.5 }}>
       <Tooltip title="メニューを開く">
         <IconButton
           onClick={(event) => setAnchorEl(event.currentTarget)}
@@ -190,12 +190,20 @@ const NavBar = ({
             </Link>
           </Typography>
           {searchSlot}
-          <ThemeModeToggle />
-          {!user ? (
-            <SigninButton />
-          ) : (
-            <UserMenu user={user} isAdminPage={homeHref === '/admin'} />
-          )}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              ml: searchSlot ? 3 : 0,
+            }}
+          >
+            <ThemeModeToggle />
+            {!user ? (
+              <SigninButton />
+            ) : (
+              <UserMenu user={user} isAdminPage={homeHref === '/admin'} />
+            )}
+          </Box>
         </Toolbar>
       </AppBar>
     </Box>


### PR DESCRIPTION
## 概要
- 管理画面の AppBar で検索バーと右側アクション群の距離が詰まって見えていたため、テーマ切り替えとユーザーメニューをラップして検索スロットとの間に余白を追加
- ユーザーアイコン側の左余白も固定 px 値から MUI spacing ベースに揃え、AppBar 内の間隔指定を統一
- 影響範囲は `src/app/_components/NavBar.tsx` のみ

## 確認事項
- pre-commit フック経由で `eslint -- src/app/_components/NavBar.tsx` が成功し、この変更で lint エラーが出ていないことを確認
- pre-commit フック経由で `tsc --noEmit` が成功し、型エラーが追加されていないことを確認
- pre-commit フック経由で `prettier --check './**/*.{ts,tsx,css}'` が成功し、整形ルールに適合していることを確認
- pre-push フック経由で `vitest run` が成功し、unit test 8 件が通過したことを確認
- 実機の画面確認は未実施のため、余白量が意図通りかをレビュー時に確認してほしい

## 補足
- 検索スロットが存在する場合のみ右側アクション群へ `ml` を付与する実装にしており、検索バーを持たない NavBar の並びには影響しない

🤖 Generated with Codex