### PR TITLE
未ログインでも仮回答可能なフォームをトップページに表示する

### DIFF
--- a/src/app/(public)/_components/LandingContent.tsx
+++ b/src/app/(public)/_components/LandingContent.tsx
@@ -11,6 +11,8 @@ import {
   Typography,
 } from '@mui/material';
 import { useLandingLogin } from './useLandingLogin';
+import { PublicFormList } from './PublicFormList';
+import type { GetFormsResponse } from '@/lib/api-types';
 
 const ErrorState = ({ errorMessage }: { errorMessage: string }) => (
   <Container maxWidth="sm" sx={{ py: 10 }}>
@@ -31,10 +33,11 @@ const ProcessingState = () => (
 
 type LandingViewProps = {
   onLogin: () => void;
+  publicForms: GetFormsResponse;
 };
 
-const LandingView = ({ onLogin }: LandingViewProps) => (
-  <Container maxWidth="sm" sx={{ py: { xs: 6, md: 10 } }}>
+const LandingView = ({ onLogin, publicForms }: LandingViewProps) => (
+  <Container maxWidth="md" sx={{ py: { xs: 6, md: 10 } }}>
     <Stack spacing={5} sx={{ alignItems: 'center', textAlign: 'center' }}>
       <Box>
         <Typography
@@ -54,10 +57,10 @@ const LandingView = ({ onLogin }: LandingViewProps) => (
 
       <Divider sx={{ width: '100%' }} />
 
-      <Box sx={{ width: '100%' }}>
+      <Box sx={{ width: '100%', maxWidth: 'sm' }}>
         <Alert severity="info" sx={{ mb: 3, textAlign: 'left' }}>
           <Typography variant="body2" component="div">
-            <strong>ご利用にはMinecraftアカウントが必要です</strong>
+            <strong>サインインするとすべての機能をご利用いただけます</strong>
             <br />
             整地鯖でプレイしたことのある、Minecraftアカウントに紐づいた
             Microsoftアカウントでサインインしてください。
@@ -73,22 +76,40 @@ const LandingView = ({ onLogin }: LandingViewProps) => (
           Microsoftアカウントでサインイン
         </Button>
       </Box>
+
+      {publicForms.length > 0 && (
+        <>
+          <Divider sx={{ width: '100%' }} />
+          <Box sx={{ width: '100%' }}>
+            <Typography
+              variant="h6"
+              component="h2"
+              sx={{ fontWeight: 700, mb: 3 }}
+            >
+              サインインなしで回答できるフォーム
+            </Typography>
+            <PublicFormList forms={publicForms} />
+          </Box>
+        </>
+      )}
     </Stack>
   </Container>
 );
 
-export const LandingContent = () => {
+type LandingContentProps = {
+  publicForms: GetFormsResponse;
+};
+
+export const LandingContent = ({ publicForms }: LandingContentProps) => {
   const { errorMessage, isProcessing, handleLogin } = useLandingLogin();
 
   if (errorMessage) {
     return <ErrorState errorMessage={errorMessage} />;
   }
 
-  // MS からのコールバック処理中（accounts が埋まり、Minecraft アクセストークン交換中）
-  // のときだけスピナーを表示。初回表示や戻り遷移時はランディングそのものを即出す。
   if (isProcessing) {
     return <ProcessingState />;
   }
 
-  return <LandingView onLogin={handleLogin} />;
+  return <LandingView onLogin={handleLogin} publicForms={publicForms} />;
 };

--- a/src/app/(public)/_components/PublicFormList.tsx
+++ b/src/app/(public)/_components/PublicFormList.tsx
@@ -15,6 +15,12 @@ const formatResponsePeriod = (startAt: string | null, endAt: string | null) => {
   if (startAt != null && endAt != null) {
     return `${formatString(startAt)} ~ ${formatString(endAt)}`;
   }
+  if (startAt != null) {
+    return `${formatString(startAt)} ~`;
+  }
+  if (endAt != null) {
+    return `~ ${formatString(endAt)}`;
+  }
   return '回答期限なし';
 };
 

--- a/src/app/(public)/_components/PublicFormList.tsx
+++ b/src/app/(public)/_components/PublicFormList.tsx
@@ -1,0 +1,83 @@
+import NextLink from 'next/link';
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  Grid,
+  Typography,
+} from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { formatString } from '@/generic/DateFormatter';
+import type { GetFormsResponse } from '@/lib/api-types';
+
+const formatResponsePeriod = (startAt: string | null, endAt: string | null) => {
+  if (startAt != null && endAt != null) {
+    return `${formatString(startAt)} ~ ${formatString(endAt)}`;
+  }
+  return '回答期限なし';
+};
+
+type FormItem = GetFormsResponse[number];
+
+const EachForm = ({ form }: { form: FormItem }) => {
+  const responsePeriod =
+    form.settings.answer_settings?.acceptance_period ?? null;
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+    >
+      <CardActionArea
+        component={NextLink}
+        href={`/forms/${form.id}`}
+        sx={{ height: '100%' }}
+      >
+        <CardContent sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" component="h3" gutterBottom>
+            {form.title}
+          </Typography>
+          <Chip
+            icon={<AccessTimeIcon />}
+            label={formatResponsePeriod(
+              responsePeriod?.start_at ?? null,
+              responsePeriod?.end_at ?? null
+            )}
+            size="small"
+            variant="outlined"
+            sx={{ mb: 1.5 }}
+          />
+          {form.description && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {form.description}
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};
+
+type Props = {
+  forms: GetFormsResponse;
+};
+
+export const PublicFormList = ({ forms }: Props) => (
+  <Grid container spacing={3}>
+    {forms.map((form) => (
+      <Grid size={{ xs: 12, sm: 6, md: 4 }} key={form.id}>
+        <EachForm form={form} />
+      </Grid>
+    ))}
+  </Grid>
+);

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,6 +1,17 @@
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/server/session';
+import { serverApiClient } from '@/lib/server/backend';
 import { LandingContent } from './_components/LandingContent';
+import type { GetFormsResponse } from '@/lib/api-types';
+
+const fetchPublicForms = async (): Promise<GetFormsResponse> => {
+  try {
+    const { data } = await serverApiClient.GET('/api/v1/forms');
+    return (data ?? []).filter((f) => f.settings.allow_temporary_answers);
+  } catch {
+    return [];
+  }
+};
 
 const LandingPage = async () => {
   const session = await getSession();
@@ -8,7 +19,9 @@ const LandingPage = async () => {
     redirect('/home');
   }
 
-  return <LandingContent />;
+  const publicForms = await fetchPublicForms();
+
+  return <LandingContent publicForms={publicForms} />;
 };
 
 export default LandingPage;

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -6,9 +6,14 @@ import type { GetFormsResponse } from '@/lib/api-types';
 
 const fetchPublicForms = async (): Promise<GetFormsResponse> => {
   try {
-    const { data } = await serverApiClient.GET('/api/v1/forms');
+    const { data, error } = await serverApiClient.GET('/api/v1/forms');
+    if (error) {
+      console.error('Failed to fetch public forms:', error);
+      return [];
+    }
     return (data ?? []).filter((f) => f.settings.allow_temporary_answers);
-  } catch {
+  } catch (err) {
+    console.error('Network error while fetching public forms:', err);
     return [];
   }
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,7 +23,7 @@ const isAnonymousAllowedApi = (request: NextRequest) => {
 
   if (
     request.method === 'GET' &&
-    /^\/api\/proxy\/api\/v1\/forms\/[^/]+$/.test(pathname)
+    /^\/api\/proxy\/api\/v1\/forms(\/[^/]+)?$/.test(pathname)
   ) {
     return true;
   }


### PR DESCRIPTION
## 概要
- トップページのメッセージを「ご利用にはMinecraftアカウントが必要です」から「サインインするとすべての機能をご利用いただけます」に変更し、ログイン必須の印象を緩和
- 未ログイン状態でもバックエンドからフォーム一覧を取得し、`allow_temporary_answers` が有効なフォームをトップページに一覧表示
- プロキシに `GET /api/v1/forms` の匿名アクセスを追加（既存の `GET /api/v1/forms/{id}` と同じパターン）

## 確認事項
- 型チェック (`pnpm type-check`)、lint (`pnpm lint`)、フォーマット (`pnpm fmt`)、ユニットテスト (`pnpm test:unit`) すべてパス
- バックエンド未接続のため、実際のフォーム一覧表示の動作確認は未実施。API 呼び出し失敗時は空配列にフォールバックするため、表示上の問題は発生しない
- ログイン済みユーザーは従来通り `/home` にリダイレクトされ、既存の動線に影響なし

## 補足
- フォーム一覧の API がバックエンド側で認証なしアクセスを許可していることが前提。未許可の場合でもフォールバックにより画面は正常に表示される

🤖 Generated with Claude Code