### PR TITLE
フォーム作成画面の初期状態にデフォルトの質問を1つ表示する

### DIFF
--- a/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
@@ -17,7 +17,7 @@ export const createEmptyFormEditorQuestion = (): FormEditorQuestion => ({
 export const createEmptyFormEditorValues = (): FormEditorValues => ({
   title: '',
   description: '',
-  questions: [],
+  questions: [createEmptyFormEditorQuestion()],
   labels: [],
   settings: {
     acceptance_period: { kind: 'none' },


### PR DESCRIPTION
close #761

## 概要
- フォーム作成には最低1つの質問が必要だが、初期表示では質問が0個で導線として不自然だった
- `createEmptyFormEditorValues` のデフォルト値に空の質問を1つ含めるようにした

## 確認事項
- 型チェック (`tsc --noEmit`)、lint、prettier、ユニットテストすべてパス済み
- フォーム編集画面 (`FormEditForm`) は既存フォームのデータを読み込むため、この変更の影響を受けない

🤖 Generated with Claude Code