### PR TITLE
選択肢入力欄で Enter を押したときにフォーム送信せず次の入力欄を追加する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
@@ -67,7 +67,7 @@ const SortableChoiceItem = (props: {
         required
         fullWidth
         onKeyDown={(event) => {
-          if (event.key === 'Enter') {
+          if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
             event.preventDefault();
             props.onAppendChoice();
           }

--- a/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
@@ -31,6 +31,7 @@ const SortableChoiceItem = (props: {
   register: UseFormRegister<FormEditorValues>;
   removeChoice: (index: number) => void;
   canRemove: boolean;
+  onAppendChoice: () => void;
 }) => {
   const {
     attributes,
@@ -65,6 +66,12 @@ const SortableChoiceItem = (props: {
         label={`選択肢${props.index + 1}`}
         required
         fullWidth
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            props.onAppendChoice();
+          }
+        }}
       />
       <IconButton
         size="small"
@@ -199,6 +206,7 @@ const ChoiceEditor = (props: {
                 register={props.register}
                 removeChoice={removeChoice}
                 canRemove={choiceFields.length > 1}
+                onAppendChoice={appendChoice}
               />
             ))}
           </Stack>


### PR DESCRIPTION
## 概要
- 選択肢の TextField で Enter キーを押すとフォーム全体が送信されてしまう問題を修正 (closes #771)
- Enter キー押下時にフォーム送信を `preventDefault` で抑止し、代わりに新しい選択肢の入力欄を追加するようにした

## 確認事項
- TypeScript の型チェック、ESLint、Prettier、ユニットテストすべてパス済み
- UI の実機確認は未実施。レビュー時にフォーム作成・編集画面で選択肢入力欄の Enter キー動作を確認してほしい

🤖 Generated with Claude Code