### PR TITLE
chore: tseslint の named export を直接 import する

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import prettier from 'eslint-config-prettier/flat';
 import { importX } from 'eslint-plugin-import-x';
 import pluginReactConfig from 'eslint-plugin-react/configs/recommended.js';
 import reactHooks from 'eslint-plugin-react-hooks';
-import { plugin as tseslintPlugin, parser as tseslintParser } from 'typescript-eslint';
+import * as tseslint from 'typescript-eslint';
 import unusedImports from 'eslint-plugin-unused-imports';
 
 const eslintReactConfig = {
@@ -41,10 +41,10 @@ const unusedImportConfig = {
 const typescriptStrictnessConfig = {
   files: ['**/*.ts', '**/*.tsx'],
   plugins: {
-    '@typescript-eslint': tseslintPlugin,
+    '@typescript-eslint': tseslint.plugin,
   },
   languageOptions: {
-    parser: tseslintParser,
+    parser: tseslint.parser,
     parserOptions: {
       projectService: true,
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import prettier from 'eslint-config-prettier/flat';
 import { importX } from 'eslint-plugin-import-x';
 import pluginReactConfig from 'eslint-plugin-react/configs/recommended.js';
 import reactHooks from 'eslint-plugin-react-hooks';
-import tseslint from 'typescript-eslint';
+import { plugin as tseslintPlugin, parser as tseslintParser } from 'typescript-eslint';
 import unusedImports from 'eslint-plugin-unused-imports';
 
 const eslintReactConfig = {
@@ -41,10 +41,10 @@ const unusedImportConfig = {
 const typescriptStrictnessConfig = {
   files: ['**/*.ts', '**/*.tsx'],
   plugins: {
-    '@typescript-eslint': tseslint.plugin,
+    '@typescript-eslint': tseslintPlugin,
   },
   languageOptions: {
-    parser: tseslint.parser,
+    parser: tseslintParser,
     parserOptions: {
       projectService: true,
     },


### PR DESCRIPTION
## 概要

`pnpm lint` で `eslint.config.mjs` に出ていた `import-x/no-named-as-default-member` の警告 2 件を解消する。

`typescript-eslint` パッケージは `plugin` と `parser` を named export として公開しているため、default import 経由ではなく named import を直接使うようにする。

## 動作確認

- [x] `pnpm lint` で警告が出ないこと