### PR TITLE
フォーム作成時の公開設定のデフォルト値を PRIVATE にする

### DIFF
--- a/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
@@ -23,8 +23,8 @@ export const createEmptyFormEditorValues = (): FormEditorValues => ({
     acceptance_period: { kind: 'none' },
     discord_webhook_url: '',
     default_answer_title: '',
-    visibility: 'PUBLIC',
-    answer_visibility: 'PUBLIC',
+    visibility: 'PRIVATE',
+    answer_visibility: 'PRIVATE',
     allow_temporary_answers: false,
   },
 });


### PR DESCRIPTION
Close #770

## 概要
- フォーム作成時の `visibility`（フォーム公開設定）と `answer_visibility`（回答公開設定）のデフォルト値を `PUBLIC` から `PRIVATE` に変更
- 意図せず PUBLIC のままフォームが作成されるリスクを防ぐ

## 確認事項
- TypeScript の型チェック (`tsc --noEmit`) が通ることを確認
- ESLint, Prettier, ユニットテスト (46件) がすべてパスすることを pre-commit / pre-push フックで確認

🤖 Generated with Claude Code