### PR TITLE
API パスを OpenAPI 定義に統一する

### DIFF
--- a/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(authed)/(standard)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -7,7 +7,7 @@ import type { AnswerFormInput } from './answerFormTypes';
 import type { ApiPaths } from '@/lib/api/types';
 
 type AnswerCreateBody =
-  ApiPaths['/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
 
 type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'UNKNOWN';
 
@@ -62,14 +62,17 @@ export const useAnswerSubmission = (formId: string) => {
     useState<SubmissionErrorCode | null>(null);
 
   const submitAnswers = async (data: AnswerFormInput) => {
-    const { response, error } = await proxyClient.POST('/forms/{id}/answers', {
-      params: {
-        path: {
-          id: formId,
+    const { response, error } = await proxyClient.POST(
+      '/api/v1/forms/{id}/answers',
+      {
+        params: {
+          path: {
+            id: formId,
+          },
         },
-      },
-      body: toAnswerCreateBody(data),
-    });
+        body: toAnswerCreateBody(data),
+      }
+    );
 
     if (response.ok) {
       setIsSubmitted(true);

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/[answerId]/page.tsx
@@ -24,7 +24,7 @@ const Home = ({
     error: answerError,
     isLoading: isLoadingAnswers,
   } = useApiQuery(
-    '/forms/{form_id}/answers/{answer_id}',
+    '/api/v1/forms/{form_id}/answers/{answer_id}',
     {
       path: { form_id: formId, answer_id: answerId },
     },
@@ -36,7 +36,7 @@ const Home = ({
     error: formQuestionsError,
     isLoading: isLoadingFormQuestions,
   } = useApiQuery(
-    '/forms/{id}',
+    '/api/v1/forms/{id}',
     {
       path: { id: answer?.form_id ?? '' },
     },
@@ -44,14 +44,14 @@ const Home = ({
   );
 
   const { data: currentUser, isLoading: isLoadingCurrentUser } =
-    useApiQuery('/users/me');
+    useApiQuery('/api/v1/users/me');
 
   const {
     data: messages,
     error: messagesError,
     isLoading: isLoadingMessages,
   } = useApiQuery(
-    '/forms/{form_id}/answers/{answer_id}/messages',
+    '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
     {
       path: { form_id: formId, answer_id: answerId },
     },

--- a/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/answers/page.tsx
@@ -1,8 +1,11 @@
 import { Box, Typography } from '@mui/material';
 import AnswerList from './_components/AnswerList';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireUser } from '@/lib/server/session';
-import type { GetFormAnswersResponse, GetFormResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -13,14 +16,22 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
   const session = await requireUser();
   const { formId } = await params;
   const [answers, form] = await Promise.all([
-    backendFetchJson<GetFormAnswersResponse>(`/forms/${formId}/answers`, {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetFormResponse>(`/forms/${formId}`, {
-      method: 'GET',
-      token: session.token,
-    }),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms/{id}/answers', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { id: formId },
+        },
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms/{id}', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { id: formId },
+        },
+      })
+    ),
   ]);
 
   return (

--- a/src/app/(authed)/(standard)/forms/[formId]/page.tsx
+++ b/src/app/(authed)/(standard)/forms/[formId]/page.tsx
@@ -1,7 +1,10 @@
 import AnswerForm from './_components/AnswerForm';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireUser } from '@/lib/server/session';
-import type { GetFormResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -11,10 +14,14 @@ export const metadata: Metadata = {
 const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
   const session = await requireUser();
   const { formId } = await params;
-  const form = await backendFetchJson<GetFormResponse>(`/forms/${formId}`, {
-    method: 'GET',
-    token: session.token,
-  });
+  const form = await requireBackendData(
+    serverApiClient.GET('/api/v1/forms/{id}', {
+      headers: authorizationHeader(session.token),
+      params: {
+        path: { id: formId },
+      },
+    })
+  );
 
   return (
     <AnswerForm

--- a/src/app/(authed)/(standard)/forms/page.tsx
+++ b/src/app/(authed)/(standard)/forms/page.tsx
@@ -1,9 +1,12 @@
 import { Box, Typography } from '@mui/material';
 import FormList from './_components/FormList';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireUser } from '@/lib/server/session';
 import type { Metadata } from 'next';
-import type { GetFormsResponse } from '@/lib/api-types';
 
 export const metadata: Metadata = {
   title: 'フォーム一覧 | Seichi Portal',
@@ -11,10 +14,11 @@ export const metadata: Metadata = {
 
 const Home = async () => {
   const session = await requireUser();
-  const forms = await backendFetchJson<GetFormsResponse>('/forms', {
-    method: 'GET',
-    token: session.token,
-  });
+  const forms = await requireBackendData(
+    serverApiClient.GET('/api/v1/forms', {
+      headers: authorizationHeader(session.token),
+    })
+  );
 
   return (
     <Box sx={{ width: '100%' }}>

--- a/src/app/(authed)/(standard)/users/[userId]/page.tsx
+++ b/src/app/(authed)/(standard)/users/[userId]/page.tsx
@@ -3,12 +3,12 @@ import DiscordNotificationSettings from './_components/DiscordNotificationSettin
 import LinkDiscordButton from './_components/LinkDiscordButton';
 import UnlinkDiscordButton from './_components/UnlinkDiscordButton';
 import UserInformation from './_components/UserInformation';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireUser } from '@/lib/server/session';
-import type {
-  GetUserNotificationSettingsResponse,
-  GetUserResponse,
-} from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -19,16 +19,21 @@ const Home = async ({ params }: { params: Promise<{ userId: string }> }) => {
   const session = await requireUser();
   const { userId } = await params;
   const [user, notificationSettings] = await Promise.all([
-    backendFetchJson<GetUserResponse>(`/users/${userId}`, {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetUserNotificationSettingsResponse>(
-      `/notifications/settings/${userId}`,
-      {
-        method: 'GET',
-        token: session.token,
-      }
+    requireBackendData(
+      serverApiClient.GET('/api/v1/users/{uuid}', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { uuid: userId },
+        },
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/notifications/settings/{uuid}', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { uuid: userId },
+        },
+      })
     ),
   ]);
 

--- a/src/app/(authed)/admin/_components/SearchResult.tsx
+++ b/src/app/(authed)/admin/_components/SearchResult.tsx
@@ -24,7 +24,7 @@ const SearchResult = (props: {
   onClose: () => void;
 }) => {
   const router = useRouter();
-  const { data, isLoading, error } = useApiQuery('/search', {
+  const { data, isLoading, error } = useApiQuery('/api/v1/search', {
     query: { query: props.searchContent },
   });
 

--- a/src/app/(authed)/admin/answer/[answerId]/page.tsx
+++ b/src/app/(authed)/admin/answer/[answerId]/page.tsx
@@ -24,7 +24,9 @@ const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
     data: allAnswers,
     error: answersError,
     isLoading: isAnswersLoading,
-  } = useApiQuery('/forms/answers', undefined, { refreshInterval: 1000 });
+  } = useApiQuery('/api/v1/forms/answers', undefined, {
+    refreshInterval: 1000,
+  });
 
   const answers = allAnswers?.find((a) => a.id === answerId);
 
@@ -33,7 +35,7 @@ const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
     error: formQuestionsError,
     isLoading: isFormQuestionsLoading,
   } = useApiQuery(
-    '/forms/{id}',
+    '/api/v1/forms/{id}',
     {
       path: { id: answers?.form_id ?? '' },
     },
@@ -44,14 +46,14 @@ const Home = ({ params }: { params: Promise<{ answerId: string }> }) => {
     data: labels,
     error: labelsError,
     isLoading: isLabelsLoading,
-  } = useApiQuery('/labels/answers');
+  } = useApiQuery('/api/v1/labels/answers');
 
   const {
     data: messages,
     error: messagesError,
     isLoading: isMessagesLoading,
   } = useApiQuery(
-    '/forms/{form_id}/answers/{answer_id}/messages',
+    '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
     {
       path: {
         form_id: answers?.form_id ?? '',

--- a/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
@@ -10,9 +10,9 @@ import type {
 } from '../_schema/formEditorSchema';
 
 type CreateFormBody =
-  ApiPaths['/forms']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
 type FormUpdateBody =
-  ApiPaths['/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
 
 const toVisibility = (value: string | null | undefined): FormVisibility =>
   value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC';

--- a/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(authed)/admin/forms/create/_hooks/useCreateForm.ts
@@ -17,9 +17,12 @@ export const useCreateForm = () => {
     setIsSubmitted(false);
 
     try {
-      const { data: createdForm, response } = await proxyClient.POST('/forms', {
-        body: toCreateFormBody(data),
-      });
+      const { data: createdForm, response } = await proxyClient.POST(
+        '/api/v1/forms',
+        {
+          body: toCreateFormBody(data),
+        }
+      );
       if (!response.ok || !createdForm) {
         setSubmitError({ message: 'フォームの作成に失敗しました。' });
         return;
@@ -27,7 +30,7 @@ export const useCreateForm = () => {
       const createdFormId = createdForm.id;
 
       const { response: setFormMetadataResponse } = await proxyClient.PUT(
-        '/forms/{id}',
+        '/api/v1/forms/{id}',
         {
           params: { path: { id: createdFormId } },
           body: toFormUpdateBody(data, false),

--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -1,7 +1,10 @@
 import FormCreateForm from './_components/FormCreateForm';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type { GetFormLabelsResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -10,12 +13,10 @@ export const metadata: Metadata = {
 
 const Home = async () => {
   const session = await requireAdmin();
-  const labels = await backendFetchJson<GetFormLabelsResponse>(
-    '/labels/forms',
-    {
-      method: 'GET',
-      token: session.token,
-    }
+  const labels = await requireBackendData(
+    serverApiClient.GET('/api/v1/labels/forms', {
+      headers: authorizationHeader(session.token),
+    })
   );
 
   return <FormCreateForm labelOptions={labels} />;

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -1,7 +1,10 @@
 import FormEditForm from './_components/FormEditForm';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type { GetFormLabelsResponse, GetFormResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,14 +15,19 @@ const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
   const session = await requireAdmin();
   const { id } = await params;
   const [form, labels] = await Promise.all([
-    backendFetchJson<GetFormResponse>(`/forms/${id}`, {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetFormLabelsResponse>('/labels/forms', {
-      method: 'GET',
-      token: session.token,
-    }),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms/{id}', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { id: String(id) },
+        },
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/labels/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
   ]);
 
   return <FormEditForm form={form} labelOptions={labels} />;

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -1,7 +1,10 @@
 import FormsPageContent from './_components/FormsPageContent';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -11,14 +14,16 @@ export const metadata: Metadata = {
 const Home = async () => {
   const session = await requireAdmin();
   const [forms, labels] = await Promise.all([
-    backendFetchJson<GetFormsResponse>('/forms', {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetFormLabelsResponse>('/labels/forms', {
-      method: 'GET',
-      token: session.token,
-    }),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/labels/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
   ]);
 
   return <FormsPageContent forms={forms} labels={labels} />;

--- a/src/app/(authed)/admin/labels/page.tsx
+++ b/src/app/(authed)/admin/labels/page.tsx
@@ -1,12 +1,12 @@
 import { Stack, Typography } from '@mui/material';
 import { Suspense } from 'react';
 import LabelsTabs from './_components/LabelsTabs';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type {
-  GetAnswerLabelsResponse,
-  GetFormLabelsResponse,
-} from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -16,14 +16,16 @@ export const metadata: Metadata = {
 const Home = async () => {
   const session = await requireAdmin();
   const [formLabels, answerLabels] = await Promise.all([
-    backendFetchJson<GetFormLabelsResponse>('/labels/forms', {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetAnswerLabelsResponse>('/labels/answers', {
-      method: 'GET',
-      token: session.token,
-    }),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/labels/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/labels/answers', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
   ]);
 
   return (

--- a/src/app/(authed)/admin/page.tsx
+++ b/src/app/(authed)/admin/page.tsx
@@ -1,7 +1,10 @@
 import DataTable from './_components/Dashboard';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type { GetAnswersResponse, GetFormsResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -11,14 +14,16 @@ export const metadata: Metadata = {
 const Home = async () => {
   const session = await requireAdmin();
   const [answers, forms] = await Promise.all([
-    backendFetchJson<GetAnswersResponse>('/forms/answers', {
-      method: 'GET',
-      token: session.token,
-    }),
-    backendFetchJson<GetFormsResponse>('/forms', {
-      method: 'GET',
-      token: session.token,
-    }),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms/answers', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
   ]);
 
   return (

--- a/src/app/(authed)/admin/users/page.tsx
+++ b/src/app/(authed)/admin/users/page.tsx
@@ -1,7 +1,10 @@
 import UserList from './_components/UserList';
-import { backendFetchJson } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
 import { requireAdmin } from '@/lib/server/session';
-import type { GetUserListResponse } from '@/lib/api-types';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -10,10 +13,11 @@ export const metadata: Metadata = {
 
 const Home = async () => {
   const session = await requireAdmin();
-  const users = await backendFetchJson<GetUserListResponse>('/users', {
-    method: 'GET',
-    token: session.token,
-  });
+  const users = await requireBackendData(
+    serverApiClient.GET('/api/v1/users', {
+      headers: authorizationHeader(session.token),
+    })
+  );
 
   return <UserList users={users} currentUserId={session.user.id} />;
 };

--- a/src/app/_swr/fetcher.ts
+++ b/src/app/_swr/fetcher.ts
@@ -45,19 +45,17 @@ export const typedFetcher = async <P extends GetPaths>(
   path: P,
   params?: GetParams<P>
 ): Promise<GetResponse<P>> => {
-  const client = proxyClient as {
-    GET: (
-      path: string,
-      options?: { params?: unknown }
-    ) => Promise<{
-      data: GetResponse<P> | undefined;
-      response: Response;
-      error?: unknown;
-    }>;
-  };
+  const get = proxyClient.GET as (
+    path: P,
+    options?: { params?: GetParams<P> }
+  ) => Promise<{
+    data: GetResponse<P> | undefined;
+    response: Response;
+    error?: unknown;
+  }>;
 
   const options = params === undefined ? undefined : { params };
-  const result = await client.GET(path, options);
+  const result = await get(path, options);
 
   if (!result.response.ok || result.data === undefined) {
     throw new HttpError({

--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { getBackendServerUrl, getDiscordConfig } from '@/env.server';
+import { getDiscordConfig } from '@/env.server';
 import {
   getPostLoginRedirectFromRequest,
   setPostLoginRedirectCookie,
 } from '@/lib/postLoginRedirect';
+import { authorizationHeader, serverApiClient } from '@/lib/server/backend';
 import { getCachedToken } from '@/user-token/mcToken';
 import { discordTokenSchema } from '../_schemas/External';
 import type { NextRequest } from 'next/server';
@@ -33,7 +34,6 @@ const clearDiscordOauthStateCookie = (response: NextResponse) => {
 
 export async function GET(req: NextRequest) {
   const { clientId, clientSecret, redirectUri } = getDiscordConfig();
-  const backendServerUrl = getBackendServerUrl();
   const seichiPortalToken = await getCachedToken(req.cookies);
 
   if (!seichiPortalToken) {
@@ -108,18 +108,15 @@ export async function GET(req: NextRequest) {
       return response;
     }
 
-    const linkDiscordResponse = await fetch(
-      `${backendServerUrl}/link-discord`,
+    const { response: linkDiscordResponse } = await serverApiClient.POST(
+      '/api/v1/link-discord',
       {
-        method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${seichiPortalToken}`,
+          ...authorizationHeader(seichiPortalToken),
         },
-        body: JSON.stringify({
+        body: {
           token: token.data.access_token,
-        }),
-        cache: 'no-cache',
+        },
       }
     );
 

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,6 +1,6 @@
-import { getBackendServerUrl } from '@/env.server';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { authorizationHeader, serverApiClient } from '@/lib/server/backend';
 
 const SESSION_COOKIE = 'SEICHI_PORTAL__SESSION_ID';
 
@@ -9,12 +9,13 @@ export const DELETE = async () => {
   const token = cookieStore.get(SESSION_COOKIE)?.value;
 
   if (token) {
-    await fetch(`${getBackendServerUrl()}/session`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }).catch((e) => console.error('Failed to delete backend session:', e));
+    await serverApiClient
+      .DELETE('/api/v1/session', {
+        headers: {
+          ...authorizationHeader(token),
+        },
+      })
+      .catch((e) => console.error('Failed to delete backend session:', e));
   }
 
   const response = NextResponse.json({ success: true });

--- a/src/app/api/minecraft-access-token/route.ts
+++ b/src/app/api/minecraft-access-token/route.ts
@@ -4,7 +4,7 @@ import {
   minecraftAccessTokenResponseSchema,
   xboxLiveServiceTokenResponseSchema,
 } from '@/_schemas/loginSchema';
-import { getBackendServerUrl } from '@/env.server';
+import { authorizationHeader, serverApiClient } from '@/lib/server/backend';
 import type { NextRequest } from 'next/server';
 
 const microsoftAccountTokenSchema = z.object({
@@ -182,15 +182,14 @@ const createSession = async ({
   token,
   expires,
 }: Awaited<ReturnType<typeof acquireMinecraftAccessToken>>) => {
-  return await fetch(`${getBackendServerUrl()}/session`, {
-    method: 'POST',
+  const { response } = await serverApiClient.POST('/api/v1/session', {
     headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+      ...authorizationHeader(token),
     },
-    body: JSON.stringify({
+    body: {
       expires: expires,
-    }),
-    cache: 'no-cache',
+    },
   });
+
+  return response;
 };

--- a/src/hooks/useAnswerActions.ts
+++ b/src/hooks/useAnswerActions.ts
@@ -6,7 +6,7 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 export const useAnswerActions = (formId: string, answerId: string) => {
   const updateTitle = async (title: string): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.PATCH(
-      '/forms/{form_id}/answers/{answer_id}',
+      '/api/v1/forms/{form_id}/answers/{answer_id}',
       {
         params: { path: { form_id: formId, answer_id: answerId } },
         body: { title },
@@ -18,7 +18,7 @@ export const useAnswerActions = (formId: string, answerId: string) => {
 
   const updateLabels = async (labelIds: string[]): Promise<{ ok: boolean }> => {
     const { error, response } = await proxyClient.PUT(
-      '/forms/answers/{answer_id}/labels',
+      '/api/v1/forms/answers/{answer_id}/labels',
       {
         params: { path: { answer_id: answerId } },
         body: { labels: labelIds },

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -8,7 +8,7 @@ type CommentActionResult = { ok: boolean; forbidden?: boolean };
 export const useCommentActions = (formId: string, answerId: string) => {
   const sendComment = async (content: string): Promise<CommentActionResult> => {
     const { data, error, response } = await proxyClient.POST(
-      '/forms/{form_id}/answers/{answer_id}/comments',
+      '/api/v1/forms/{form_id}/answers/{answer_id}/comments',
       {
         params: {
           path: { form_id: formId, answer_id: answerId },
@@ -28,7 +28,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     commentId: string
   ): Promise<CommentActionResult> => {
     const { data, error, response } = await proxyClient.DELETE(
-      '/forms/{form_id}/answers/{answer_id}/comments/{comment_id}',
+      '/api/v1/forms/{form_id}/answers/{answer_id}/comments/{comment_id}',
       {
         params: {
           path: {

--- a/src/hooks/useDiscordActions.ts
+++ b/src/hooks/useDiscordActions.ts
@@ -6,7 +6,7 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 export const useDiscordActions = () => {
   const unlinkDiscord = async (): Promise<void> => {
     const { data, error, response } = await proxyClient.DELETE(
-      '/link-discord',
+      '/api/v1/link-discord',
       {}
     );
     handleMutationResponse(response, data, error);

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -6,7 +6,7 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 export const useFormActions = () => {
   const deleteForm = async (formId: string): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.POST(
-      '/forms/{id}/archive',
+      '/api/v1/forms/{id}/archive',
       {
         params: { path: { id: formId } },
       }

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -5,16 +5,19 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 import type { ApiPaths } from '@/lib/api/types';
 
 type FormUpdateBody =
-  ApiPaths['/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
 type FormUpdateResponse =
-  ApiPaths['/forms/{id}']['put']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}']['put']['responses'][200]['content']['application/json'];
 
 export const useFormEditActions = (formId: string) => {
   const updateForm = async (body: FormUpdateBody): Promise<{ ok: boolean }> => {
-    const { data, error, response } = await proxyClient.PUT('/forms/{id}', {
-      params: { path: { id: formId } },
-      body,
-    });
+    const { data, error, response } = await proxyClient.PUT(
+      '/api/v1/forms/{id}',
+      {
+        params: { path: { id: formId } },
+        body,
+      }
+    );
     const result = handleMutationResponse<FormUpdateResponse>(
       response,
       data,

--- a/src/hooks/useFormLabelActions.ts
+++ b/src/hooks/useFormLabelActions.ts
@@ -5,10 +5,13 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 
 export const useFormLabelActions = (formId: string) => {
   const updateLabels = async (labelIds: string[]): Promise<{ ok: boolean }> => {
-    const { data, error, response } = await proxyClient.PUT('/forms/{id}', {
-      params: { path: { id: formId } },
-      body: { labels: labelIds },
-    });
+    const { data, error, response } = await proxyClient.PUT(
+      '/api/v1/forms/{id}',
+      {
+        params: { path: { id: formId } },
+        body: { labels: labelIds },
+      }
+    );
     const result = handleMutationResponse(response, data, error);
     return { ok: result.success };
   };

--- a/src/hooks/useLabelCRUD.ts
+++ b/src/hooks/useLabelCRUD.ts
@@ -5,17 +5,20 @@ import { proxyClient } from '@/lib/proxyClient';
 
 export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
   const { mutate } = useSWRConfig();
-  const key = labelType === 'answers' ? ['/labels/answers'] : ['/labels/forms'];
+  const key =
+    labelType === 'answers'
+      ? ['/api/v1/labels/answers']
+      : ['/api/v1/labels/forms'];
 
   const createLabel = async (name: string): Promise<{ ok: boolean }> => {
     if (labelType === 'answers') {
-      const { response } = await proxyClient.POST('/labels/answers', {
+      const { response } = await proxyClient.POST('/api/v1/labels/answers', {
         body: { name },
       });
       if (response.ok) await mutate(key);
       return { ok: response.ok };
     } else {
-      const { response } = await proxyClient.POST('/labels/forms', {
+      const { response } = await proxyClient.POST('/api/v1/labels/forms', {
         body: { name },
       });
       if (response.ok) await mutate(key);
@@ -26,14 +29,14 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
   const deleteLabel = async (id: string | number): Promise<{ ok: boolean }> => {
     if (labelType === 'answers') {
       const { response } = await proxyClient.DELETE(
-        '/labels/answers/{label_id}',
+        '/api/v1/labels/answers/{label_id}',
         { params: { path: { label_id: String(id) } } }
       );
       if (response.ok) await mutate(key);
       return { ok: response.ok };
     } else {
       const { response } = await proxyClient.DELETE(
-        '/labels/forms/{label_id}',
+        '/api/v1/labels/forms/{label_id}',
         {
           params: { path: { label_id: String(id) } },
         }
@@ -49,7 +52,7 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
   ): Promise<{ ok: boolean }> => {
     if (labelType === 'answers') {
       const { response } = await proxyClient.PATCH(
-        '/labels/answers/{label_id}',
+        '/api/v1/labels/answers/{label_id}',
         {
           params: { path: { label_id: String(id) } },
           body: { name },
@@ -58,10 +61,13 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
       if (response.ok) await mutate(key);
       return { ok: response.ok };
     } else {
-      const { response } = await proxyClient.PATCH('/labels/forms/{label_id}', {
-        params: { path: { label_id: String(id) } },
-        body: { name },
-      });
+      const { response } = await proxyClient.PATCH(
+        '/api/v1/labels/forms/{label_id}',
+        {
+          params: { path: { label_id: String(id) } },
+          body: { name },
+        }
+      );
       if (response.ok) await mutate(key);
       return { ok: response.ok };
     }

--- a/src/hooks/useMessageActions.ts
+++ b/src/hooks/useMessageActions.ts
@@ -11,7 +11,7 @@ export const useMessageActions = (formId: string, answerId: string) => {
     body: string
   ): Promise<MessageActionResult> => {
     const { data, error, response } = await proxyClient.PATCH(
-      '/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
+      '/api/v1/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
       {
         params: {
           path: {
@@ -35,7 +35,7 @@ export const useMessageActions = (formId: string, answerId: string) => {
     messageId: string
   ): Promise<MessageActionResult> => {
     const { data, error, response } = await proxyClient.DELETE(
-      '/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
+      '/api/v1/forms/{form_id}/answers/{answer_id}/messages/{message_id}',
       {
         params: {
           path: {

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -4,15 +4,18 @@ import { proxyClient } from '@/lib/proxyClient';
 import type { ApiPaths } from '@/lib/api/types';
 
 type NotificationSettingsUpdateBody =
-  ApiPaths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
 
 export const useNotificationSettings = () => {
   const updateSettings = async (
     data: NotificationSettingsUpdateBody
   ): Promise<{ ok: boolean }> => {
-    const { response } = await proxyClient.PATCH('/notifications/settings/me', {
-      body: data,
-    });
+    const { response } = await proxyClient.PATCH(
+      '/api/v1/notifications/settings/me',
+      {
+        body: data,
+      }
+    );
     return { ok: response.ok };
   };
 

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -8,7 +8,7 @@ type SendMessageResult = { success: boolean; forbidden?: boolean };
 export const useSendMessage = (formId: string, answerId: string) => {
   const sendMessage = async (body: string): Promise<SendMessageResult> => {
     const { data, error, response } = await proxyClient.POST(
-      '/forms/{form_id}/answers/{answer_id}/messages',
+      '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
       {
         params: { path: { form_id: formId, answer_id: answerId } },
         body: { body },

--- a/src/hooks/useUserRoleActions.ts
+++ b/src/hooks/useUserRoleActions.ts
@@ -5,10 +5,13 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 
 export const useUserRoleActions = () => {
   const updateUserRole = async (uuid: string, role: string): Promise<void> => {
-    const { data, error, response } = await proxyClient.PATCH('/users/{uuid}', {
-      params: { path: { uuid } },
-      body: { role },
-    });
+    const { data, error, response } = await proxyClient.PATCH(
+      '/api/v1/users/{uuid}',
+      {
+        params: { path: { uuid } },
+        body: { role },
+      }
+    );
     handleMutationResponse(response, data, error);
   };
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,14 +1,6 @@
 import type { components, paths } from '@/generated/api-types';
 
-type StripApiV1Prefix<Path> = Path extends `/api/v1${infer Rest}`
-  ? Rest extends ''
-    ? '/'
-    : Rest
-  : Path;
-
-export type ApiPaths = {
-  [Path in keyof paths as StripApiV1Prefix<Path>]: paths[Path];
-};
+export type ApiPaths = paths;
 export type ApiComponents = components;
 
 export type AnswerCommentType = components['schemas']['AnswerComment'] & {
@@ -18,36 +10,36 @@ export type AnswerCommentType = components['schemas']['AnswerComment'] & {
 export type GetQuestionsResponse =
   components['schemas']['QuestionResponseSchema'][];
 export type GetFormsResponse =
-  ApiPaths['/forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms']['get']['responses'][200]['content']['application/json'];
 export type GetFormResponse =
-  ApiPaths['/forms/{id}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormResponse =
-  ApiPaths['/forms']['post']['responses'][201]['content']['application/json'];
+  ApiPaths['/api/v1/forms']['post']['responses'][201]['content']['application/json'];
 export type GetFormAnswersResponse =
-  ApiPaths['/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
 export type GetAnswersResponse =
-  ApiPaths['/forms/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/answers']['get']['responses'][200]['content']['application/json'];
 export type GetAnswerResponse =
-  ApiPaths['/forms/{form_id}/answers/{answer_id}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}/answers/{answer_id}']['get']['responses'][200]['content']['application/json'];
 export type GetFormLabelsResponse =
-  ApiPaths['/labels/forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/labels/forms']['get']['responses'][200]['content']['application/json'];
 export type GetAnswerLabelsResponse =
-  ApiPaths['/labels/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/labels/answers']['get']['responses'][200]['content']['application/json'];
 export type GetMessagesResponse =
-  ApiPaths['/forms/{form_id}/answers/{answer_id}/messages']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}/answers/{answer_id}/messages']['get']['responses'][200]['content']['application/json'];
 export type GetUsersResponse =
-  ApiPaths['/users/me']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/users/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserResponse =
-  ApiPaths['/users/{uuid}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/users/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type GetUserListResponse =
-  ApiPaths['/users']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/users']['get']['responses'][200]['content']['application/json'];
 export type SearchResponse =
-  ApiPaths['/search']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/search']['get']['responses'][200]['content']['application/json'];
 export type GetNotificationSettingsResponse =
-  ApiPaths['/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserNotificationSettingsResponse =
-  ApiPaths['/notifications/settings/{uuid}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/notifications/settings/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormSchema =
-  ApiPaths['/forms']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
 export type UpdateNotificationSettingsSchema =
-  ApiPaths['/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/notifications/settings/me']['patch']['requestBody']['content']['application/json'];

--- a/src/lib/server/backend.ts
+++ b/src/lib/server/backend.ts
@@ -1,5 +1,6 @@
 import createClient from 'openapi-fetch';
 import { getBackendServerUrl } from '@/env.server';
+import type { Client } from 'openapi-fetch';
 import type { ApiPaths } from '@/lib/api/types';
 
 export class BackendError extends Error {
@@ -34,7 +35,18 @@ export const createServerApiClient = () =>
     cache: 'no-cache',
   });
 
-export const serverApiClient = createServerApiClient();
+let cachedServerApiClient: Client<ApiPaths> | undefined;
+
+const getServerApiClient = () => {
+  cachedServerApiClient ??= createServerApiClient();
+  return cachedServerApiClient;
+};
+
+export const serverApiClient = new Proxy({} as Client<ApiPaths>, {
+  get(_target, property, receiver) {
+    return Reflect.get(getServerApiClient(), property, receiver);
+  },
+});
 
 export const authorizationHeader = (token: string) => ({
   Authorization: `Bearer ${token}`,

--- a/src/lib/server/backend.ts
+++ b/src/lib/server/backend.ts
@@ -1,4 +1,6 @@
+import createClient from 'openapi-fetch';
 import { getBackendServerUrl } from '@/env.server';
+import type { ApiPaths } from '@/lib/api/types';
 
 export class BackendError extends Error {
   status: number;
@@ -20,43 +22,55 @@ export class BackendError extends Error {
   }
 }
 
-type BackendFetchOptions = Omit<RequestInit, 'headers'> & {
-  headers?: HeadersInit;
-  token?: string;
+type BackendFetchResult<T> = {
+  data?: T;
+  error?: unknown;
+  response: Response;
 };
 
-const createUrl = (path: string) => {
-  const backendServerUrl = getBackendServerUrl();
-  return new URL(path, backendServerUrl).toString();
-};
+export const createServerApiClient = () =>
+  createClient<ApiPaths>({
+    baseUrl: getBackendServerUrl(),
+    cache: 'no-cache',
+  });
 
-export const backendFetch = async (
-  path: string,
-  options: BackendFetchOptions = {}
-) => {
-  const { token, headers, cache = 'no-cache', ...init } = options;
-  const requestHeaders = new Headers(headers);
+export const serverApiClient = createServerApiClient();
 
-  if (token) {
-    requestHeaders.set('Authorization', `Bearer ${token}`);
+export const authorizationHeader = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+});
+
+export const requireBackendData = async <T>(
+  request: Promise<BackendFetchResult<T>>
+): Promise<T> => {
+  const { data } = await requireBackendResponse(request);
+
+  if (data === undefined) {
+    throw new BackendError({
+      message: 'Backend request did not return a response body',
+      status: 502,
+      code: 'http_error',
+    });
   }
 
-  try {
-    const response = await fetch(createUrl(path), {
-      ...init,
-      headers: requestHeaders,
-      cache,
-    });
+  return data;
+};
 
-    if (!response.ok) {
+export const requireBackendResponse = async <T>(
+  request: Promise<BackendFetchResult<T>>
+): Promise<BackendFetchResult<T>> => {
+  try {
+    const result = await request;
+
+    if (!result.response.ok) {
       throw new BackendError({
-        message: `Backend request failed with status ${response.status}`,
-        status: response.status,
+        message: `Backend request failed with status ${result.response.status}`,
+        status: result.response.status,
         code: 'http_error',
       });
     }
 
-    return response;
+    return result;
   } catch (error) {
     if (error instanceof BackendError) {
       throw error;
@@ -68,19 +82,4 @@ export const backendFetch = async (
       code: 'network_error',
     });
   }
-};
-
-export const backendFetchJson = async <T>(
-  path: string,
-  options: BackendFetchOptions = {}
-): Promise<T> => {
-  const response = await backendFetch(path, {
-    ...options,
-    headers: {
-      Accept: 'application/json',
-      ...options.headers,
-    },
-  });
-
-  return (await response.json()) as T;
 };

--- a/src/lib/server/session.ts
+++ b/src/lib/server/session.ts
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { cache } from 'react';
-import { backendFetch, BackendError } from './backend';
+import { authorizationHeader, BackendError, serverApiClient } from './backend';
 import { AccessError } from '@/lib/accessError';
 import { normalizeRedirectTarget } from '@/lib/redirect';
 import { getPostLoginRedirectCookie } from '@/lib/postLoginRedirect';
@@ -33,8 +33,7 @@ export type SessionResult =
   | UnauthenticatedSession
   | UnavailableSession;
 
-const parseUser = async (response: Response) => {
-  const body: unknown = await response.json().catch(() => null);
+const parseUser = (body: unknown) => {
   const parsed = userInfoResponseSchema.safeParse(body);
 
   if (!parsed.success) {
@@ -54,14 +53,22 @@ const getSessionInternal = async (
   }
 
   try {
-    const response = await backendFetch('/users/me', {
-      method: 'GET',
+    const { data, response } = await serverApiClient.GET('/api/v1/users/me', {
       headers: {
         Accept: 'application/json',
+        ...authorizationHeader(token),
       },
-      token,
     });
-    const user = await parseUser(response);
+
+    if (!response.ok) {
+      throw new BackendError({
+        message: `Backend request failed with status ${response.status}`,
+        status: response.status,
+        code: 'http_error',
+      });
+    }
+
+    const user = parseUser(data);
 
     if (!user) {
       return {

--- a/src/lib/server/session.ts
+++ b/src/lib/server/session.ts
@@ -1,7 +1,12 @@
 import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { cache } from 'react';
-import { authorizationHeader, BackendError, serverApiClient } from './backend';
+import {
+  authorizationHeader,
+  BackendError,
+  requireBackendResponse,
+  serverApiClient,
+} from './backend';
 import { AccessError } from '@/lib/accessError';
 import { normalizeRedirectTarget } from '@/lib/redirect';
 import { getPostLoginRedirectCookie } from '@/lib/postLoginRedirect';
@@ -53,20 +58,14 @@ const getSessionInternal = async (
   }
 
   try {
-    const { data, response } = await serverApiClient.GET('/api/v1/users/me', {
-      headers: {
-        Accept: 'application/json',
-        ...authorizationHeader(token),
-      },
-    });
-
-    if (!response.ok) {
-      throw new BackendError({
-        message: `Backend request failed with status ${response.status}`,
-        status: response.status,
-        code: 'http_error',
-      });
-    }
+    const { data } = await requireBackendResponse(
+      serverApiClient.GET('/api/v1/users/me', {
+        headers: {
+          Accept: 'application/json',
+          ...authorizationHeader(token),
+        },
+      })
+    );
 
     const user = parseUser(data);
 

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -3,10 +3,36 @@ import { AccessError } from '@/lib/accessError';
 import { BackendError } from '@/lib/server/backend';
 import { normalizeRedirectTarget } from '@/lib/redirect';
 
+const { backendGetMock, MockBackendError } = vi.hoisted(() => {
+  class MockBackendError extends Error {
+    status: number;
+    code: 'http_error' | 'network_error';
+
+    constructor({
+      message,
+      status,
+      code,
+    }: {
+      message: string;
+      status: number;
+      code: 'http_error' | 'network_error';
+    }) {
+      super(message);
+      this.name = 'BackendError';
+      this.status = status;
+      this.code = code;
+    }
+  }
+
+  return {
+    backendGetMock: vi.fn(),
+    MockBackendError,
+  };
+});
+
 const redirectMock = vi.fn<(url: string) => never>();
 const headersMock = vi.fn(async () => new Headers());
 const getCachedTokenMock = vi.fn();
-const backendFetchMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
   redirect: (url: string) => redirectMock(url),
@@ -20,16 +46,15 @@ vi.mock('@/user-token/mcToken', () => ({
   getCachedToken: (...args: unknown[]) => getCachedTokenMock(...args),
 }));
 
-vi.mock('@/lib/server/backend', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/server/backend')>(
-    '@/lib/server/backend'
-  );
-
-  return {
-    ...actual,
-    backendFetch: (...args: unknown[]) => backendFetchMock(...args),
-  };
-});
+vi.mock('@/lib/server/backend', () => ({
+  authorizationHeader: (token: string) => ({
+    Authorization: `Bearer ${token}`,
+  }),
+  BackendError: MockBackendError,
+  serverApiClient: {
+    GET: (...args: unknown[]) => backendGetMock(...args),
+  },
+}));
 
 const loadSessionModule = async () => import('@/lib/server/session');
 
@@ -61,19 +86,17 @@ describe('server session helpers', () => {
 
   it('バックエンドのユーザー取得に成功した場合は認証済みを返す', async () => {
     getCachedTokenMock.mockResolvedValue('token-123');
-    backendFetchMock.mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          id: 'user-id',
-          name: 'Alice',
-          role: 'ADMINISTRATOR',
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      )
-    );
+    backendGetMock.mockResolvedValue({
+      data: {
+        id: 'user-id',
+        name: 'Alice',
+        role: 'ADMINISTRATOR',
+      },
+      response: new Response(null, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
     const { getSession } = await loadSessionModule();
 
     await expect(getSession()).resolves.toEqual({
@@ -89,12 +112,13 @@ describe('server session helpers', () => {
 
   it('バックエンドのレスポンスボディが不正な場合は unavailable を返す', async () => {
     getCachedTokenMock.mockResolvedValue('token-123');
-    backendFetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ id: 'user-id' }), {
+    backendGetMock.mockResolvedValue({
+      data: { id: 'user-id' },
+      response: new Response(null, {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      })
-    );
+      }),
+    });
     const { getSession } = await loadSessionModule();
 
     await expect(getSession()).resolves.toEqual({
@@ -118,19 +142,17 @@ describe('server session helpers', () => {
 
   it('認証済みでも管理者でない場合は forbidden を送出する', async () => {
     getCachedTokenMock.mockResolvedValue('token-123');
-    backendFetchMock.mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          id: 'user-id',
-          name: 'Alice',
-          role: 'STANDARD_USER',
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      )
-    );
+    backendGetMock.mockResolvedValue({
+      data: {
+        id: 'user-id',
+        name: 'Alice',
+        role: 'STANDARD_USER',
+      },
+      response: new Response(null, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
     const { requireAdmin } = await loadSessionModule();
 
     await expect(requireAdmin()).rejects.toEqual(
@@ -144,7 +166,7 @@ describe('server session helpers', () => {
 
   it('バックエンドに到達できない場合は unavailable を返す', async () => {
     getCachedTokenMock.mockResolvedValue('token-123');
-    backendFetchMock.mockRejectedValue(
+    backendGetMock.mockRejectedValue(
       new BackendError({
         message: 'backend unavailable',
         status: 503,

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -51,6 +51,7 @@ vi.mock('@/lib/server/backend', () => ({
     Authorization: `Bearer ${token}`,
   }),
   BackendError: MockBackendError,
+  requireBackendResponse: async (request: Promise<unknown>) => request,
   serverApiClient: {
     GET: (...args: unknown[]) => backendGetMock(...args),
   },


### PR DESCRIPTION
## 概要
- backend OpenAPI schema の /api/v1 パスを frontend の API 型としてそのまま使うようにし、/api/v1 を剥がす型変換を削除しました。
- client/server の backend API 呼び出しを openapi-fetch ベースに寄せ、server page や route handler も生成された schema path と params.path で呼び出すようにしました。
- session 作成や Discord 連携など response headers や Authorization header が必要な箇所は、既存挙動を保ったまま serverApiClient 経由にしました。

## 確認事項
- pnpm type-check により、/session など OpenAPI に存在しない旧パスが通常の API client 呼び出しで型エラーになることを確認しました。
- pnpm lint と pnpm fmt が成功し、変更ファイルの静的検査と整形チェックが通ることを確認しました。
- pnpm test:unit が成功し、session helper の既存挙動が維持されていることを確認しました。
- pre-commit hook で lint/type-check/fmt、pre-push hook で unit-test が成功しました。

🤖 Generated with Codex