### PR TITLE
[codex] 回答期間表示を画面用モデルに分離

### DIFF
--- a/src/app/(protected)/(standard)/forms/_components/FormList.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormList.tsx
@@ -15,21 +15,18 @@ import {
 } from '@mui/material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import NextLink from 'next/link';
-import { formatString } from '@/generic/DateFormatter';
+import {
+  formatResponsePeriod,
+  toResponsePeriod,
+} from '@/lib/forms/responsePeriod';
 import type { GetFormsResponse } from '@/lib/api-types';
-
-const formatResponsePeriod = (startAt: string | null, endAt: string | null) => {
-  if (startAt != null && endAt != null) {
-    return `${formatString(startAt)} ~ ${formatString(endAt)}`;
-  }
-  return '回答期限なし';
-};
 
 type FormItem = GetFormsResponse[number];
 
 const EachForm = ({ form }: { form: FormItem }) => {
-  const responsePeriod =
-    form.settings.answer_settings?.acceptance_period ?? null;
+  const responsePeriod = toResponsePeriod(
+    form.settings.answer_settings?.acceptance_period
+  );
 
   return (
     <Card
@@ -48,10 +45,7 @@ const EachForm = ({ form }: { form: FormItem }) => {
         </Link>
         <Chip
           icon={<AccessTimeIcon />}
-          label={formatResponsePeriod(
-            responsePeriod?.start_at ?? null,
-            responsePeriod?.end_at ?? null
-          )}
+          label={formatResponsePeriod(responsePeriod)}
           size="small"
           variant="outlined"
           sx={{ mb: 1.5 }}

--- a/src/app/(protected)/admin/forms/_components/FormsTable.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsTable.tsx
@@ -13,19 +13,15 @@ import {
 import { useRouter } from 'next/navigation';
 import FormRowMenu from './FormRowMenu';
 import LabelChips from './LabelChips';
-import { formatString } from '@/generic/DateFormatter';
+import {
+  formatResponsePeriod,
+  toResponsePeriod,
+} from '@/lib/forms/responsePeriod';
 import type { GetFormsResponse } from '@/lib/api-types';
 
 interface Props {
   forms: GetFormsResponse;
 }
-
-const formatResponsePeriod = (startAt: string | null, endAt: string | null) => {
-  if (startAt != null && endAt != null) {
-    return `${formatString(startAt)} ~ ${formatString(endAt)}`;
-  }
-  return '回答期限なし';
-};
 
 const FormsTable = ({ forms }: Props) => {
   const router = useRouter();
@@ -67,10 +63,9 @@ const FormsTable = ({ forms }: Props) => {
                 <TableCell>
                   <Typography variant="body2" color="text.secondary">
                     {formatResponsePeriod(
-                      form.settings.answer_settings?.acceptance_period
-                        ?.start_at ?? null,
-                      form.settings.answer_settings?.acceptance_period
-                        ?.end_at ?? null
+                      toResponsePeriod(
+                        form.settings.answer_settings?.acceptance_period
+                      )
                     )}
                   </Typography>
                 </TableCell>

--- a/src/app/(public)/_components/PublicFormList.tsx
+++ b/src/app/(public)/_components/PublicFormList.tsx
@@ -8,27 +8,18 @@ import {
   Typography,
 } from '@mui/material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import { formatString } from '@/generic/DateFormatter';
+import {
+  formatResponsePeriod,
+  toResponsePeriod,
+} from '@/lib/forms/responsePeriod';
 import type { GetFormsResponse } from '@/lib/api-types';
-
-const formatResponsePeriod = (startAt: string | null, endAt: string | null) => {
-  if (startAt != null && endAt != null) {
-    return `${formatString(startAt)} ~ ${formatString(endAt)}`;
-  }
-  if (startAt != null) {
-    return `${formatString(startAt)} ~`;
-  }
-  if (endAt != null) {
-    return `~ ${formatString(endAt)}`;
-  }
-  return '回答期限なし';
-};
 
 type FormItem = GetFormsResponse[number];
 
 const EachForm = ({ form }: { form: FormItem }) => {
-  const responsePeriod =
-    form.settings.answer_settings?.acceptance_period ?? null;
+  const responsePeriod = toResponsePeriod(
+    form.settings.answer_settings?.acceptance_period
+  );
 
   return (
     <Card
@@ -46,10 +37,7 @@ const EachForm = ({ form }: { form: FormItem }) => {
           </Typography>
           <Chip
             icon={<AccessTimeIcon />}
-            label={formatResponsePeriod(
-              responsePeriod?.start_at ?? null,
-              responsePeriod?.end_at ?? null
-            )}
+            label={formatResponsePeriod(responsePeriod)}
             size="small"
             variant="outlined"
             sx={{ mb: 1.5 }}

--- a/src/lib/forms/responsePeriod.ts
+++ b/src/lib/forms/responsePeriod.ts
@@ -28,7 +28,9 @@ export const toResponsePeriod = (
   return { kind: 'none' };
 };
 
-export const formatResponsePeriod = (responsePeriod: ResponsePeriod) => {
+export const formatResponsePeriod = (
+  responsePeriod: ResponsePeriod
+): string => {
   switch (responsePeriod.kind) {
     case 'specified':
       return `${formatString(responsePeriod.startAt)} ~ ${formatString(

--- a/src/lib/forms/responsePeriod.ts
+++ b/src/lib/forms/responsePeriod.ts
@@ -1,0 +1,44 @@
+import { formatString } from '@/generic/DateFormatter';
+import type { ApiComponents } from '@/lib/api/types';
+
+type AnswerAcceptancePeriod =
+  ApiComponents['schemas']['AnswerAcceptancePeriodSchema'];
+
+export type ResponsePeriod =
+  | { kind: 'none' }
+  | { kind: 'startsAt'; startAt: string }
+  | { kind: 'endsAt'; endAt: string }
+  | { kind: 'specified'; startAt: string; endAt: string };
+
+export const toResponsePeriod = (
+  acceptancePeriod: AnswerAcceptancePeriod | null | undefined
+): ResponsePeriod => {
+  const startAt = acceptancePeriod?.start_at;
+  const endAt = acceptancePeriod?.end_at;
+
+  if (startAt && endAt) {
+    return { kind: 'specified', startAt, endAt };
+  }
+  if (startAt) {
+    return { kind: 'startsAt', startAt };
+  }
+  if (endAt) {
+    return { kind: 'endsAt', endAt };
+  }
+  return { kind: 'none' };
+};
+
+export const formatResponsePeriod = (responsePeriod: ResponsePeriod) => {
+  switch (responsePeriod.kind) {
+    case 'specified':
+      return `${formatString(responsePeriod.startAt)} ~ ${formatString(
+        responsePeriod.endAt
+      )}`;
+    case 'startsAt':
+      return `${formatString(responsePeriod.startAt)} ~`;
+    case 'endsAt':
+      return `~ ${formatString(responsePeriod.endAt)}`;
+    case 'none':
+      return '回答期限なし';
+  }
+};

--- a/tests/unit/responsePeriod.test.ts
+++ b/tests/unit/responsePeriod.test.ts
@@ -7,6 +7,7 @@ import {
 describe('toResponsePeriod', () => {
   it('API の未設定状態を画面用 model の none に変換する', () => {
     expect(toResponsePeriod(null)).toEqual({ kind: 'none' });
+    expect(toResponsePeriod(undefined)).toEqual({ kind: 'none' });
     expect(toResponsePeriod({ start_at: null, end_at: null })).toEqual({
       kind: 'none',
     });

--- a/tests/unit/responsePeriod.test.ts
+++ b/tests/unit/responsePeriod.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatResponsePeriod,
+  toResponsePeriod,
+} from '@/lib/forms/responsePeriod';
+
+describe('toResponsePeriod', () => {
+  it('API の未設定状態を画面用 model の none に変換する', () => {
+    expect(toResponsePeriod(null)).toEqual({ kind: 'none' });
+    expect(toResponsePeriod({ start_at: null, end_at: null })).toEqual({
+      kind: 'none',
+    });
+  });
+
+  it('開始日時のみの回答期間を区別する', () => {
+    expect(
+      toResponsePeriod({
+        start_at: '2026-06-01T10:00:00+09:00',
+        end_at: null,
+      })
+    ).toEqual({
+      kind: 'startsAt',
+      startAt: '2026-06-01T10:00:00+09:00',
+    });
+  });
+
+  it('終了日時のみの回答期間を区別する', () => {
+    expect(
+      toResponsePeriod({
+        start_at: null,
+        end_at: '2026-06-30T23:59:00+09:00',
+      })
+    ).toEqual({
+      kind: 'endsAt',
+      endAt: '2026-06-30T23:59:00+09:00',
+    });
+  });
+
+  it('開始日時と終了日時がある回答期間を区別する', () => {
+    expect(
+      toResponsePeriod({
+        start_at: '2026-06-01T10:00:00+09:00',
+        end_at: '2026-06-30T23:59:00+09:00',
+      })
+    ).toEqual({
+      kind: 'specified',
+      startAt: '2026-06-01T10:00:00+09:00',
+      endAt: '2026-06-30T23:59:00+09:00',
+    });
+  });
+});
+
+describe('formatResponsePeriod', () => {
+  it('画面用 model から回答期間の表示文字列を作る', () => {
+    expect(formatResponsePeriod({ kind: 'none' })).toBe('回答期限なし');
+    expect(
+      formatResponsePeriod({
+        kind: 'startsAt',
+        startAt: '2026-06-01T10:00:00+09:00',
+      })
+    ).toBe('2026年06月01日 10時00分 ~');
+    expect(
+      formatResponsePeriod({
+        kind: 'endsAt',
+        endAt: '2026-06-30T23:59:00+09:00',
+      })
+    ).toBe('~ 2026年06月30日 23時59分');
+    expect(
+      formatResponsePeriod({
+        kind: 'specified',
+        startAt: '2026-06-01T10:00:00+09:00',
+        endAt: '2026-06-30T23:59:00+09:00',
+      })
+    ).toBe('2026年06月01日 10時00分 ~ 2026年06月30日 23時59分');
+  });
+});


### PR DESCRIPTION
## 概要
- Refs #754
- API response の nullable な `acceptance_period` を、フォーム一覧 UI が直接解釈していた箇所を表示用 model へ分離しました。
- 公開フォーム一覧、通常ユーザー向けフォーム一覧、管理者向けフォーム一覧で共通の `ResponsePeriod` 変換・表示関数を使うようにしました。
- 開始のみ、終了のみ、両方あり、未設定を discriminated union として区別し、変換ロジックを副作用なしで確認できるようにしました。

## 確認事項
- `pnpm test:unit` で既存テストと追加した回答期間 model のテストが通ることを確認しました。
- `pnpm type-check` で型エラーがないことを確認しました。
- `pnpm fmt` でフォーマット違反がないことを確認しました。
- `pnpm lint` は通過しました。全体 lint では既存の `eslint.config.mjs` に import-x の warning が 2 件出ていますが、今回変更ファイルの pre-commit lint は warning なしで通過しています。

🤖 Generated with Codex