### PR TITLE
pnpm のビルド許可設定を workspace に移す

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,17 +49,6 @@
     "ts-pattern": "^5.6.2",
     "zod": "^4"
   },
-  "pnpm": {
-    "overrides": {
-      "minimatch": "^10.2.5"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook",
-      "sharp",
-      "unrs-resolver"
-    ]
-  },
   "devDependencies": {
     "@eslint/compat": "^2.0.1",
     "@eslint/js": "^9.39.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,12 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   # Renovate security update: next@16.1.7 || 16.2.3 || 16.2.6
   - next@16.1.7 || 16.2.3 || 16.2.6
+
+overrides:
+  minimatch: ^10.2.5
+
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## 概要
- `package.json` の `pnpm` フィールドが現在の pnpm で読まれなくなったため、設定を `pnpm-workspace.yaml` に移しました。
- `overrides` は `pnpm-workspace.yaml` のルートへ移し、`onlyBuiltDependencies` は `allowBuilds` に置き換えました。
- 依存関係や生成物は変更せず、pnpm の設定読み込みだけを更新しています。

## 確認事項
- `pnpm config list` で、対象の warning が出ないことと `overrides` が読まれていることを確認しました。
- `pnpm --version` で、同じ warning が出ないことを確認しました。
- `pnpm install --lockfile-only --offline --ignore-scripts` で、lockfile の更新が不要であることを確認しました。
- `pnpm dev` を短時間実行し、対象の warning が出ないことを確認しました。既存の Next.js dev server が動作中だったため、起動自体は既存プロセス検出で終了しています。
- pre-commit hook で `pnpm type-check` と `pnpm fmt` が通りました。
- pre-push hook で `pnpm test:unit` が通りました。

## 補足
- pnpm 10.34.3 では `allowBuilds` の許可設定が `pnpm config list` 上で `only-built-dependencies` として表示されますが、`package.json` の非推奨フィールド由来の warning は出なくなっています。

🤖 Generated with Codex
