### PR TITLE
フォーム作成成功時に管理者フォーム一覧ページへ遷移させる

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Stack } from '@mui/material';
+import { Alert, Button, Snackbar, Stack } from '@mui/material';
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import FormsTable from './FormsTable';
 import FormsToolbar from './FormsToolbar';
@@ -9,12 +10,15 @@ import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
 const FormsPageContent = ({
   forms,
   labels,
+  createdFormId,
 }: {
   forms: GetFormsResponse;
   labels: GetFormLabelsResponse;
+  createdFormId?: string | undefined;
 }) => {
   const [titleSearch, setTitleSearch] = useState('');
   const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
+  const [snackbarOpen, setSnackbarOpen] = useState(createdFormId != null);
 
   const filteredForms = useMemo(() => {
     const normalizedSearch = titleSearch.trim().toLowerCase();
@@ -40,6 +44,29 @@ const FormsPageContent = ({
         onLabelFilterChange={setLabelFilter}
       />
       <FormsTable forms={filteredForms} />
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={10000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="success"
+          onClose={() => setSnackbarOpen(false)}
+          action={
+            <Button
+              component={Link}
+              href={`/admin/forms/edit/${createdFormId}`}
+              color="inherit"
+              size="small"
+            >
+              編集画面へ
+            </Button>
+          }
+        >
+          フォームを作成しました
+        </Alert>
+      </Snackbar>
     </Stack>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -2,7 +2,8 @@
 
 import { Alert, Button, Snackbar, Stack } from '@mui/material';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
 import FormsTable from './FormsTable';
 import FormsToolbar from './FormsToolbar';
 import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
@@ -16,9 +17,16 @@ const FormsPageContent = ({
   labels: GetFormLabelsResponse;
   createdFormId?: string | undefined;
 }) => {
+  const router = useRouter();
   const [titleSearch, setTitleSearch] = useState('');
   const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
   const [snackbarOpen, setSnackbarOpen] = useState(createdFormId != null);
+
+  useEffect(() => {
+    if (createdFormId != null) {
+      router.replace('/admin/forms', { scroll: false });
+    }
+  }, [createdFormId, router]);
 
   const filteredForms = useMemo(() => {
     const normalizedSearch = titleSearch.trim().toLowerCase();
@@ -47,7 +55,9 @@ const FormsPageContent = ({
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={10000}
-        onClose={() => setSnackbarOpen(false)}
+        onClose={(_event, reason) => {
+          if (reason !== 'clickaway') setSnackbarOpen(false);
+        }}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert

--- a/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
@@ -10,6 +10,8 @@ import {
   Stack,
 } from '@mui/material';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import type { GetFormLabelsResponse } from '@/lib/api-types';
 import FormEditorLayout from '../../_components/FormEditorLayout';
@@ -42,7 +44,17 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
     name: 'questions',
   });
 
+  const router = useRouter();
   const { createForm, submitState } = useCreateForm();
+
+  useEffect(() => {
+    if (submitState.kind === 'submitted') {
+      router.push(
+        `/admin/forms?createdFormId=${encodeURIComponent(submitState.formId)}`
+      );
+    }
+  }, [submitState, router]);
+
   const questionListError =
     typeof errors.questions?.message === 'string'
       ? errors.questions.message
@@ -88,9 +100,6 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
         )}
         {questionListError && (
           <Alert severity="error">{questionListError}</Alert>
-        )}
-        {submitState.kind === 'submitted' && (
-          <Alert severity="success">フォームを作成しました。</Alert>
         )}
         <Button
           type="submit"

--- a/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
@@ -8,7 +8,7 @@ import type { FormEditorValues } from '../../_schema/formEditorSchema';
 
 type SubmitState =
   | { kind: 'idle' }
-  | { kind: 'submitted' }
+  | { kind: 'submitted'; formId: string }
   | { kind: 'failed'; message: string };
 
 export const useCreateForm = () => {
@@ -50,7 +50,7 @@ export const useCreateForm = () => {
         return;
       }
 
-      setSubmitState({ kind: 'submitted' });
+      setSubmitState({ kind: 'submitted', formId: createdFormId });
     } catch {
       setSubmitState({
         kind: 'failed',

--- a/src/app/(protected)/admin/forms/page.tsx
+++ b/src/app/(protected)/admin/forms/page.tsx
@@ -11,9 +11,11 @@ export const metadata: Metadata = {
   title: 'フォーム管理 | Seichi Portal',
 };
 
-const Home = async () => {
+const Home = async (props: {
+  searchParams: Promise<{ createdFormId?: string }>;
+}) => {
   const { session } = await getAdminAccess();
-  const [forms, labels] = await Promise.all([
+  const [forms, labels, searchParams] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms', {
         headers: authorizationHeader(session.token),
@@ -24,9 +26,16 @@ const Home = async () => {
         headers: authorizationHeader(session.token),
       })
     ),
+    props.searchParams,
   ]);
 
-  return <FormsPageContent forms={forms} labels={labels} />;
+  return (
+    <FormsPageContent
+      forms={forms}
+      labels={labels}
+      createdFormId={searchParams.createdFormId}
+    />
+  );
 };
 
 export default Home;


### PR DESCRIPTION
closes #762

## 概要
- フォーム作成成功時に、作成ページにとどまる代わりに管理者フォーム一覧ページ (`/admin/forms`) へ遷移するようにした
- 遷移先で Snackbar を 10 秒間表示し、作成したフォームの編集画面へのリンクを提供する
- 成功時のインライン Alert は不要になったため削除した

## 確認事項
- TypeScript の型チェック、ESLint、Prettier、ユニットテストがすべて通ることを確認した
- Snackbar の表示と編集ページへの遷移リンクは、実際のブラウザでの動作確認が必要（バックエンド API が必要なため、ローカルでの E2E 確認は未実施）

🤖 Generated with Claude Code