### PR TITLE
fix: E2E テストで相対 URL の Location ヘッダーを正しく解析する

### DIFF
--- a/tests/e2e/auth-guards.spec.ts
+++ b/tests/e2e/auth-guards.spec.ts
@@ -9,7 +9,10 @@ test('未認証で /forms にアクセスした場合はランディングペー
 
   expect(response.status()).toBeGreaterThanOrEqual(300);
   expect(response.status()).toBeLessThan(400);
-  const location = new URL(response.headers()['location'] ?? '');
+  const location = new URL(
+    response.headers()['location'] ?? '',
+    response.url()
+  );
   expect(location.pathname).toBe('/');
   expect(response.headers()['set-cookie']).toContain(
     'SEICHI_PORTAL__POST_LOGIN_REDIRECT=%2Fforms'
@@ -25,7 +28,10 @@ test('未認証で /admin にアクセスした場合はランディングペー
 
   expect(response.status()).toBeGreaterThanOrEqual(300);
   expect(response.status()).toBeLessThan(400);
-  const location = new URL(response.headers()['location'] ?? '');
+  const location = new URL(
+    response.headers()['location'] ?? '',
+    response.url()
+  );
   expect(location.pathname).toBe('/');
   expect(response.headers()['set-cookie']).toContain(
     'SEICHI_PORTAL__POST_LOGIN_REDIRECT=%2Fadmin'


### PR DESCRIPTION
## 概要

- Next.js 16 が同一オリジンへのリダイレクト時に `Location` ヘッダーを相対 URL（例: `/`）として返す挙動により、`abad3f3` で導入した `new URL(location)` が `TypeError: Invalid URL` で落ちていた
- `new URL(location, response.url())` とベース URL を渡すことで、相対・絶対どちらの `Location` ヘッダーでも正しく解析できるよう修正

## 確認事項

- curl で実際のリダイレクト動作を確認し、`Location: /` が返ること・`set-cookie` にリダイレクト先クッキーが付くことを確認済み
- lint / type-check / unit test はすべてパスしてコミット・プッシュ完了
- E2E テスト自体はローカルで実行中の dev server が別ポートで起動済みのため手元では走らせていないが、CI（GitHub Actions）で実行予定

## 補足

- ミドルウェア（`src/proxy.ts`）の実装自体は正しく、修正は E2E テストのアサーションのみ

🤖 Generated with Claude Code