### PR TITLE
想定内のアクセス中断を例外扱いしない

### DIFF
--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -4,7 +4,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const labels = await requireBackendData(
     serverApiClient.GET('/api/v1/labels/forms', {
       headers: authorizationHeader(session.token),

--- a/src/app/(authed)/admin/forms/create/page.tsx
+++ b/src/app/(authed)/admin/forms/create/page.tsx
@@ -4,7 +4,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -13,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const labels = await requireBackendData(
     serverApiClient.GET('/api/v1/labels/forms', {
       headers: authorizationHeader(session.token),

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -4,7 +4,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -13,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const { id } = await params;
   const [form, labels] = await Promise.all([
     requireBackendData(

--- a/src/app/(authed)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/page.tsx
@@ -4,7 +4,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const { id } = await params;
   const [form, labels] = await Promise.all([
     requireBackendData(

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -4,7 +4,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -13,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const [forms, labels] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms', {

--- a/src/app/(authed)/admin/forms/page.tsx
+++ b/src/app/(authed)/admin/forms/page.tsx
@@ -4,7 +4,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const [forms, labels] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms', {

--- a/src/app/(authed)/admin/labels/page.tsx
+++ b/src/app/(authed)/admin/labels/page.tsx
@@ -6,7 +6,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -15,11 +14,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const [formLabels, answerLabels] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/labels/forms', {

--- a/src/app/(authed)/admin/labels/page.tsx
+++ b/src/app/(authed)/admin/labels/page.tsx
@@ -6,7 +6,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -14,7 +15,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const [formLabels, answerLabels] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/labels/forms', {

--- a/src/app/(authed)/admin/layout.tsx
+++ b/src/app/(authed)/admin/layout.tsx
@@ -1,4 +1,4 @@
-import { requireUser } from '@/lib/server/session';
+import { getAdminAccess } from '@/lib/server/session';
 import ErrorDialog from '@/app/_components/ErrorDialog';
 import NavBar from '@/app/_components/NavBar';
 import SearchField from './_components/SearchField';
@@ -7,9 +7,9 @@ import styles from '../../page.module.css';
 import type { ReactNode } from 'react';
 
 const RootLayout = async ({ children }: { children: ReactNode }) => {
-  const session = await requireUser();
+  const adminAccess = await getAdminAccess();
 
-  if (session.user.role !== 'ADMINISTRATOR') {
+  if (adminAccess.state === 'forbidden') {
     return <ErrorDialog status={403} showDiagnostics={false} />;
   }
 

--- a/src/app/(authed)/admin/page.tsx
+++ b/src/app/(authed)/admin/page.tsx
@@ -4,7 +4,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const [answers, forms] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms/answers', {

--- a/src/app/(authed)/admin/page.tsx
+++ b/src/app/(authed)/admin/page.tsx
@@ -4,7 +4,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -13,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const [answers, forms] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms/answers', {

--- a/src/app/(authed)/admin/users/page.tsx
+++ b/src/app/(authed)/admin/users/page.tsx
@@ -4,7 +4,8 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import { requireAdmin } from '@/lib/server/session';
+import ErrorDialog from '@/app/_components/ErrorDialog';
+import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const session = await requireAdmin();
+  const adminAccess = await getAdminAccess();
+  if (adminAccess.state === 'forbidden') {
+    return <ErrorDialog status={403} showDiagnostics={false} />;
+  }
+  const { session } = adminAccess;
   const users = await requireBackendData(
     serverApiClient.GET('/api/v1/users', {
       headers: authorizationHeader(session.token),

--- a/src/app/(authed)/admin/users/page.tsx
+++ b/src/app/(authed)/admin/users/page.tsx
@@ -4,7 +4,6 @@ import {
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import { getAdminAccess } from '@/lib/server/session';
 import type { Metadata } from 'next';
 
@@ -13,11 +12,7 @@ export const metadata: Metadata = {
 };
 
 const Home = async () => {
-  const adminAccess = await getAdminAccess();
-  if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
-  }
-  const { session } = adminAccess;
+  const { session } = await getAdminAccess();
   const users = await requireBackendData(
     serverApiClient.GET('/api/v1/users', {
       headers: authorizationHeader(session.token),

--- a/src/app/(unauthed)/_components/useLandingLogin.ts
+++ b/src/app/(unauthed)/_components/useLandingLogin.ts
@@ -60,11 +60,13 @@ type CompleteLoginParams = {
   router: ReturnType<typeof useRouter>;
 };
 
+type CompleteLoginResult = { success: true } | { success: false };
+
 const completeLogin = async ({
   account,
   instance,
   router,
-}: CompleteLoginParams) => {
+}: CompleteLoginParams): Promise<CompleteLoginResult> => {
   const request: SilentRequest = {
     account,
     ...loginRequest,
@@ -76,10 +78,11 @@ const completeLogin = async ({
   );
 
   if (!isLinkedMinecraftAccount) {
-    throw new Error(LOGIN_ERROR_MESSAGE);
+    return { success: false };
   }
 
   router.push(await fetchPostLoginRedirect());
+  return { success: true };
 };
 
 export const useLandingLogin = () => {
@@ -113,16 +116,15 @@ export const useLandingLogin = () => {
       setIsProcessing(true);
 
       try {
-        await completeLogin({ account, instance, router });
+        const result = await completeLogin({ account, instance, router });
+        if (!result.success) {
+          setProcessingErrorMessage(LOGIN_ERROR_MESSAGE);
+          setIsProcessing(false);
+        }
       } catch (error) {
         if (error instanceof InteractionRequiredAuthError) {
           // Token requires interaction — don't auto-redirect; let the user click the button.
           setIsProcessing(false);
-        } else if (
-          error instanceof Error &&
-          error.message === LOGIN_ERROR_MESSAGE
-        ) {
-          handleFailure(LOGIN_ERROR_MESSAGE, error);
         } else {
           handleFailure(RETRY_ERROR_MESSAGE, error);
         }

--- a/src/lib/accessError.ts
+++ b/src/lib/accessError.ts
@@ -1,6 +1,6 @@
 export class AccessError extends Error {
   status: number;
-  code: 'FORBIDDEN' | 'SERVICE_UNAVAILABLE';
+  code: 'SERVICE_UNAVAILABLE';
 
   constructor({
     message,
@@ -9,7 +9,7 @@ export class AccessError extends Error {
   }: {
     message: string;
     status: number;
-    code: 'FORBIDDEN' | 'SERVICE_UNAVAILABLE';
+    code: 'SERVICE_UNAVAILABLE';
   }) {
     super(message);
     this.name = 'AccessError';

--- a/src/lib/server/session.ts
+++ b/src/lib/server/session.ts
@@ -38,6 +38,10 @@ export type SessionResult =
   | UnauthenticatedSession
   | UnavailableSession;
 
+export type AdminAccessResult =
+  | { state: 'allowed'; session: AuthenticatedSession }
+  | { state: 'forbidden'; session: AuthenticatedSession };
+
 const parseUser = (body: unknown) => {
   const parsed = userInfoResponseSchema.safeParse(body);
 
@@ -141,16 +145,14 @@ export const requireUser = async (
   });
 };
 
-export const requireAdmin = async (cookie?: RequestCookies) => {
+export const getAdminAccess = async (
+  cookie?: RequestCookies
+): Promise<AdminAccessResult> => {
   const session = await requireUser(cookie);
 
   if (session.user.role !== 'ADMINISTRATOR') {
-    throw new AccessError({
-      message: 'Administrator role is required',
-      status: 403,
-      code: 'FORBIDDEN',
-    });
+    return { state: 'forbidden', session };
   }
 
-  return session;
+  return { state: 'allowed', session };
 };

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AccessError } from '@/lib/accessError';
 import { BackendError } from '@/lib/server/backend';
 import { normalizeRedirectTarget } from '@/lib/redirect';
 
@@ -141,7 +140,36 @@ describe('server session helpers', () => {
     );
   });
 
-  it('認証済みでも管理者でない場合は forbidden を送出する', async () => {
+  it('管理者の場合は admin access allowed を返す', async () => {
+    getCachedTokenMock.mockResolvedValue('token-123');
+    backendGetMock.mockResolvedValue({
+      data: {
+        id: 'user-id',
+        name: 'Alice',
+        role: 'ADMINISTRATOR',
+      },
+      response: new Response(null, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
+    const { getAdminAccess } = await loadSessionModule();
+
+    await expect(getAdminAccess()).resolves.toEqual({
+      state: 'allowed',
+      session: {
+        state: 'authenticated',
+        token: 'token-123',
+        user: {
+          id: 'user-id',
+          name: 'Alice',
+          role: 'ADMINISTRATOR',
+        },
+      },
+    });
+  });
+
+  it('認証済みでも管理者でない場合は forbidden を返す', async () => {
     getCachedTokenMock.mockResolvedValue('token-123');
     backendGetMock.mockResolvedValue({
       data: {
@@ -154,15 +182,20 @@ describe('server session helpers', () => {
         headers: { 'Content-Type': 'application/json' },
       }),
     });
-    const { requireAdmin } = await loadSessionModule();
+    const { getAdminAccess } = await loadSessionModule();
 
-    await expect(requireAdmin()).rejects.toEqual(
-      expect.objectContaining<Partial<AccessError>>({
-        name: 'AccessError',
-        status: 403,
-        code: 'FORBIDDEN',
-      })
-    );
+    await expect(getAdminAccess()).resolves.toEqual({
+      state: 'forbidden',
+      session: {
+        state: 'authenticated',
+        token: 'token-123',
+        user: {
+          id: 'user-id',
+          name: 'Alice',
+          role: 'STANDARD_USER',
+        },
+      },
+    });
   });
 
   it('バックエンドに到達できない場合は unavailable を返す', async () => {


### PR DESCRIPTION
## 概要
- 管理者権限不足を `AccessError` の throw ではなく `getAdminAccess()` の戻り値で表現し、admin 画面では通常の render 経路で 403 ダイアログを表示するようにしました。
- Minecraft アカウント未連携のログイン失敗も例外ではなく結果値で扱い、想定内のユーザー状態を error boundary や `console.error` に流さないようにしました。
- `AccessError` は backend unavailable など保護ルート表示不能の異常系用途に絞り、session helper の unit test を更新しました。

## 確認事項
- `pnpm test:unit` で session helper の admin allowed / forbidden を含む unit test が通ることを確認しました。
- `pnpm lint`、`pnpm type-check`、`pnpm fmt` が通ることを確認しました。
- commit 時の pre-commit hook で lint / type-check / fmt が通り、push 時の pre-push hook で unit test が通ることを確認しました。

🤖 Generated with Codex