### PR TITLE
test: 未認証時の E2E テストをランディングページへのリダイレクトに修正

### DIFF
--- a/tests/e2e/auth-guards.spec.ts
+++ b/tests/e2e/auth-guards.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('未認証で /forms にアクセスした場合はログイン画面へリダイレクトする', async ({
+test('未認証で /forms にアクセスした場合はランディングページへリダイレクトする', async ({
   request,
 }) => {
   const response = await request.get('/forms', {
@@ -9,13 +9,14 @@ test('未認証で /forms にアクセスした場合はログイン画面へリ
 
   expect(response.status()).toBeGreaterThanOrEqual(300);
   expect(response.status()).toBeLessThan(400);
-  expect(response.headers()['location']).toContain('/login');
+  const location = new URL(response.headers()['location'] ?? '');
+  expect(location.pathname).toBe('/');
   expect(response.headers()['set-cookie']).toContain(
     'SEICHI_PORTAL__POST_LOGIN_REDIRECT=%2Fforms'
   );
 });
 
-test('未認証で /admin にアクセスした場合はログイン画面へリダイレクトする', async ({
+test('未認証で /admin にアクセスした場合はランディングページへリダイレクトする', async ({
   request,
 }) => {
   const response = await request.get('/admin', {
@@ -24,7 +25,8 @@ test('未認証で /admin にアクセスした場合はログイン画面へリ
 
   expect(response.status()).toBeGreaterThanOrEqual(300);
   expect(response.status()).toBeLessThan(400);
-  expect(response.headers()['location']).toContain('/login');
+  const location = new URL(response.headers()['location'] ?? '');
+  expect(location.pathname).toBe('/');
   expect(response.headers()['set-cookie']).toContain(
     'SEICHI_PORTAL__POST_LOGIN_REDIRECT=%2Fadmin'
   );


### PR DESCRIPTION
## 概要

- `ef82a9c` のコミットで `/login` ページが廃止され、未認証アクセス時のリダイレクト先が `/login` から `/`（ランディングページ）に変更された
- これに伴い `tests/e2e/auth-guards.spec.ts` のテストが実際の挙動と乖離していたため修正した
- テスト名の「ログイン画面」→「ランディングページ」への変更と、`location` ヘッダーのアサーションを `/login` を含む文字列チェックから `pathname === '/'` のチェックに変更した
- ポストログインリダイレクト用 Cookie（`SEICHI_PORTAL__POST_LOGIN_REDIRECT`）の設定は変わらないため、Cookie のアサーションはそのまま維持している

## 確認事項

- pre-commit フック（lint・型チェック・フォーマット）はすべて通過
- pre-push フック（ユニットテスト 8件）はすべて通過

## 補足

- E2E テスト自体の実行は dev サーバーが必要なため CI での確認に委ねる

🤖 Generated with Claude Code