### PR TITLE
認証済みユーザー provider を保護ルートへ移す

### DIFF
--- a/src/app/(protected)/(standard)/_components/MainMenu.tsx
+++ b/src/app/(protected)/(standard)/_components/MainMenu.tsx
@@ -14,7 +14,7 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import GavelIcon from '@mui/icons-material/Gavel';
 import CampaignIcon from '@mui/icons-material/Campaign';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import { useCurrentUser } from '@/app/_providers/themeMode';
+import { useCurrentUser } from '@/app/_providers/currentUser';
 
 const menuItems = [
   {

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,12 +1,19 @@
+import { AuthenticatedUserProvider } from '@/app/_providers/currentUser';
 import { requireUser } from '@/lib/server/session';
 import type { ReactNode } from 'react';
 
-// ログイン必須ルートのゲート。未ログインなら requireUser がログインへ誘導する。
-// <html>/<body> と provider は共有 root layout（src/app/layout.tsx）が持つ。
-const ProtectedLayout = async ({ children }: { children: ReactNode }) => {
-  await requireUser();
+export const dynamic = 'force-dynamic';
 
-  return <>{children}</>;
+// ログイン必須ルートのゲート。未ログインなら requireUser がログインへ誘導する。
+// root layout は全体共通の provider だけを持ち、認証済みユーザーはここで提供する。
+const ProtectedLayout = async ({ children }: { children: ReactNode }) => {
+  const session = await requireUser();
+
+  return (
+    <AuthenticatedUserProvider currentUser={session.user}>
+      {children}
+    </AuthenticatedUserProvider>
+  );
 };
 
 export default ProtectedLayout;

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -25,7 +25,7 @@ import Image from 'next/image';
 import NextLink from 'next/link';
 import { useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
-import { useOptionalCurrentUser } from '@/app/_providers/themeMode';
+import { useOptionalCurrentUser } from '@/app/_providers/currentUser';
 import { SigninButton } from './SigninButton';
 import { getMsalInstance } from './MsalProvider';
 import ThemeModeToggle from '@/app/_components/ThemeModeToggle';

--- a/src/app/_providers/currentUser.tsx
+++ b/src/app/_providers/currentUser.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { CurrentUser } from '@/lib/currentUser';
+import type { ReactNode } from 'react';
+
+const CurrentUserContext = createContext<CurrentUser | null>(null);
+
+export const AuthenticatedUserProvider = ({
+  children,
+  currentUser,
+}: {
+  children: ReactNode;
+  currentUser: CurrentUser;
+}) => (
+  <CurrentUserContext.Provider value={currentUser}>
+    {children}
+  </CurrentUserContext.Provider>
+);
+
+export const useCurrentUser = () => {
+  const currentUser = useContext(CurrentUserContext);
+
+  if (!currentUser) {
+    throw new Error(
+      'useCurrentUser must be used within AuthenticatedUserProvider'
+    );
+  }
+
+  return currentUser;
+};
+
+export const useOptionalCurrentUser = () => useContext(CurrentUserContext);

--- a/src/app/_providers/themeMode.tsx
+++ b/src/app/_providers/themeMode.tsx
@@ -12,7 +12,6 @@ import { SWRConfig } from 'swr';
 import { MsalProvider } from '@/app/_components/MsalProvider';
 import { fetcher } from '@/app/_swr/fetcher';
 import { getAuthedTheme, type ThemeMode } from './getAuthedTheme';
-import type { CurrentUser } from '@/lib/currentUser';
 import type { ReactNode } from 'react';
 
 const STORAGE_KEY = 'seichi-portal-theme-mode';
@@ -25,7 +24,6 @@ type ThemeModeContextValue = {
 };
 
 const ThemeModeContext = createContext<ThemeModeContextValue | null>(null);
-const CurrentUserContext = createContext<CurrentUser | null>(null);
 
 const subscribeThemeMode = (callback: () => void) => {
   const handleStorage = (event: StorageEvent) => {
@@ -54,12 +52,10 @@ const getThemeModeServerSnapshot = (): ThemeMode => 'light';
 
 export const AppProviders = ({
   children,
-  currentUser,
   msalClientId,
   msalRedirectUri,
 }: {
   children: ReactNode;
-  currentUser: CurrentUser | null;
   msalClientId: string;
   msalRedirectUri: string;
 }) => {
@@ -87,25 +83,20 @@ export const AppProviders = ({
 
   return (
     <AppRouterCacheProvider>
-      <CurrentUserContext.Provider value={currentUser}>
-        <ThemeModeContext.Provider value={value}>
-          <ThemeProvider theme={theme}>
-            <CssBaseline />
-            <SWRConfig
-              value={{
-                fetcher,
-              }}
-            >
-              <MsalProvider
-                clientId={msalClientId}
-                redirectUri={msalRedirectUri}
-              >
-                {children}
-              </MsalProvider>
-            </SWRConfig>
-          </ThemeProvider>
-        </ThemeModeContext.Provider>
-      </CurrentUserContext.Provider>
+      <ThemeModeContext.Provider value={value}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <SWRConfig
+            value={{
+              fetcher,
+            }}
+          >
+            <MsalProvider clientId={msalClientId} redirectUri={msalRedirectUri}>
+              {children}
+            </MsalProvider>
+          </SWRConfig>
+        </ThemeProvider>
+      </ThemeModeContext.Provider>
     </AppRouterCacheProvider>
   );
 };
@@ -121,15 +112,3 @@ export const useThemeMode = () => {
 };
 
 export const useOptionalThemeMode = () => useContext(ThemeModeContext);
-
-export const useCurrentUser = () => {
-  const currentUser = useContext(CurrentUserContext);
-
-  if (!currentUser) {
-    throw new Error('useCurrentUser must be used within AppProviders');
-  }
-
-  return currentUser;
-};
-
-export const useOptionalCurrentUser = () => useContext(CurrentUserContext);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,17 @@
 import './globals.css';
 import { AppProviders } from './_providers/themeMode';
-import { getSession } from '@/lib/server/session';
 import { getMsalConfig } from '@/env.server';
 import type { ReactNode } from 'react';
 
+export const dynamic = 'force-dynamic';
+
 const RootLayout = async ({ children }: { children: ReactNode }) => {
-  const session = await getSession();
   const msalConfig = getMsalConfig();
 
   return (
     <html lang="ja">
       <body>
         <AppProviders
-          currentUser={session.state === 'authenticated' ? session.user : null}
           msalClientId={msalConfig.clientId}
           msalRedirectUri={msalConfig.redirectUri}
         >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,6 @@ import { AppProviders } from './_providers/themeMode';
 import { getMsalConfig } from '@/env.server';
 import type { ReactNode } from 'react';
 
-export const dynamic = 'force-dynamic';
-
 const RootLayout = async ({ children }: { children: ReactNode }) => {
   const msalConfig = getMsalConfig();
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import ErrorDialog from './_components/ErrorDialog';
+
+export const dynamic = 'force-dynamic';
+
+const NotFound = () => (
+  <ErrorDialog
+    status={404}
+    title="ページが見つかりません"
+    message="URL を確認してから、もう一度アクセスしてください。"
+    showDiagnostics={false}
+  />
+);
+
+export default NotFound;


### PR DESCRIPTION
## 概要
- root の `AppProviders` から `currentUser` の保持を外し、未ログイン状態の値がログイン後の保護ページに残る問題を避けました。
- `AuthenticatedUserProvider` を追加し、`requireUser()` で認証済みと分かった保護ルート内だけで現在ユーザーを提供するようにしました。
- 保護ルートだけを `force-dynamic` にし、root layout 全体では不要に Full Route Cache を無効化しないようにしました。
- root 直下の `not-found` を明示し、Next.js の自動 404 静的生成で build worker が落ちる問題を避けました。

## 確認事項
- `pnpm lint` で ESLint が通ることを確認しました。
- `pnpm type-check` で TypeScript の型検査が通ることを確認しました。
- `pnpm build` で Next.js の production build が通り、保護ルートが dynamic として扱われることを確認しました。
- push 時の lefthook により `pnpm test:unit` が実行され、3 ファイル / 18 テストが通ることを確認しました。

🤖 Generated with Codex
