### PR TITLE
feat: 回答投稿制限の管理 UI を実装する

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@mui/material": "^9.0.0",
     "@mui/material-nextjs": "^9.0.0",
     "@mui/x-data-grid": "^9.0.0",
+    "@mui/x-date-pickers": "^9.6.0",
     "browserslist": "^4.23.0",
     "dayjs": "^1.11.9",
     "fp-ts": "^2.16.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@mui/x-data-grid':
         specifier: ^9.0.0
         version: 9.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/x-date-pickers':
+        specifier: ^9.6.0
+        version: 9.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.21)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       browserslist:
         specifier: ^4.23.0
         version: 4.28.2
@@ -894,6 +897,43 @@ packages:
       '@emotion/react':
         optional: true
       '@emotion/styled':
+        optional: true
+
+  '@mui/x-date-pickers@9.6.0':
+    resolution: {integrity: sha512-Cdk0qkdfxjQtDAnrQdrkCCGyXifjmqzzoDnnoPPxLz5915BWW33cAG9RcZFUAupRaUuh3i6QE8C5oUA9Mrx+1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
         optional: true
 
   '@mui/x-internals@9.6.0':
@@ -4482,6 +4522,26 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-date-pickers@9.6.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@mui/material@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(dayjs@1.11.21)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/system': 9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@mui/x-internals': 9.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      dayjs: 1.11.21
     transitivePeerDependencies:
       - '@types/react'
 

--- a/src/app/(protected)/admin/users/_components/RestrictionCell.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionCell.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Button, Tooltip } from '@mui/material';
+import { useState } from 'react';
+import RestrictionDialog from './RestrictionDialog';
+
+const RestrictionCell = ({
+  userId,
+  userName,
+  disabled,
+}: {
+  userId: string;
+  userName: string;
+  disabled: boolean;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Tooltip title={disabled ? '自分自身は制限できません' : ''} placement="top">
+      <span>
+        <Button
+          variant="outlined"
+          size="small"
+          color="error"
+          disabled={disabled}
+          onClick={() => setOpen(true)}
+        >
+          制限を管理
+        </Button>
+        <RestrictionDialog
+          uuid={userId}
+          userName={userName}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      </span>
+    </Tooltip>
+  );
+};
+
+export default RestrictionCell;

--- a/src/app/(protected)/admin/users/_components/RestrictionDialog.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialog.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Dialog, DialogTitle } from '@mui/material';
+import RestrictionDialogBody from './RestrictionDialogBody';
+
+const RestrictionDialog = ({
+  uuid,
+  userName,
+  open,
+  onClose,
+}: {
+  uuid: string;
+  userName: string;
+  open: boolean;
+  onClose: () => void;
+}) => (
+  <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <DialogTitle>回答投稿制限: {userName}</DialogTitle>
+    {/* open のときだけ body を mount し、GET を開いたときだけ走らせる。 */}
+    {open && <RestrictionDialogBody uuid={uuid} onClose={onClose} />}
+  </Dialog>
+);
+
+export default RestrictionDialog;

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -89,13 +89,13 @@ const RestrictionDialogBody = ({
           <Stack spacing={2}>
             {submitError && <Alert severity="error">{submitError}</Alert>}
             <Stack spacing={1}>
-              <Typography>
+              <Typography component="p">
                 <strong>理由:</strong> {data.reason}
               </Typography>
-              <Typography>
+              <Typography component="p">
                 <strong>制限日時:</strong> {formatString(data.restricted_at)}
               </Typography>
-              <Typography>
+              <Typography component="p">
                 <strong>解除予定:</strong>{' '}
                 {data.expires_at ? formatString(data.expires_at) : '無期限'}
               </Typography>

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  DialogActions,
+  DialogContent,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { formatString } from '@/generic/DateFormatter';
+import { useAnswerSubmitterRestrictionActions } from '@/hooks/useAnswerSubmitterRestrictionActions';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { restrictionFormSchema, toRestrictionRequest } from './restrictionForm';
+import type {
+  RestrictionFormInput,
+  RestrictionFormValues,
+} from './restrictionForm';
+
+const RestrictionDialogBody = ({
+  uuid,
+  onClose,
+}: {
+  uuid: string;
+  onClose: () => void;
+}) => {
+  const { data, error, isLoading, mutate } = useApiQuery(
+    '/api/v1/users/{uuid}/answer-submitter-restriction',
+    { path: { uuid } }
+  );
+
+  const { restrictUser, unrestrictUser } =
+    useAnswerSubmitterRestrictionActions();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<RestrictionFormInput, unknown, RestrictionFormValues>({
+    resolver: zodResolver(restrictionFormSchema),
+    defaultValues: { reason: '', expiresAt: null },
+  });
+
+  if (isLoading) {
+    return (
+      <DialogContent>
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      </DialogContent>
+    );
+  }
+
+  if (error) {
+    return (
+      <DialogContent>
+        <Alert severity="error">制限状態の取得に失敗しました。</Alert>
+      </DialogContent>
+    );
+  }
+
+  // 既に制限中: 現在の内容を表示し、解除のみ行える。
+  if (data) {
+    const onUnrestrict = async () => {
+      const result = await unrestrictUser(uuid);
+      if (result.success) {
+        await mutate();
+        onClose();
+      } else {
+        alert('制限の解除に失敗しました。');
+      }
+    };
+
+    return (
+      <>
+        <DialogContent>
+          <Stack spacing={1}>
+            <Typography>
+              <strong>理由:</strong> {data.reason}
+            </Typography>
+            <Typography>
+              <strong>制限日時:</strong> {formatString(data.restricted_at)}
+            </Typography>
+            <Typography>
+              <strong>解除予定:</strong>{' '}
+              {data.expires_at ? formatString(data.expires_at) : '無期限'}
+            </Typography>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>閉じる</Button>
+          <Button color="error" variant="contained" onClick={onUnrestrict}>
+            制限を解除する
+          </Button>
+        </DialogActions>
+      </>
+    );
+  }
+
+  // 未制限: 制限を付与するフォームを表示する。
+  const onRestrict = async (values: RestrictionFormValues) => {
+    const result = await restrictUser(uuid, toRestrictionRequest(values));
+    if (result.success) {
+      await mutate();
+      onClose();
+    } else {
+      alert('制限の付与に失敗しました。');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onRestrict)}>
+      <DialogContent>
+        <Stack spacing={2}>
+          <Controller
+            name="reason"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="理由"
+                required
+                multiline
+                minRows={2}
+                fullWidth
+                error={Boolean(fieldState.error)}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="expiresAt"
+            control={control}
+            render={({ field }) => (
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DateTimePicker
+                  label="解除予定日時（任意・未指定で無期限）"
+                  value={field.value ?? null}
+                  onChange={field.onChange}
+                  slotProps={{
+                    field: { clearable: true },
+                    textField: { fullWidth: true },
+                  }}
+                />
+              </LocalizationProvider>
+            )}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isSubmitting}>
+          キャンセル
+        </Button>
+        <Button
+          type="submit"
+          color="error"
+          variant="contained"
+          disabled={isSubmitting}
+        >
+          制限する
+        </Button>
+      </DialogActions>
+    </form>
+  );
+};
+
+export default RestrictionDialogBody;

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -15,6 +15,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { formatString } from '@/generic/DateFormatter';
 import { useAnswerSubmitterRestrictionActions } from '@/hooks/useAnswerSubmitterRestrictionActions';
@@ -32,6 +33,8 @@ const RestrictionDialogBody = ({
   uuid: string;
   onClose: () => void;
 }) => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const { data, error, isLoading, mutate } = useApiQuery(
     '/api/v1/users/{uuid}/answer-submitter-restriction',
     { path: { uuid } }
@@ -70,29 +73,33 @@ const RestrictionDialogBody = ({
   // 既に制限中: 現在の内容を表示し、解除のみ行える。
   if (data) {
     const onUnrestrict = async () => {
+      setSubmitError(null);
       const result = await unrestrictUser(uuid);
       if (result.success) {
         await mutate();
         onClose();
       } else {
-        alert('制限の解除に失敗しました。');
+        setSubmitError('制限の解除に失敗しました。');
       }
     };
 
     return (
       <>
         <DialogContent>
-          <Stack spacing={1}>
-            <Typography>
-              <strong>理由:</strong> {data.reason}
-            </Typography>
-            <Typography>
-              <strong>制限日時:</strong> {formatString(data.restricted_at)}
-            </Typography>
-            <Typography>
-              <strong>解除予定:</strong>{' '}
-              {data.expires_at ? formatString(data.expires_at) : '無期限'}
-            </Typography>
+          <Stack spacing={2}>
+            {submitError && <Alert severity="error">{submitError}</Alert>}
+            <Stack spacing={1}>
+              <Typography>
+                <strong>理由:</strong> {data.reason}
+              </Typography>
+              <Typography>
+                <strong>制限日時:</strong> {formatString(data.restricted_at)}
+              </Typography>
+              <Typography>
+                <strong>解除予定:</strong>{' '}
+                {data.expires_at ? formatString(data.expires_at) : '無期限'}
+              </Typography>
+            </Stack>
           </Stack>
         </DialogContent>
         <DialogActions>
@@ -107,68 +114,74 @@ const RestrictionDialogBody = ({
 
   // 未制限: 制限を付与するフォームを表示する。
   const onRestrict = async (values: RestrictionFormValues) => {
+    setSubmitError(null);
     const result = await restrictUser(uuid, toRestrictionRequest(values));
     if (result.success) {
       await mutate();
       onClose();
     } else {
-      alert('制限の付与に失敗しました。');
+      setSubmitError('制限の付与に失敗しました。');
     }
   };
 
   return (
-    <form onSubmit={handleSubmit(onRestrict)}>
-      <DialogContent>
-        <Stack spacing={2}>
-          <Controller
-            name="reason"
-            control={control}
-            render={({ field, fieldState }) => (
-              <TextField
-                {...field}
-                label="理由"
-                required
-                multiline
-                minRows={2}
-                fullWidth
-                error={Boolean(fieldState.error)}
-                helperText={fieldState.error?.message}
-              />
-            )}
-          />
-          <Controller
-            name="expiresAt"
-            control={control}
-            render={({ field }) => (
-              <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <form onSubmit={handleSubmit(onRestrict)}>
+        <DialogContent>
+          <Stack spacing={2}>
+            {submitError && <Alert severity="error">{submitError}</Alert>}
+            <Controller
+              name="reason"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label="理由"
+                  required
+                  multiline
+                  minRows={2}
+                  fullWidth
+                  error={Boolean(fieldState.error)}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+            <Controller
+              name="expiresAt"
+              control={control}
+              render={({ field, fieldState }) => (
                 <DateTimePicker
                   label="解除予定日時（任意・未指定で無期限）"
                   value={field.value ?? null}
                   onChange={field.onChange}
                   slotProps={{
                     field: { clearable: true },
-                    textField: { fullWidth: true },
+                    textField: {
+                      fullWidth: true,
+                      error: Boolean(fieldState.error),
+                      helperText: fieldState.error?.message,
+                    },
                   }}
                 />
-              </LocalizationProvider>
-            )}
-          />
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={isSubmitting}>
-          キャンセル
-        </Button>
-        <Button
-          type="submit"
-          color="error"
-          variant="contained"
-          disabled={isSubmitting}
-        >
-          制限する
-        </Button>
-      </DialogActions>
-    </form>
+              )}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isSubmitting}>
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            color="error"
+            variant="contained"
+            disabled={isSubmitting}
+          >
+            制限する
+          </Button>
+        </DialogActions>
+      </form>
+    </LocalizationProvider>
   );
 };
 

--- a/src/app/(protected)/admin/users/_components/UserList.tsx
+++ b/src/app/(protected)/admin/users/_components/UserList.tsx
@@ -29,6 +29,7 @@ const UserList = ({
             <TableCell>UUID</TableCell>
             <TableCell>現在の権限</TableCell>
             <TableCell>権限の変更</TableCell>
+            <TableCell>回答投稿制限</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/src/app/(protected)/admin/users/_components/UserRow.tsx
+++ b/src/app/(protected)/admin/users/_components/UserRow.tsx
@@ -1,4 +1,5 @@
 import { TableCell, TableRow } from '@mui/material';
+import RestrictionCell from './RestrictionCell';
 import RoleChip from './RoleChip';
 import RoleSelectCell from './RoleSelectCell';
 import UserIdCell from './UserIdCell';
@@ -26,6 +27,13 @@ const UserRow = ({
       <RoleSelectCell
         userId={user.id}
         currentRole={user.role}
+        disabled={isSelf}
+      />
+    </TableCell>
+    <TableCell>
+      <RestrictionCell
+        userId={user.id}
+        userName={user.name}
         disabled={isSelf}
       />
     </TableCell>

--- a/src/app/(protected)/admin/users/_components/restrictionForm.ts
+++ b/src/app/(protected)/admin/users/_components/restrictionForm.ts
@@ -1,3 +1,4 @@
+import { isDayjs } from 'dayjs';
 import { z } from 'zod';
 import type { Dayjs } from 'dayjs';
 import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
@@ -5,7 +6,12 @@ import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
 export const restrictionFormSchema = z.object({
   reason: z.string().trim().min(1, '理由を入力してください'),
   // 有効期限は任意。未指定なら無期限の制限になる。
-  expiresAt: z.custom<Dayjs>().nullable(),
+  // 指定時は有効な Dayjs であることを保証し、Invalid Date が API に渡らないようにする。
+  expiresAt: z
+    .custom<Dayjs>((val) => isDayjs(val) && val.isValid(), {
+      message: '有効な日時を入力してください',
+    })
+    .nullable(),
 });
 
 export type RestrictionFormInput = z.input<typeof restrictionFormSchema>;

--- a/src/app/(protected)/admin/users/_components/restrictionForm.ts
+++ b/src/app/(protected)/admin/users/_components/restrictionForm.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import type { Dayjs } from 'dayjs';
+import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
+
+export const restrictionFormSchema = z.object({
+  reason: z.string().trim().min(1, '理由を入力してください'),
+  // 有効期限は任意。未指定なら無期限の制限になる。
+  expiresAt: z.custom<Dayjs>().nullable(),
+});
+
+export type RestrictionFormInput = z.input<typeof restrictionFormSchema>;
+export type RestrictionFormValues = z.output<typeof restrictionFormSchema>;
+
+/**
+ * フォーム入力を PUT リクエストの body に変換する。
+ * expires_at は未指定なら送らず、指定時のみ ISO 8601（タイムゾーン付き）にする。
+ */
+export const toRestrictionRequest = (
+  values: RestrictionFormValues
+): PutAnswerSubmitterRestrictionSchema => ({
+  reason: values.reason.trim(),
+  ...(values.expiresAt ? { expires_at: values.expiresAt.format() } : {}),
+});

--- a/src/hooks/useAnswerSubmitterRestrictionActions.ts
+++ b/src/hooks/useAnswerSubmitterRestrictionActions.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { proxyClient } from '@/lib/proxyClient';
+import { handleMutationResponse } from '@/hooks/useApiMutation';
+import type { MutationResult } from '@/hooks/useApiMutation';
+import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
+
+export const useAnswerSubmitterRestrictionActions = () => {
+  const restrictUser = async (
+    uuid: string,
+    body: PutAnswerSubmitterRestrictionSchema
+  ): Promise<MutationResult<unknown>> => {
+    const { data, error, response } = await proxyClient.PUT(
+      '/api/v1/users/{uuid}/answer-submitter-restriction',
+      {
+        params: { path: { uuid } },
+        body,
+      }
+    );
+    return handleMutationResponse(response, data, error);
+  };
+
+  const unrestrictUser = async (
+    uuid: string
+  ): Promise<MutationResult<unknown>> => {
+    const { data, error, response } = await proxyClient.DELETE(
+      '/api/v1/users/{uuid}/answer-submitter-restriction',
+      {
+        params: { path: { uuid } },
+      }
+    );
+    return handleMutationResponse(response, data, error);
+  };
+
+  return { restrictUser, unrestrictUser };
+};

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -12,6 +12,7 @@ export type {
   CreateFormSchema,
   GetAnswerLabelsResponse,
   GetAnswerResponse,
+  GetAnswerSubmitterRestrictionResponse,
   GetAnswersResponse,
   GetFormAnswersResponse,
   GetFormLabelsResponse,
@@ -24,6 +25,7 @@ export type {
   GetQuestionsResponse,
   GetUserListResponse,
   GetUsersResponse,
+  PutAnswerSubmitterRestrictionSchema,
   SearchResponse,
   UpdateNotificationSettingsSchema,
 } from '@/lib/api/types';

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -33,6 +33,10 @@ export type GetUserResponse =
   ApiPaths['/api/v1/users/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type GetUserListResponse =
   ApiPaths['/api/v1/users']['get']['responses'][200]['content']['application/json'];
+export type GetAnswerSubmitterRestrictionResponse =
+  ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['get']['responses'][200]['content']['application/json'];
+export type PutAnswerSubmitterRestrictionSchema =
+  ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['put']['requestBody']['content']['application/json'];
 export type SearchResponse =
   ApiPaths['/api/v1/search']['get']['responses'][200]['content']['application/json'];
 export type GetNotificationSettingsResponse =

--- a/tests/unit/restrictionForm.test.ts
+++ b/tests/unit/restrictionForm.test.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import {
+  restrictionFormSchema,
+  toRestrictionRequest,
+} from '@/app/(protected)/admin/users/_components/restrictionForm';
+
+describe('restrictionFormSchema', () => {
+  it('空の理由は弾く', () => {
+    const result = restrictionFormSchema.safeParse({
+      reason: '   ',
+      expiresAt: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('理由があれば通る', () => {
+    const result = restrictionFormSchema.safeParse({
+      reason: '不適切な回答のため',
+      expiresAt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('toRestrictionRequest', () => {
+  it('expiresAt 未指定なら expires_at を含めない', () => {
+    const body = toRestrictionRequest({
+      reason: ' 理由 ',
+      expiresAt: null,
+    });
+    expect(body).toEqual({ reason: '理由' });
+    expect('expires_at' in body).toBe(false);
+  });
+
+  it('expiresAt 指定時は ISO 8601（オフセット付き）で送る', () => {
+    const expiresAt = dayjs('2026-07-01T12:34:00+09:00');
+    const body = toRestrictionRequest({
+      reason: '理由',
+      expiresAt,
+    });
+    expect(body.reason).toBe('理由');
+    expect(body.expires_at).toBe(expiresAt.format());
+  });
+});

--- a/tests/unit/restrictionForm.test.ts
+++ b/tests/unit/restrictionForm.test.ts
@@ -21,6 +21,14 @@ describe('restrictionFormSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('無効な日時は弾く', () => {
+    const result = restrictionFormSchema.safeParse({
+      reason: '不適切な回答のため',
+      expiresAt: dayjs('invalid-date-string'),
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('toRestrictionRequest', () => {


### PR DESCRIPTION
## 概要
- 管理画面のユーザー一覧から、対象ユーザーの回答投稿制限を付与・解除できる UI を追加（Issue #746）
- 各ユーザー行に「制限を管理」ボタンとダイアログを追加。ダイアログを開いたときだけ現在の制限状態（`GET .../answer-submitter-restriction`）を取得する
- 付与時は理由（必須）と解除予定日時（任意・未指定で無期限）を入力（`PUT`）。制限中ユーザーには現在の制限内容を表示して解除（`DELETE`）できる
- 自分自身への制限は権限変更と同様に不可（行を disable）

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm fmt` を実行し、いずれも通過（pre-commit hook でも実行・通過）
- `pnpm test:unit` 実行、17 件パス。フォーム入力 → リクエスト body 変換（`toRestrictionRequest`）と理由必須バリデーションを単体テストで確認
- `pnpm codegen:check` で生成物（`src/generated`）に差分がないことを確認
- ブラウザでの実画面の動作確認は未実施。レビューでは、ダイアログの付与/解除フローと解除予定日時の送信値（ISO 8601・オフセット付き）を中心に見てほしい

## 補足
- 日時入力のため `@mui/x-date-pickers` を新規導入し、ダイアログ内に `LocalizationProvider`（AdapterDayjs）をローカルに設置している

🤖 Generated with Claude Code