### PR TITLE
フォーム送信時の空値を API 互換に正規化する

### DIFF
--- a/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(authed)/admin/forms/_lib/formEditorMappers.ts
@@ -17,6 +17,20 @@ type FormUpdateBody =
 const toVisibility = (value: string | null | undefined): FormVisibility =>
   value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC';
 
+const toNullableNonEmptyString = (
+  value: string | null | undefined
+): string | null => {
+  const trimmed = value?.trim();
+
+  return trimmed || null;
+};
+
+const toTemplateKey = (value: string, index: number): string => {
+  const trimmed = value.trim();
+
+  return trimmed === '' ? `question_${index + 1}` : trimmed;
+};
+
 const toEditorQuestion = (
   question: GetFormResponse['questions'][number]
 ): FormEditorQuestion => ({
@@ -38,11 +52,11 @@ const toApiQuestion = (
   index: number
 ): ApiComponents['schemas']['QuestionSchema'] => {
   const base: ApiComponents['schemas']['QuestionDefinitionSchema'] = {
-    title: question.title,
-    description: question.description,
+    title: question.title.trim(),
+    description: toNullableNonEmptyString(question.description),
     is_required: question.is_required,
     position: index,
-    template_key: question.template_key,
+    template_key: toTemplateKey(question.template_key, index),
     id: question.id ?? null,
   };
 
@@ -57,7 +71,7 @@ const toApiQuestion = (
     ...base,
     question_type: question.question_type,
     choices: question.choices.map((choice, choiceIndex) => ({
-      label: choice.choice,
+      label: choice.choice.trim(),
       position: choiceIndex,
     })),
   };
@@ -92,7 +106,7 @@ export const fromFormResponseToEditorValues = (
 };
 
 export const toCreateFormBody = (data: FormEditorValues): CreateFormBody => ({
-  title: data.title,
+  title: data.title.trim(),
   description: data.description,
   questions: data.questions.map((question, index) =>
     toApiQuestion(question, index)
@@ -107,12 +121,12 @@ export const toFormUpdateBody = (
   const endAt = data.settings.response_period.end_at;
 
   const body: FormUpdateBody = {
-    title: data.title,
+    title: data.title.trim(),
     description: data.description,
     labels: data.labels.map((label) => label.id),
     settings: {
       visibility: data.settings.visibility,
-      webhook_url: data.settings.webhook_url,
+      webhook_url: toNullableNonEmptyString(data.settings.webhook_url),
       answer_settings: {
         default_answer_title:
           data.settings.default_answer_title === ''

--- a/src/app/(authed)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(authed)/admin/forms/_schema/formEditorSchema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+const requiredStringSchema = z.string().trim().min(1, '入力してください。');
+
 export const questionTypeSchema = z.enum([
   'Text',
   'SingleChoice',
@@ -7,7 +9,7 @@ export const questionTypeSchema = z.enum([
 ]);
 
 const choiceSchema = z.object({
-  choice: z.string(),
+  choice: requiredStringSchema,
 });
 
 export const visibilitySchema = z.enum(['PUBLIC', 'PRIVATE']);
@@ -17,21 +19,33 @@ const formLabelSchema = z.object({
   name: z.string(),
 });
 
-export const formEditorQuestionSchema = z.object({
-  id: z.string().nullable().optional(),
-  title: z.string(),
-  description: z.string(),
-  question_type: questionTypeSchema,
-  choices: choiceSchema.array(),
-  is_required: z.boolean(),
-  position: z.number().int().gte(0),
-  template_key: z.string(),
-});
+export const formEditorQuestionSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    title: requiredStringSchema,
+    description: z.string(),
+    question_type: questionTypeSchema,
+    choices: choiceSchema.array(),
+    is_required: z.boolean(),
+    position: z.number().int().gte(0),
+    template_key: z.string(),
+  })
+  .superRefine((question, context) => {
+    if (question.question_type !== 'Text' && question.choices.length === 0) {
+      context.addIssue({
+        code: 'custom',
+        path: ['choices'],
+        message: '選択肢を1つ以上追加してください。',
+      });
+    }
+  });
 
 export const formEditorSchema = z.object({
-  title: z.string(),
-  description: z.string(),
-  questions: formEditorQuestionSchema.array(),
+  title: requiredStringSchema,
+  description: requiredStringSchema,
+  questions: formEditorQuestionSchema
+    .array()
+    .min(1, '質問を1つ以上追加してください。'),
   labels: formLabelSchema.array(),
   settings: z.object({
     has_response_period: z.boolean(),

--- a/src/app/(authed)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(authed)/admin/forms/create/_components/FormCreateForm.tsx
@@ -9,6 +9,7 @@ import {
   Container,
   Stack,
 } from '@mui/material';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import type { GetFormLabelsResponse } from '@/lib/api-types';
 import FormEditorLayout from '../../_components/FormEditorLayout';
@@ -16,6 +17,7 @@ import FormSettings from '../../_components/FormSettings';
 import QuestionEditor from '../../_components/QuestionEditor';
 import QuestionList from '../../_components/QuestionList';
 import type { FormEditorValues } from '../../_schema/formEditorSchema';
+import { formEditorSchema } from '../../_schema/formEditorSchema';
 import {
   createEmptyFormEditorQuestion,
   createEmptyFormEditorValues,
@@ -30,6 +32,7 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
     formState: { errors, isSubmitting },
   } = useForm<FormEditorValues>({
     mode: 'onSubmit',
+    resolver: zodResolver(formEditorSchema),
     defaultValues: createEmptyFormEditorValues(),
   });
 
@@ -45,6 +48,10 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
   });
 
   const { createForm, isSubmitted, submitError } = useCreateForm();
+  const questionListError =
+    typeof errors.questions?.message === 'string'
+      ? errors.questions.message
+      : null;
 
   const addQuestion = () => {
     append(createEmptyFormEditorQuestion());
@@ -81,6 +88,9 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
           <Alert severity="error">
             {errors.root?.message ?? submitError?.message}
           </Alert>
+        )}
+        {questionListError && (
+          <Alert severity="error">{questionListError}</Alert>
         )}
         {isSubmitted && (
           <Alert severity="success">フォームを作成しました。</Alert>

--- a/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(authed)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -9,6 +9,7 @@ import {
   Container,
   Stack,
 } from '@mui/material';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import type { GetFormLabelsResponse, GetFormResponse } from '@/lib/api-types';
 import FormEditorLayout from '../../../_components/FormEditorLayout';
@@ -18,6 +19,7 @@ import QuestionList from '../../../_components/QuestionList';
 import { createEmptyFormEditorQuestion } from '../../../_lib/formEditorDefaults';
 import { fromFormResponseToEditorValues } from '../../../_lib/formRequestBuilders';
 import type { FormEditorValues } from '../../../_schema/formEditorSchema';
+import { formEditorSchema } from '../../../_schema/formEditorSchema';
 import { useUpdateFormSubmission } from '../../../_hooks/useUpdateFormSubmission';
 
 const FormEditForm = (props: {
@@ -33,6 +35,7 @@ const FormEditForm = (props: {
   } = useForm<FormEditorValues>({
     mode: 'onSubmit',
     reValidateMode: 'onBlur',
+    resolver: zodResolver(formEditorSchema),
     defaultValues: fromFormResponseToEditorValues(props.form),
   });
 
@@ -49,6 +52,10 @@ const FormEditForm = (props: {
   });
 
   const { submit, isSubmitted } = useUpdateFormSubmission(props.form.id);
+  const questionListError =
+    typeof errors.questions?.message === 'string'
+      ? errors.questions.message
+      : null;
 
   const onSubmit = async (data: FormEditorValues) => {
     const result = await submit(data);
@@ -91,6 +98,9 @@ const FormEditForm = (props: {
             />
           </Card>
           {errors.root && <Alert severity="error">{errors.root.message}</Alert>}
+          {questionListError && (
+            <Alert severity="error">{questionListError}</Alert>
+          )}
           {isSubmitted && (
             <Alert severity="success">フォームの編集に成功しました。</Alert>
           )}

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCreateFormBody,
+  toFormUpdateBody,
+} from '@/app/(authed)/admin/forms/_lib/formRequestBuilders';
+import type { FormEditorValues } from '@/app/(authed)/admin/forms/_schema/formEditorSchema';
+
+const baseValues: FormEditorValues = {
+  title: ' Form title ',
+  description: 'Form description',
+  labels: [],
+  questions: [
+    {
+      id: null,
+      title: ' Question title ',
+      description: '',
+      question_type: 'Text',
+      choices: [],
+      is_required: false,
+      position: 0,
+      template_key: '',
+    },
+  ],
+  settings: {
+    has_response_period: false,
+    response_period: {
+      start_at: null,
+      end_at: null,
+    },
+    webhook_url: null,
+    default_answer_title: null,
+    visibility: 'PUBLIC',
+    answer_visibility: 'PUBLIC',
+  },
+};
+
+describe('form request builders', () => {
+  it('空のテンプレートキーと質問説明を API が受け付ける値へ正規化する', () => {
+    const body = toCreateFormBody(baseValues);
+
+    expect(body.title).toBe('Form title');
+    expect(body.questions[0]).toMatchObject({
+      title: 'Question title',
+      description: null,
+      question_type: 'Text',
+      template_key: 'question_1',
+    });
+  });
+
+  it('フォーム更新時も質問定義の空値を正規化する', () => {
+    const body = toFormUpdateBody(baseValues, true);
+
+    expect(body.questions?.[0]).toMatchObject({
+      description: null,
+      template_key: 'question_1',
+    });
+  });
+
+  it('空の Webhook URL は null に正規化する', () => {
+    const body = toFormUpdateBody(
+      {
+        ...baseValues,
+        settings: {
+          ...baseValues.settings,
+          webhook_url: '',
+        },
+      },
+      false
+    );
+
+    expect(body.settings?.webhook_url).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
- フォーム作成・編集で空のテンプレートキー、質問説明、Webhook URL などが backend の NonEmptyString デシリアライズで 422 にならないように送信値を正規化しました。
- 作成・編集フォームに Zod resolver を接続し、必須項目や選択式質問の選択肢不足を API 送信前に検出するようにしました。
- リクエスト組み立ての正規化挙動をユニットテストで固定しました。

## 確認事項
- pre-commit で lint / type-check / fmt が通ることを確認しました。
- pre-push で unit-test が通り、既存テストを含む 12 件が成功することを確認しました。
- 個別に `pnpm exec vitest run tests/unit/formEditorMappers.test.ts`、`pnpm type-check`、`pnpm lint` が成功することを確認しました。

## 補足
- backend 側は `webhook_url: null` と未指定を同じ扱いにしているように見えるため、既存 Webhook の明示的なクリア挙動が必要な場合は backend 側で null と omitted を区別する追加対応が必要です。

🤖 Generated with Codex