### PR TITLE
[codex] nullableなAPI状態を画面モデルへ分離

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -12,28 +12,27 @@ import {
 import Checkbox from '@mui/material/Checkbox';
 import { Controller, useForm } from 'react-hook-form';
 import { useNotificationSettings } from '@/hooks/useNotificationSettings';
-import type {
-  GetUserNotificationSettingsResponse,
-  UpdateNotificationSettingsSchema,
-} from '@/lib/api-types';
+import {
+  fromNotificationSettingsResponseToFormValues,
+  toNotificationSettingsUpdateBody,
+} from './notificationSettingsForm';
+import type { GetUserNotificationSettingsResponse } from '@/lib/api-types';
+import type { NotificationSettingsFormValues } from './notificationSettingsForm';
 
 const DiscordNotificationSettings = (props: {
   currentSettings: GetUserNotificationSettingsResponse;
   userId: string;
 }) => {
-  const { handleSubmit, control } = useForm<UpdateNotificationSettingsSchema>({
-    defaultValues: {
-      is_send_message_notification:
-        props.currentSettings.is_send_message_notification,
-    },
+  const { handleSubmit, control } = useForm<NotificationSettingsFormValues>({
+    defaultValues: fromNotificationSettingsResponseToFormValues(
+      props.currentSettings
+    ),
   });
 
   const { updateSettings } = useNotificationSettings();
 
-  const onSubmit = async (data: UpdateNotificationSettingsSchema) => {
-    const result = await updateSettings({
-      is_send_message_notification: data.is_send_message_notification ?? null,
-    });
+  const onSubmit = async (data: NotificationSettingsFormValues) => {
+    const result = await updateSettings(toNotificationSettingsUpdateBody(data));
     if (result.ok) {
       alert('設定を更新しました');
     } else {
@@ -49,15 +48,15 @@ const DiscordNotificationSettings = (props: {
       <Divider sx={{ mb: 2 }} />
       <Stack spacing={2}>
         <Controller
-          name="is_send_message_notification"
+          name="isSendMessageNotificationEnabled"
           control={control}
           render={({ field }) => (
             <FormControlLabel
               label="自身の回答に対するメッセージ通知を受け取る"
               control={
                 <Checkbox
-                  checked={field.value ?? false}
-                  onChange={field.onChange}
+                  checked={field.value}
+                  onChange={(_, checked) => field.onChange(checked)}
                   onBlur={field.onBlur}
                   ref={field.ref}
                 />

--- a/src/app/(protected)/(standard)/users/[userId]/_components/notificationSettingsForm.ts
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/notificationSettingsForm.ts
@@ -1,16 +1,18 @@
-import type {
-  GetUserNotificationSettingsResponse,
-  UpdateNotificationSettingsSchema,
-} from '@/lib/api-types';
+import type { UpdateNotificationSettingsSchema } from '@/lib/api-types';
+
+type NotificationSettingsResponseInput = {
+  is_send_message_notification?: boolean | null;
+};
 
 export type NotificationSettingsFormValues = {
   isSendMessageNotificationEnabled: boolean;
 };
 
 export const fromNotificationSettingsResponseToFormValues = (
-  settings: GetUserNotificationSettingsResponse
+  settings: NotificationSettingsResponseInput
 ): NotificationSettingsFormValues => ({
-  isSendMessageNotificationEnabled: settings.is_send_message_notification,
+  isSendMessageNotificationEnabled:
+    settings.is_send_message_notification ?? false,
 });
 
 export const toNotificationSettingsUpdateBody = (

--- a/src/app/(protected)/(standard)/users/[userId]/_components/notificationSettingsForm.ts
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/notificationSettingsForm.ts
@@ -1,0 +1,20 @@
+import type {
+  GetUserNotificationSettingsResponse,
+  UpdateNotificationSettingsSchema,
+} from '@/lib/api-types';
+
+export type NotificationSettingsFormValues = {
+  isSendMessageNotificationEnabled: boolean;
+};
+
+export const fromNotificationSettingsResponseToFormValues = (
+  settings: GetUserNotificationSettingsResponse
+): NotificationSettingsFormValues => ({
+  isSendMessageNotificationEnabled: settings.is_send_message_notification,
+});
+
+export const toNotificationSettingsUpdateBody = (
+  values: NotificationSettingsFormValues
+): UpdateNotificationSettingsSchema => ({
+  is_send_message_notification: values.isSendMessageNotificationEnabled,
+});

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -19,10 +19,14 @@ import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { formatString } from '@/generic/DateFormatter';
 import { useAnswerSubmitterRestrictionActions } from '@/hooks/useAnswerSubmitterRestrictionActions';
+import {
+  formatRestrictionExpiration,
+  toRestrictionExpiration,
+} from '@/lib/restrictions/expiration';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { restrictionFormSchema, toRestrictionRequest } from './restrictionForm';
 import type {
-  RestrictionExpiration,
+  RestrictionFormExpiration,
   RestrictionFormInput,
   RestrictionFormValues,
 } from './restrictionForm';
@@ -73,6 +77,8 @@ const RestrictionDialogBody = ({
 
   // 既に制限中: 現在の内容を表示し、解除のみ行える。
   if (data) {
+    const expiration = toRestrictionExpiration(data.expires_at);
+
     const onUnrestrict = async () => {
       setSubmitError(null);
       const result = await unrestrictUser(uuid);
@@ -98,7 +104,7 @@ const RestrictionDialogBody = ({
               </Typography>
               <Typography component="p">
                 <strong>解除予定:</strong>{' '}
-                {data.expires_at ? formatString(data.expires_at) : '無期限'}
+                {formatRestrictionExpiration(expiration)}
               </Typography>
             </Stack>
           </Stack>
@@ -159,7 +165,7 @@ const RestrictionDialogBody = ({
                       : null
                   }
                   onChange={(value) => {
-                    const expiration: RestrictionExpiration =
+                    const expiration: RestrictionFormExpiration =
                       value == null
                         ? { kind: 'indefinite' }
                         : { kind: 'expiresAt', expiresAt: value };

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -22,6 +22,7 @@ import { useAnswerSubmitterRestrictionActions } from '@/hooks/useAnswerSubmitter
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { restrictionFormSchema, toRestrictionRequest } from './restrictionForm';
 import type {
+  RestrictionExpiration,
   RestrictionFormInput,
   RestrictionFormValues,
 } from './restrictionForm';
@@ -49,7 +50,7 @@ const RestrictionDialogBody = ({
     formState: { isSubmitting },
   } = useForm<RestrictionFormInput, unknown, RestrictionFormValues>({
     resolver: zodResolver(restrictionFormSchema),
-    defaultValues: { reason: '', expiresAt: null },
+    defaultValues: { reason: '', expiration: { kind: 'indefinite' } },
   });
 
   if (isLoading) {
@@ -147,13 +148,23 @@ const RestrictionDialogBody = ({
               )}
             />
             <Controller
-              name="expiresAt"
+              name="expiration"
               control={control}
               render={({ field, fieldState }) => (
                 <DateTimePicker
                   label="解除予定日時（任意・未指定で無期限）"
-                  value={field.value ?? null}
-                  onChange={field.onChange}
+                  value={
+                    field.value.kind === 'expiresAt'
+                      ? field.value.expiresAt
+                      : null
+                  }
+                  onChange={(value) => {
+                    const expiration: RestrictionExpiration =
+                      value == null
+                        ? { kind: 'indefinite' }
+                        : { kind: 'expiresAt', expiresAt: value };
+                    field.onChange(expiration);
+                  }}
                   slotProps={{
                     field: { clearable: true },
                     textField: {

--- a/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionDialogBody.tsx
@@ -160,7 +160,7 @@ const RestrictionDialogBody = ({
                 <DateTimePicker
                   label="解除予定日時（任意・未指定で無期限）"
                   value={
-                    field.value.kind === 'expiresAt'
+                    field.value?.kind === 'expiresAt'
                       ? field.value.expiresAt
                       : null
                   }

--- a/src/app/(protected)/admin/users/_components/restrictionForm.ts
+++ b/src/app/(protected)/admin/users/_components/restrictionForm.ts
@@ -13,7 +13,9 @@ const restrictionExpirationSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
-export type RestrictionExpiration = z.infer<typeof restrictionExpirationSchema>;
+export type RestrictionFormExpiration = z.infer<
+  typeof restrictionExpirationSchema
+>;
 
 export const restrictionFormSchema = z.object({
   reason: z.string().trim().min(1, '理由を入力してください'),

--- a/src/app/(protected)/admin/users/_components/restrictionForm.ts
+++ b/src/app/(protected)/admin/users/_components/restrictionForm.ts
@@ -3,15 +3,21 @@ import { z } from 'zod';
 import type { Dayjs } from 'dayjs';
 import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
 
+const restrictionExpirationSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('indefinite') }),
+  z.object({
+    kind: z.literal('expiresAt'),
+    expiresAt: z.custom<Dayjs>((val) => isDayjs(val) && val.isValid(), {
+      message: '有効な日時を入力してください',
+    }),
+  }),
+]);
+
+export type RestrictionExpiration = z.infer<typeof restrictionExpirationSchema>;
+
 export const restrictionFormSchema = z.object({
   reason: z.string().trim().min(1, '理由を入力してください'),
-  // 有効期限は任意。未指定なら無期限の制限になる。
-  // 指定時は有効な Dayjs であることを保証し、Invalid Date が API に渡らないようにする。
-  expiresAt: z
-    .custom<Dayjs>((val) => isDayjs(val) && val.isValid(), {
-      message: '有効な日時を入力してください',
-    })
-    .nullable(),
+  expiration: restrictionExpirationSchema,
 });
 
 export type RestrictionFormInput = z.input<typeof restrictionFormSchema>;
@@ -23,7 +29,14 @@ export type RestrictionFormValues = z.output<typeof restrictionFormSchema>;
  */
 export const toRestrictionRequest = (
   values: RestrictionFormValues
-): PutAnswerSubmitterRestrictionSchema => ({
-  reason: values.reason.trim(),
-  ...(values.expiresAt ? { expires_at: values.expiresAt.format() } : {}),
-});
+): PutAnswerSubmitterRestrictionSchema => {
+  const request: PutAnswerSubmitterRestrictionSchema = {
+    reason: values.reason.trim(),
+  };
+
+  if (values.expiration.kind === 'expiresAt') {
+    request.expires_at = values.expiration.expiresAt.format();
+  }
+
+  return request;
+};

--- a/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { Alert, Box, Stack, Typography } from '@mui/material';
-import { formatString } from '@/generic/DateFormatter';
 import { SigninButton } from '@/app/_components/SigninButton';
+import { formatRestrictionExpiration } from '@/lib/restrictions/expiration';
 import type { GetQuestionsResponse } from '@/lib/api-types';
 import AnswerSubmissionForm from './AnswerSubmissionForm';
 import AnswerSubmissionSuccess from './AnswerSubmissionSuccess';
+import type { SubmissionState } from './useAnswerSubmission';
 import { useAnswerSubmission } from './useAnswerSubmission';
 
 interface Props {
@@ -31,15 +32,10 @@ const AnswerForm = ({
 }: Props) => {
   // 未ログインかつフォームが未ログイン回答を許可している場合のみ匿名回答モード。
   const isTemporary = !isAuthenticated && allowTemporaryAnswers;
-  const {
-    isSubmitted,
-    submissionErrorCode,
-    restriction,
-    submitAnswers,
-    resetSubmissionState,
-  } = useAnswerSubmission(formId, isTemporary);
+  const { submissionState, submitAnswers, resetSubmissionState } =
+    useAnswerSubmission(formId, isTemporary);
 
-  if (isSubmitted) {
+  if (submissionState.kind === 'submitted') {
     return <AnswerSubmissionSuccess onReset={resetSubmissionState} />;
   }
 
@@ -63,33 +59,7 @@ const AnswerForm = ({
 
   return (
     <Stack spacing={0}>
-      {submissionErrorCode === 'OUT_OF_PERIOD' && (
-        <Alert
-          severity="error"
-          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
-        >
-          回答期間が終了しています
-        </Alert>
-      )}
-      {submissionErrorCode === 'RESTRICTED' && (
-        <Alert
-          severity="error"
-          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
-        >
-          現在、回答の投稿が制限されています。
-          {restriction?.reason && `（理由: ${restriction.reason}）`}
-          {restriction?.expires_at &&
-            ` 制限解除予定: ${formatString(restriction.expires_at)}`}
-        </Alert>
-      )}
-      {submissionErrorCode === 'UNKNOWN' && (
-        <Alert
-          severity="error"
-          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
-        >
-          回答の送信に失敗しました。時間をおいて再度お試しください。
-        </Alert>
-      )}
+      <SubmissionErrorAlert submissionState={submissionState} />
       <AnswerSubmissionForm
         questions={questions}
         title={title}
@@ -99,6 +69,46 @@ const AnswerForm = ({
       />
     </Stack>
   );
+};
+
+const SubmissionErrorAlert = ({
+  submissionState,
+}: {
+  submissionState: SubmissionState;
+}) => {
+  if (submissionState.kind !== 'failed') {
+    return null;
+  }
+
+  const alertSx = { width: '100%', maxWidth: 800, mx: 'auto', mb: 2 };
+
+  switch (submissionState.error.kind) {
+    case 'outOfPeriod':
+      return (
+        <Alert severity="error" sx={alertSx}>
+          回答期間が終了しています
+        </Alert>
+      );
+    case 'restricted': {
+      const restriction = submissionState.error.restriction;
+      return (
+        <Alert severity="error" sx={alertSx}>
+          現在、回答の投稿が制限されています。
+          {restriction && `（理由: ${restriction.reason}）`}
+          {restriction?.expiration.kind === 'expiresAt' &&
+            ` 制限解除予定: ${formatRestrictionExpiration(
+              restriction.expiration
+            )}`}
+        </Alert>
+      );
+    }
+    case 'unknown':
+      return (
+        <Alert severity="error" sx={alertSx}>
+          回答の送信に失敗しました。時間をおいて再度お試しください。
+        </Alert>
+      );
+  }
 };
 
 export default AnswerForm;

--- a/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
@@ -94,7 +94,7 @@ const SubmissionErrorAlert = ({
       return (
         <Alert severity="error" sx={alertSx}>
           現在、回答の投稿が制限されています。
-          {restriction && `（理由: ${restriction.reason}）`}
+          {restriction?.reason && `（理由: ${restriction.reason}）`}
           {restriction?.expiration.kind === 'expiresAt' &&
             ` 制限解除予定: ${formatRestrictionExpiration(
               restriction.expiration

--- a/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -3,10 +3,12 @@
 import { useState } from 'react';
 import { errorResponseSchema } from '@/lib/api/errors';
 import { proxyClient } from '@/lib/proxyClient';
+import { toRestrictionExpiration } from '@/lib/restrictions/expiration';
 import { isTemporaryUserField, TEMPORARY_USER_FIELDS } from './answerFormTypes';
 import type { AnswerFormInput } from './answerFormTypes';
 import type { ErrorRestriction } from '@/lib/api/errors';
 import type { ApiPaths } from '@/lib/api/types';
+import type { RestrictionExpiration } from '@/lib/restrictions/expiration';
 
 type AnswerCreateBody =
   ApiPaths['/api/v1/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
@@ -15,6 +17,18 @@ type TemporaryAnswerCreateBody =
 type AnswerContents = AnswerCreateBody['contents'];
 
 type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'RESTRICTED' | 'UNKNOWN';
+type SubmissionRestriction = {
+  reason: string;
+  expiration: RestrictionExpiration;
+};
+type SubmissionError =
+  | { kind: 'outOfPeriod' }
+  | { kind: 'restricted'; restriction?: SubmissionRestriction }
+  | { kind: 'unknown' };
+export type SubmissionState =
+  | { kind: 'editing' }
+  | { kind: 'submitted' }
+  | { kind: 'failed'; error: SubmissionError };
 
 // 質問の回答（key は質問 UUID）だけを contents に変換する。
 // 未ログイン回答の投稿者情報フィールドは除外する。
@@ -63,10 +77,19 @@ const toTemporaryUser = (
 
 type ParsedSubmissionError = {
   code: SubmissionErrorCode;
-  restriction?: ErrorRestriction;
+  restriction?: SubmissionRestriction;
 };
 
-const parseSubmissionError = (error: unknown): ParsedSubmissionError | null => {
+const toSubmissionRestriction = (
+  restriction: ErrorRestriction
+): SubmissionRestriction => ({
+  reason: restriction.reason,
+  expiration: toRestrictionExpiration(restriction.expires_at),
+});
+
+export const parseSubmissionError = (
+  error: unknown
+): ParsedSubmissionError | null => {
   const parsed = errorResponseSchema.safeParse(error);
 
   if (!parsed.success) {
@@ -78,7 +101,7 @@ const parseSubmissionError = (error: unknown): ParsedSubmissionError | null => {
     return {
       code: 'RESTRICTED',
       ...(parsed.data.restriction
-        ? { restriction: parsed.data.restriction }
+        ? { restriction: toSubmissionRestriction(parsed.data.restriction) }
         : {}),
     };
   }
@@ -98,10 +121,9 @@ export const useAnswerSubmission = (
   formId: string,
   isTemporary: boolean = false
 ) => {
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [submissionErrorCode, setSubmissionErrorCode] =
-    useState<SubmissionErrorCode | null>(null);
-  const [restriction, setRestriction] = useState<ErrorRestriction | null>(null);
+  const [submissionState, setSubmissionState] = useState<SubmissionState>({
+    kind: 'editing',
+  });
 
   const postAnswers = (data: AnswerFormInput) => {
     const params = { path: { id: formId } };
@@ -126,30 +148,36 @@ export const useAnswerSubmission = (
     const { response, error } = await postAnswers(data);
 
     if (response.ok) {
-      setIsSubmitted(true);
-      setSubmissionErrorCode(null);
-      setRestriction(null);
+      setSubmissionState({ kind: 'submitted' });
       return { ok: true as const };
     }
 
     const parsed = parseSubmissionError(error);
     const errorCode = parsed?.code ?? 'UNKNOWN';
-    setSubmissionErrorCode(errorCode);
-    setRestriction(parsed?.restriction ?? null);
+    const submissionError = (() => {
+      switch (errorCode) {
+        case 'OUT_OF_PERIOD':
+          return { kind: 'outOfPeriod' } satisfies SubmissionError;
+        case 'RESTRICTED':
+          return {
+            kind: 'restricted',
+            ...(parsed?.restriction ? { restriction: parsed.restriction } : {}),
+          } satisfies SubmissionError;
+        case 'UNKNOWN':
+          return { kind: 'unknown' } satisfies SubmissionError;
+      }
+    })();
+    setSubmissionState({ kind: 'failed', error: submissionError });
 
     return { ok: false as const, errorCode };
   };
 
   const resetSubmissionState = () => {
-    setIsSubmitted(false);
-    setSubmissionErrorCode(null);
-    setRestriction(null);
+    setSubmissionState({ kind: 'editing' });
   };
 
   return {
-    isSubmitted,
-    submissionErrorCode,
-    restriction,
+    submissionState,
     submitAnswers,
     resetSubmissionState,
   };

--- a/src/lib/restrictions/expiration.ts
+++ b/src/lib/restrictions/expiration.ts
@@ -1,0 +1,21 @@
+import { formatString } from '@/generic/DateFormatter';
+
+export type RestrictionExpiration =
+  | { kind: 'indefinite' }
+  | { kind: 'expiresAt'; expiresAt: string };
+
+export const toRestrictionExpiration = (
+  expiresAt: string | null | undefined
+): RestrictionExpiration =>
+  expiresAt ? { kind: 'expiresAt', expiresAt } : { kind: 'indefinite' };
+
+export const formatRestrictionExpiration = (
+  expiration: RestrictionExpiration
+): string => {
+  switch (expiration.kind) {
+    case 'expiresAt':
+      return formatString(expiration.expiresAt);
+    case 'indefinite':
+      return '無期限';
+  }
+};

--- a/tests/unit/answerSubmission.test.ts
+++ b/tests/unit/answerSubmission.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseSubmissionError } from '@/app/(public)/forms/[formId]/_components/useAnswerSubmission';
+
+describe('parseSubmissionError', () => {
+  it('制限エラーの nullable な解除予定を送信用 model に変換する', () => {
+    expect(
+      parseSubmissionError({
+        detail: 'restricted',
+        errorCode: 'ANSWER_SUBMISSION_RESTRICTED',
+        status: 403,
+        title: 'Forbidden',
+        type: 'about:blank',
+        restriction: {
+          reason: '不適切な回答のため',
+          expires_at: null,
+        },
+      })
+    ).toEqual({
+      code: 'RESTRICTED',
+      restriction: {
+        reason: '不適切な回答のため',
+        expiration: { kind: 'indefinite' },
+      },
+    });
+  });
+
+  it('制限エラーの解除予定日時を区別する', () => {
+    expect(
+      parseSubmissionError({
+        detail: 'restricted',
+        errorCode: 'ANSWER_SUBMISSION_RESTRICTED',
+        status: 403,
+        title: 'Forbidden',
+        type: 'about:blank',
+        restriction: {
+          reason: '不適切な回答のため',
+          expires_at: '2026-07-01T12:34:00+09:00',
+        },
+      })
+    ).toEqual({
+      code: 'RESTRICTED',
+      restriction: {
+        reason: '不適切な回答のため',
+        expiration: {
+          kind: 'expiresAt',
+          expiresAt: '2026-07-01T12:34:00+09:00',
+        },
+      },
+    });
+  });
+});

--- a/tests/unit/notificationSettingsForm.test.ts
+++ b/tests/unit/notificationSettingsForm.test.ts
@@ -13,6 +13,17 @@ describe('notification settings form mappers', () => {
     ).toEqual({ isSendMessageNotificationEnabled: true });
   });
 
+  it('API response の通知設定が欠けていても false に正規化する', () => {
+    expect(
+      fromNotificationSettingsResponseToFormValues({
+        is_send_message_notification: null,
+      })
+    ).toEqual({ isSendMessageNotificationEnabled: false });
+    expect(fromNotificationSettingsResponseToFormValues({})).toEqual({
+      isSendMessageNotificationEnabled: false,
+    });
+  });
+
   it('フォーム値を nullable ではない更新 body へ変換する', () => {
     expect(
       toNotificationSettingsUpdateBody({

--- a/tests/unit/notificationSettingsForm.test.ts
+++ b/tests/unit/notificationSettingsForm.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fromNotificationSettingsResponseToFormValues,
+  toNotificationSettingsUpdateBody,
+} from '@/app/(protected)/(standard)/users/[userId]/_components/notificationSettingsForm';
+
+describe('notification settings form mappers', () => {
+  it('API response を boolean のフォーム値へ変換する', () => {
+    expect(
+      fromNotificationSettingsResponseToFormValues({
+        is_send_message_notification: true,
+      })
+    ).toEqual({ isSendMessageNotificationEnabled: true });
+  });
+
+  it('フォーム値を nullable ではない更新 body へ変換する', () => {
+    expect(
+      toNotificationSettingsUpdateBody({
+        isSendMessageNotificationEnabled: false,
+      })
+    ).toEqual({ is_send_message_notification: false });
+  });
+});

--- a/tests/unit/restrictionExpiration.test.ts
+++ b/tests/unit/restrictionExpiration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatRestrictionExpiration,
+  toRestrictionExpiration,
+} from '@/lib/restrictions/expiration';
+
+describe('restriction expiration', () => {
+  it('API の nullable な解除予定を制限期限 model に変換する', () => {
+    expect(toRestrictionExpiration(null)).toEqual({ kind: 'indefinite' });
+    expect(toRestrictionExpiration(undefined)).toEqual({ kind: 'indefinite' });
+    expect(toRestrictionExpiration('2026-07-01T12:34:00+09:00')).toEqual({
+      kind: 'expiresAt',
+      expiresAt: '2026-07-01T12:34:00+09:00',
+    });
+  });
+
+  it('制限期限 model から表示文字列を作る', () => {
+    expect(formatRestrictionExpiration({ kind: 'indefinite' })).toBe('無期限');
+    expect(
+      formatRestrictionExpiration({
+        kind: 'expiresAt',
+        expiresAt: '2026-07-01T12:34:00+09:00',
+      })
+    ).toBe('2026年07月01日 12時34分');
+  });
+});

--- a/tests/unit/restrictionForm.test.ts
+++ b/tests/unit/restrictionForm.test.ts
@@ -9,7 +9,7 @@ describe('restrictionFormSchema', () => {
   it('空の理由は弾く', () => {
     const result = restrictionFormSchema.safeParse({
       reason: '   ',
-      expiresAt: null,
+      expiration: { kind: 'indefinite' },
     });
     expect(result.success).toBe(false);
   });
@@ -17,7 +17,7 @@ describe('restrictionFormSchema', () => {
   it('理由があれば通る', () => {
     const result = restrictionFormSchema.safeParse({
       reason: '不適切な回答のため',
-      expiresAt: null,
+      expiration: { kind: 'indefinite' },
     });
     expect(result.success).toBe(true);
   });
@@ -25,7 +25,10 @@ describe('restrictionFormSchema', () => {
   it('無効な日時は弾く', () => {
     const result = restrictionFormSchema.safeParse({
       reason: '不適切な回答のため',
-      expiresAt: dayjs('invalid-date-string'),
+      expiration: {
+        kind: 'expiresAt',
+        expiresAt: dayjs('invalid-date-string'),
+      },
     });
     expect(result.success).toBe(false);
   });
@@ -35,7 +38,7 @@ describe('toRestrictionRequest', () => {
   it('expiresAt 未指定なら expires_at を含めない', () => {
     const body = toRestrictionRequest({
       reason: ' 理由 ',
-      expiresAt: null,
+      expiration: { kind: 'indefinite' },
     });
     expect(body).toEqual({ reason: '理由' });
     expect('expires_at' in body).toBe(false);
@@ -45,7 +48,7 @@ describe('toRestrictionRequest', () => {
     const expiresAt = dayjs('2026-07-01T12:34:00+09:00');
     const body = toRestrictionRequest({
       reason: '理由',
-      expiresAt,
+      expiration: { kind: 'expiresAt', expiresAt },
     });
     expect(body.reason).toBe('理由');
     expect(body.expires_at).toBe(expiresAt.format());


### PR DESCRIPTION
## 概要
- Refs #754
- 回答投稿制限フォームの有効期限未指定を `null` ではなく、`indefinite | expiresAt` のフォーム内部 model として表すようにしました。
- 制限解除予定の API nullable 値を共通の `RestrictionExpiration` model に変換し、回答送信エラー表示と管理画面の制限表示で使うようにしました。
- 回答送信 hook の `submissionErrorCode | restriction` の組み合わせ state を `SubmissionState` union に寄せ、不正な状態を作りにくくしました。
- 通知設定フォームを API request DTO から分離し、フォーム内部は boolean、request 変換は mapper で行うようにしました。

## 確認事項
- `pnpm test:unit` で restriction / notification / answer submission の mapper と既存 unit test が通ることを確認しました。
- `pnpm type-check` で React Hook Form、DateTimePicker、送信状態 union の型が通ることを確認しました。
- `pnpm fmt` でフォーマット違反がないことを確認しました。
- `pnpm lint` は通過しました。全体 lint では既存の `eslint.config.mjs` に import-x の warning が 2 件出ていますが、今回変更ファイルの pre-commit lint は warning なしで通過しています。

## 補足
- UI 制御用の `null`（MUI の anchor element、エラーダイアログ state など）と API schema 定義上の nullable は今回の対象外です。

🤖 Generated with Codex