### PR TITLE
OpenAPI 生成元を backend 管理スキーマに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@
 
 ## API定義
 
-Seichi Portalではフロントエンドとバックエンド間の通信に REST APIを使っています。詳細については、[seichi-portal-backend](https://github.com/GiganticMinecraft/seichi-portal-backend)および[seichi-portal-api-schema](https://github.com/GiganticMinecraft/seichi-portal-api-schema)を参照してください。
+Seichi Portalではフロントエンドとバックエンド間の通信に REST APIを使っています。API型定義は、[seichi-portal-backend](https://github.com/GiganticMinecraft/seichi-portal-backend) の `docs/openapi.json` から生成します。
+
+```sh
+pnpm codegen
+```
+
+通常は backend の `main` ブランチで管理される OpenAPI スキーマを使います。ローカル backend や別ブランチのスキーマで一時的に生成したい場合は、`OPENAPI_URL` を指定してください。
+
+```sh
+OPENAPI_URL=http://localhost:9000/api-docs/openapi.json pnpm codegen
+```
 
 ## 開発環境とミドルウェア
 

--- a/scripts/codegen.ts
+++ b/scripts/codegen.ts
@@ -1,13 +1,19 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 
-const OPENAPI_URL = 'http://localhost:9000/api-docs/openapi.json';
+const DEFAULT_OPENAPI_URL =
+  'https://raw.githubusercontent.com/GiganticMinecraft/seichi-portal-backend/main/docs/openapi.json';
+const OPENAPI_URL = process.env['OPENAPI_URL'] ?? DEFAULT_OPENAPI_URL;
 const OUT_DIR = 'src/generated';
+const OUT_FILE = `${OUT_DIR}/api-types.ts`;
 
 fs.mkdirSync(OUT_DIR, { recursive: true });
 
 // OpenAPI から TypeScript 型定義を生成
-execSync(`pnpm openapi-typescript ${OPENAPI_URL} -o ${OUT_DIR}/api-types.ts`, {
+console.log(`Generating API types from ${OPENAPI_URL}`);
+console.log(`Output: ${OUT_FILE}`);
+
+execFileSync('pnpm', ['openapi-typescript', OPENAPI_URL, '-o', OUT_FILE], {
   stdio: 'inherit',
 });
 

--- a/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -1,13 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import type { paths } from '@/generated/api-types';
 import { errorResponseSchema } from '@/lib/api/errors';
 import { proxyClient } from '@/lib/proxyClient';
 import type { AnswerFormInput } from './answerFormTypes';
+import type { ApiPaths } from '@/lib/api/types';
 
 type AnswerCreateBody =
-  paths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
 
 type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'UNKNOWN';
 

--- a/src/app/(authed)/admin/forms/_hooks/useUpdateFormSubmission.ts
+++ b/src/app/(authed)/admin/forms/_hooks/useUpdateFormSubmission.ts
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useFormEditActions } from '@/hooks/useFormEditActions';
-import { useFormLabelActions } from '@/hooks/useFormLabelActions';
 import { toFormUpdateBody } from '../_lib/formRequestBuilders';
 import type { FormEditorValues } from '../_schema/formEditorSchema';
 
@@ -10,7 +9,6 @@ export const useUpdateFormSubmission = (formId: string) => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const { updateForm } = useFormEditActions(formId);
-  const { updateLabels } = useFormLabelActions(formId);
 
   const submit = async (
     data: FormEditorValues
@@ -21,15 +19,6 @@ export const useUpdateFormSubmission = (formId: string) => {
     const updateFormResult = await updateForm(toFormUpdateBody(data, true));
     if (!updateFormResult.ok) {
       const errorMessage = 'フォームの更新に失敗しました。';
-      setSubmitError(errorMessage);
-      return { ok: false, errorMessage };
-    }
-
-    const updateLabelsResult = await updateLabels(
-      data.labels.map((label) => label.id)
-    );
-    if (!updateLabelsResult.ok) {
-      const errorMessage = 'フォームラベルの更新に失敗しました。';
       setSubmitError(errorMessage);
       return { ok: false, errorMessage };
     }

--- a/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
@@ -2,8 +2,7 @@ import {
   fromStringToJSTDateTime,
   toApiDateTime,
 } from '@/generic/DateFormatter';
-import type { components, paths } from '@/generated/api-types';
-import type { GetFormResponse } from '@/lib/api/types';
+import type { ApiComponents, ApiPaths, GetFormResponse } from '@/lib/api/types';
 import type {
   FormEditorQuestion,
   FormEditorValues,
@@ -11,11 +10,9 @@ import type {
 } from '../_schema/formEditorSchema';
 
 type CreateFormBody =
-  paths['/forms']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/forms']['post']['requestBody']['content']['application/json'];
 type FormUpdateBody =
-  paths['/forms/{id}']['put']['requestBody']['content']['application/json'];
-type FormLabelsUpdateBody =
-  paths['/forms/{form_id}/labels']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/forms/{id}']['put']['requestBody']['content']['application/json'];
 
 const toVisibility = (value: string | null | undefined): FormVisibility =>
   value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC';
@@ -39,8 +36,8 @@ const toEditorQuestion = (
 const toApiQuestion = (
   question: FormEditorQuestion,
   index: number
-): components['schemas']['QuestionSchema'] => {
-  const base: components['schemas']['QuestionDefinitionSchema'] = {
+): ApiComponents['schemas']['QuestionSchema'] => {
+  const base: ApiComponents['schemas']['QuestionDefinitionSchema'] = {
     title: question.title,
     description: question.description,
     is_required: question.is_required,
@@ -112,6 +109,7 @@ export const toFormUpdateBody = (
   const body: FormUpdateBody = {
     title: data.title,
     description: data.description,
+    labels: data.labels.map((label) => label.id),
     settings: {
       visibility: data.settings.visibility,
       webhook_url: data.settings.webhook_url,
@@ -125,7 +123,10 @@ export const toFormUpdateBody = (
               start_at: toApiDateTime(startAt),
               end_at: toApiDateTime(endAt),
             }
-          : null,
+          : {
+              start_at: null,
+              end_at: null,
+            },
         visibility: data.settings.answer_visibility,
       },
     },
@@ -139,9 +140,3 @@ export const toFormUpdateBody = (
 
   return body;
 };
-
-export const toFormLabelsUpdateBody = (
-  labels: FormEditorValues['labels']
-): FormLabelsUpdateBody => ({
-  labels: labels.map((label) => label.id),
-});

--- a/src/app/(authed)/admin/forms/_lib/formRequestBuilders.ts
+++ b/src/app/(authed)/admin/forms/_lib/formRequestBuilders.ts
@@ -1,6 +1,5 @@
 export {
   fromFormResponseToEditorValues,
   toCreateFormBody,
-  toFormLabelsUpdateBody,
   toFormUpdateBody,
 } from './formEditorMappers';

--- a/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { proxyClient } from '@/lib/proxyClient';
 import {
   toCreateFormBody,
-  toFormLabelsUpdateBody,
   toFormUpdateBody,
 } from '../../_lib/formRequestBuilders';
 import type { FormEditorValues } from '../../_schema/formEditorSchema';
@@ -38,18 +37,6 @@ export const useCreateForm = () => {
         setSubmitError({
           message: 'フォームのメタデータの設定に失敗しました。',
         });
-        return;
-      }
-
-      const { response: putLabelsResponse } = await proxyClient.PUT(
-        '/forms/{form_id}/labels',
-        {
-          params: { path: { form_id: createdFormId } },
-          body: toFormLabelsUpdateBody(data.labels),
-        }
-      );
-      if (!putLabelsResponse.ok) {
-        setSubmitError({ message: 'ラベルの設定に失敗しました。' });
         return;
       }
 

--- a/src/app/_swr/fetcher.ts
+++ b/src/app/_swr/fetcher.ts
@@ -1,6 +1,6 @@
 import { HttpError } from '@/lib/httpError';
 import { proxyClient } from '@/lib/proxyClient';
-import type { paths } from '@/generated/api-types';
+import type { ApiPaths } from '@/lib/api/types';
 
 /** @deprecated useApiQuery を使用してください */
 export const fetcher = async (url: string) => {
@@ -18,16 +18,16 @@ export const fetcher = async (url: string) => {
 };
 
 export type GetPaths = {
-  [P in keyof paths]: paths[P] extends { get: unknown } ? P : never;
-}[keyof paths];
+  [P in keyof ApiPaths]: ApiPaths[P] extends { get: unknown } ? P : never;
+}[keyof ApiPaths];
 
-export type GetParams<P extends GetPaths> = paths[P] extends {
+export type GetParams<P extends GetPaths> = ApiPaths[P] extends {
   get: { parameters?: infer Params };
 }
   ? Params
   : never;
 
-export type GetResponse<P extends GetPaths> = paths[P] extends {
+export type GetResponse<P extends GetPaths> = ApiPaths[P] extends {
   get: {
     responses: {
       200: {

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -4,7 +4,58 @@
  */
 
 export interface paths {
-    "/forms": {
+    "/api/v1/archived-forms": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** アーカイブ済みフォームの一覧取得 */
+        get: operations["archived_form_list_handler"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/archived-forms/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** アーカイブ済みフォームの取得 */
+        get: operations["get_archived_form_handler"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/archived-forms/{id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** アーカイブ済みフォームの復元 */
+        post: operations["restore_archived_form_handler"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/forms": {
         parameters: {
             query?: never;
             header?: never;
@@ -22,7 +73,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/forms/answers": {
+    "/api/v1/forms/answers": {
         parameters: {
             query?: never;
             header?: never;
@@ -39,7 +90,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/forms/answers/{answer_id}/labels": {
+    "/api/v1/forms/answers/{answer_id}/labels": {
         parameters: {
             query?: never;
             header?: never;
@@ -55,7 +106,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/forms/{form_id}/answers/{answer_id}": {
+    "/api/v1/forms/{form_id}/answers/{answer_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -73,7 +124,7 @@ export interface paths {
         patch: operations["update_answer_handler"];
         trace?: never;
     };
-    "/forms/{form_id}/answers/{answer_id}/comments": {
+    "/api/v1/forms/{form_id}/answers/{answer_id}/comments": {
         parameters: {
             query?: never;
             header?: never;
@@ -91,7 +142,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/forms/{form_id}/answers/{answer_id}/comments/{comment_id}": {
+    "/api/v1/forms/{form_id}/answers/{answer_id}/comments/{comment_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -109,7 +160,7 @@ export interface paths {
         patch: operations["update_form_comment"];
         trace?: never;
     };
-    "/forms/{form_id}/answers/{answer_id}/messages": {
+    "/api/v1/forms/{form_id}/answers/{answer_id}/messages": {
         parameters: {
             query?: never;
             header?: never;
@@ -127,7 +178,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/forms/{form_id}/answers/{answer_id}/messages/{message_id}": {
+    "/api/v1/forms/{form_id}/answers/{answer_id}/messages/{message_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -145,23 +196,7 @@ export interface paths {
         patch: operations["update_message_handler"];
         trace?: never;
     };
-    "/forms/{form_id}/labels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put: operations["replace_form_labels"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/forms/{id}": {
+    "/api/v1/forms/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -172,18 +207,17 @@ export interface paths {
         get: operations["get_form_handler"];
         /**
          * フォームの更新
-         * @description questions を含めた場合、その form 配下の question 定義全体を指定内容で置換します。questions を省略した場合は既存 question を保持します。
+         * @description questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。
          */
         put: operations["update_form_handler"];
         post?: never;
-        /** フォームの削除 */
-        delete: operations["delete_form_handler"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/forms/{id}/answers": {
+    "/api/v1/forms/{id}/answers": {
         parameters: {
             query?: never;
             header?: never;
@@ -201,23 +235,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/health": {
+    "/api/v1/forms/{id}/archive": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations["health_check"];
+        get?: never;
         put?: never;
-        post?: never;
+        /** フォームのアーカイブ */
+        post: operations["archive_form_handler"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/labels/answers": {
+    "/api/v1/labels/answers": {
         parameters: {
             query?: never;
             header?: never;
@@ -235,7 +270,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/labels/answers/{label_id}": {
+    "/api/v1/labels/answers/{label_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -253,7 +288,7 @@ export interface paths {
         patch: operations["edit_label_for_answers"];
         trace?: never;
     };
-    "/labels/forms": {
+    "/api/v1/labels/forms": {
         parameters: {
             query?: never;
             header?: never;
@@ -271,7 +306,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/labels/forms/{label_id}": {
+    "/api/v1/labels/forms/{label_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -289,7 +324,7 @@ export interface paths {
         patch: operations["edit_label_for_forms"];
         trace?: never;
     };
-    "/link-discord": {
+    "/api/v1/link-discord": {
         parameters: {
             query?: never;
             header?: never;
@@ -307,7 +342,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/notifications/settings/me": {
+    "/api/v1/notifications/settings/me": {
         parameters: {
             query?: never;
             header?: never;
@@ -325,7 +360,7 @@ export interface paths {
         patch: operations["update_notification_settings"];
         trace?: never;
     };
-    "/notifications/settings/{uuid}": {
+    "/api/v1/notifications/settings/{uuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -342,7 +377,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/search": {
+    "/api/v1/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -359,7 +394,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/session": {
+    "/api/v1/session": {
         parameters: {
             query?: never;
             header?: never;
@@ -377,7 +412,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/users": {
+    "/api/v1/users": {
         parameters: {
             query?: never;
             header?: never;
@@ -394,7 +429,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/users/me": {
+    "/api/v1/users/me": {
         parameters: {
             query?: never;
             header?: never;
@@ -411,7 +446,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/users/{uuid}": {
+    "/api/v1/users/{uuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -469,14 +504,27 @@ export interface components {
         };
         AnswerSettingsSchema: {
             default_answer_title?: string | null;
-            response_period?: null | components["schemas"]["ResponsePeriodInput"];
-            visibility?: string | null;
+            response_period: components["schemas"]["ResponsePeriodSchema"];
+            visibility: components["schemas"]["AnswerVisibility"];
         };
         AnswerUpdateSchema: {
             title?: string | null;
         };
         /** @enum {string} */
         AnswerVisibility: "PUBLIC" | "PRIVATE";
+        ArchivedFormSchema: {
+            /** Format: date-time */
+            archived_at: string;
+            archived_by: unknown;
+            description: string;
+            /** Format: uuid */
+            id: string;
+            labels: components["schemas"]["FormLabelResponseSchema"][];
+            metadata: components["schemas"]["FormMetaSchema"];
+            questions: components["schemas"]["QuestionResponseSchema"][];
+            settings: components["schemas"]["FormSettingsSchema"];
+            title: string;
+        };
         ChoiceResponseSchema: {
             /** Format: int32 */
             id?: number | null;
@@ -570,12 +618,17 @@ export interface components {
             title: string;
         };
         FormSettingsSchema: {
-            answer_settings?: null | components["schemas"]["AnswerSettingsSchema"];
-            visibility?: string | null;
+            answer_settings: components["schemas"]["AnswerSettingsSchema"];
+            visibility: string;
             webhook_url?: string | null;
         };
         FormUpdateSchema: {
             description?: string | null;
+            /**
+             * @description When provided, replaces the full set of labels attached to the form.
+             *     Omit this field to leave existing labels unchanged.
+             */
+            labels?: string[] | null;
             /**
              * @description When provided, replaces the full set of question definitions under the form.
              *     Omit this field to leave existing questions unchanged.
@@ -648,9 +701,6 @@ export interface components {
         ReplaceAnswerLabelSchema: {
             labels: string[];
         };
-        ReplaceFormLabelSchema: {
-            labels: string[];
-        };
         ResponsePeriodInput: {
             end_at?: string | null;
             start_at?: string | null;
@@ -712,6 +762,203 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    archived_form_list_handler: {
+        parameters: {
+            query?: {
+                /** @description Offset for pagination */
+                offset?: number;
+                /** @description Limit for pagination */
+                limit?: number;
+                /** @description Search query */
+                query?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchivedFormSchema"][];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_archived_form_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchivedFormSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    restore_archived_form_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description There is no content to send for this request, but the headers may be useful. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     form_list_handler: {
         parameters: {
             query?: {
@@ -1765,76 +2012,6 @@ export interface operations {
             };
         };
     };
-    replace_form_labels: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                form_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReplaceFormLabelSchema"];
-            };
-        };
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
     get_form_handler: {
         parameters: {
             query?: never;
@@ -1966,72 +2143,6 @@ export interface operations {
             };
             /** @description Client error */
             422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    delete_form_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description There is no content to send for this request, but the headers may be useful. */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2206,28 +2317,69 @@ export interface operations {
             };
         };
     };
-    health_check: {
+    archive_form_handler: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                /** @description Form ID */
+                id: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description All dependencies are healthy. */
-            200: {
+            /** @description There is no content to send for this request, but the headers may be useful. */
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
-            /** @description One or more dependencies are unavailable. */
-            503: {
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -5,9 +5,12 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 
 export const useFormActions = () => {
   const deleteForm = async (formId: string): Promise<{ ok: boolean }> => {
-    const { data, error, response } = await proxyClient.DELETE('/forms/{id}', {
-      params: { path: { id: formId } },
-    });
+    const { data, error, response } = await proxyClient.POST(
+      '/forms/{id}/archive',
+      {
+        params: { path: { id: formId } },
+      }
+    );
     const result = handleMutationResponse(response, data, error);
     return { ok: result.success };
   };

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -2,12 +2,12 @@
 
 import { proxyClient } from '@/lib/proxyClient';
 import { handleMutationResponse } from '@/hooks/useApiMutation';
-import type { paths } from '@/generated/api-types';
+import type { ApiPaths } from '@/lib/api/types';
 
 type FormUpdateBody =
-  paths['/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/forms/{id}']['put']['requestBody']['content']['application/json'];
 type FormUpdateResponse =
-  paths['/forms/{id}']['put']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/{id}']['put']['responses'][200]['content']['application/json'];
 
 export const useFormEditActions = (formId: string) => {
   const updateForm = async (body: FormUpdateBody): Promise<{ ok: boolean }> => {

--- a/src/hooks/useFormLabelActions.ts
+++ b/src/hooks/useFormLabelActions.ts
@@ -5,13 +5,10 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 
 export const useFormLabelActions = (formId: string) => {
   const updateLabels = async (labelIds: string[]): Promise<{ ok: boolean }> => {
-    const { data, error, response } = await proxyClient.PUT(
-      '/forms/{form_id}/labels',
-      {
-        params: { path: { form_id: formId } },
-        body: { labels: labelIds },
-      }
-    );
+    const { data, error, response } = await proxyClient.PUT('/forms/{id}', {
+      params: { path: { id: formId } },
+      body: { labels: labelIds },
+    });
     const result = handleMutationResponse(response, data, error);
     return { ok: result.success };
   };

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { proxyClient } from '@/lib/proxyClient';
-import type { paths } from '@/generated/api-types';
+import type { ApiPaths } from '@/lib/api/types';
 
 type NotificationSettingsUpdateBody =
-  paths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
+  ApiPaths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
 
 export const useNotificationSettings = () => {
   const updateSettings = async (

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,4 +1,4 @@
 import createClient from 'openapi-fetch';
-import type { paths } from '@/generated/api-types';
+import type { ApiPaths } from '@/lib/api/types';
 
-export const apiClient = createClient<paths>({ baseUrl: '/api/proxy' });
+export const apiClient = createClient<ApiPaths>({ baseUrl: '/api/proxy' });

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,6 +1,14 @@
 import type { components, paths } from '@/generated/api-types';
 
-export type ApiPaths = paths;
+type StripApiV1Prefix<Path> = Path extends `/api/v1${infer Rest}`
+  ? Rest extends ''
+    ? '/'
+    : Rest
+  : Path;
+
+export type ApiPaths = {
+  [Path in keyof paths as StripApiV1Prefix<Path>]: paths[Path];
+};
 export type ApiComponents = components;
 
 export type AnswerCommentType = components['schemas']['AnswerComment'] & {
@@ -10,36 +18,36 @@ export type AnswerCommentType = components['schemas']['AnswerComment'] & {
 export type GetQuestionsResponse =
   components['schemas']['QuestionResponseSchema'][];
 export type GetFormsResponse =
-  paths['/forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms']['get']['responses'][200]['content']['application/json'];
 export type GetFormResponse =
-  paths['/forms/{id}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/{id}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormResponse =
-  paths['/forms']['post']['responses'][201]['content']['application/json'];
+  ApiPaths['/forms']['post']['responses'][201]['content']['application/json'];
 export type GetFormAnswersResponse =
-  paths['/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
 export type GetAnswersResponse =
-  paths['/forms/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/answers']['get']['responses'][200]['content']['application/json'];
 export type GetAnswerResponse =
-  paths['/forms/{form_id}/answers/{answer_id}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/{form_id}/answers/{answer_id}']['get']['responses'][200]['content']['application/json'];
 export type GetFormLabelsResponse =
-  paths['/labels/forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/labels/forms']['get']['responses'][200]['content']['application/json'];
 export type GetAnswerLabelsResponse =
-  paths['/labels/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/labels/answers']['get']['responses'][200]['content']['application/json'];
 export type GetMessagesResponse =
-  paths['/forms/{form_id}/answers/{answer_id}/messages']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/forms/{form_id}/answers/{answer_id}/messages']['get']['responses'][200]['content']['application/json'];
 export type GetUsersResponse =
-  paths['/users/me']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/users/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserResponse =
-  paths['/users/{uuid}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/users/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type GetUserListResponse =
-  paths['/users']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/users']['get']['responses'][200]['content']['application/json'];
 export type SearchResponse =
-  paths['/search']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/search']['get']['responses'][200]['content']['application/json'];
 export type GetNotificationSettingsResponse =
-  paths['/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserNotificationSettingsResponse =
-  paths['/notifications/settings/{uuid}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/notifications/settings/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormSchema =
-  paths['/forms']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/forms']['post']['requestBody']['content']['application/json'];
 export type UpdateNotificationSettingsSchema =
-  paths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
+  ApiPaths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];


### PR DESCRIPTION
## 概要
- OpenAPI 型生成の既定入力を backend リポジトリの docs/openapi.json raw URL に変更し、OPENAPI_URL で一時的に差し替えられるようにしました。
- backend 最新 schema で src/generated/api-types.ts を再生成し、/api/v1 prefix を frontend 既存呼び出し用の ApiPaths 型で吸収しました。
- 最新 schema に合わせて、フォームラベル更新をフォーム更新 payload に統合し、フォーム削除操作は archive API を呼ぶようにしました。

## 確認事項
- pnpm codegen:check: backend raw schema から再生成して、ステージ済み生成物との差分が出ないことを確認しました。
- pnpm type-check: 最新 schema に合わせた型で frontend 全体が通ることを確認しました。
- pnpm lint: ESLint が通ることを確認しました。
- pnpm fmt: Prettier のチェックが通ることを確認しました。
- git push 時の pre-push で pnpm test:unit が実行され、1 ファイル 8 テストが通りました。

## 補足
- backend schema では path が /api/v1 prefix 付きで生成されますが、既存 runtime は BACKEND_SERVER_URL 側で API base を管理しているため、frontend の openapi-fetch 呼び出しでは従来どおり prefix なし path を使う型に正規化しています。

🤖 Generated with Codex
