### PR TITLE
画面ロジックを純粋関数へ切り出す

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -3,9 +3,10 @@
 import { Alert, Button, Snackbar, Stack } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import FormsTable from './FormsTable';
 import FormsToolbar from './FormsToolbar';
+import { useFormListFilters } from '../_hooks/useFormListFilters';
 import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
 
 const FormsPageContent = ({
@@ -18,30 +19,15 @@ const FormsPageContent = ({
   createdFormId?: string | undefined;
 }) => {
   const router = useRouter();
-  const [titleSearch, setTitleSearch] = useState('');
-  const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
   const [snackbarOpen, setSnackbarOpen] = useState(createdFormId != null);
+  const { titleSearch, setTitleSearch, setLabelFilter, filteredForms } =
+    useFormListFilters(forms);
 
   useEffect(() => {
     if (createdFormId != null) {
       router.replace('/admin/forms', { scroll: false });
     }
   }, [createdFormId, router]);
-
-  const filteredForms = useMemo(() => {
-    const normalizedSearch = titleSearch.trim().toLowerCase();
-    return forms.filter((form) => {
-      const matchesTitle =
-        normalizedSearch.length === 0 ||
-        form.title.toLowerCase().includes(normalizedSearch);
-      const matchesLabels =
-        labelFilter.length === 0 ||
-        labelFilter.every((label) =>
-          form.labels.some((formLabel) => formLabel.id === label.id)
-        );
-      return matchesTitle && matchesLabels;
-    });
-  }, [forms, titleSearch, labelFilter]);
 
   return (
     <Stack spacing={3}>

--- a/src/app/(protected)/admin/forms/_hooks/useFormListFilters.ts
+++ b/src/app/(protected)/admin/forms/_hooks/useFormListFilters.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { filterForms } from '../_lib/formListFilters';
+import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+
+export const useFormListFilters = (forms: GetFormsResponse) => {
+  const [titleSearch, setTitleSearch] = useState('');
+  const [labelFilter, setLabelFilter] = useState<GetFormLabelsResponse>([]);
+  const filteredForms = useMemo(
+    () => filterForms(forms, { titleSearch, labels: labelFilter }),
+    [forms, titleSearch, labelFilter]
+  );
+
+  return {
+    titleSearch,
+    setTitleSearch,
+    setLabelFilter,
+    filteredForms,
+  };
+};

--- a/src/app/(protected)/admin/forms/_lib/formListFilters.ts
+++ b/src/app/(protected)/admin/forms/_lib/formListFilters.ts
@@ -15,11 +15,17 @@ export const filterForms = (
     const matchesTitle =
       normalizedSearch.length === 0 ||
       form.title.toLowerCase().includes(normalizedSearch);
-    const formLabelIds = new Set(form.labels.map((label) => label.id));
+
+    if (!matchesTitle) {
+      return false;
+    }
+
     const matchesLabels =
       filter.labels.length === 0 ||
-      filter.labels.every((label) => formLabelIds.has(label.id));
+      filter.labels.every((label) =>
+        form.labels.some((formLabel) => formLabel.id === label.id)
+      );
 
-    return matchesTitle && matchesLabels;
+    return matchesLabels;
   });
 };

--- a/src/app/(protected)/admin/forms/_lib/formListFilters.ts
+++ b/src/app/(protected)/admin/forms/_lib/formListFilters.ts
@@ -1,0 +1,25 @@
+import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+
+export interface FormListFilter {
+  titleSearch: string;
+  labels: GetFormLabelsResponse;
+}
+
+export const filterForms = (
+  forms: GetFormsResponse,
+  filter: FormListFilter
+): GetFormsResponse => {
+  const normalizedSearch = filter.titleSearch.trim().toLowerCase();
+
+  return forms.filter((form) => {
+    const matchesTitle =
+      normalizedSearch.length === 0 ||
+      form.title.toLowerCase().includes(normalizedSearch);
+    const formLabelIds = new Set(form.labels.map((label) => label.id));
+    const matchesLabels =
+      filter.labels.length === 0 ||
+      filter.labels.every((label) => formLabelIds.has(label.id));
+
+    return matchesTitle && matchesLabels;
+  });
+};

--- a/src/app/(protected)/admin/users/_components/UserList.tsx
+++ b/src/app/(protected)/admin/users/_components/UserList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import UserListHeader from './UserListHeader';
 import UserRow from './UserRow';
+import { toUserListRows } from '../_lib/userListRows';
 import type { GetUserListResponse } from '@/lib/api-types';
 
 const UserList = ({
@@ -18,32 +19,32 @@ const UserList = ({
 }: {
   users: GetUserListResponse;
   currentUserId: string;
-}) => (
-  <Box sx={{ p: 3 }}>
-    <UserListHeader count={users.length} />
-    <TableContainer component={Paper} variant="outlined">
-      <Table>
-        <TableHead>
-          <TableRow sx={{ '& th': { fontWeight: 'bold' } }}>
-            <TableCell>ユーザー</TableCell>
-            <TableCell>UUID</TableCell>
-            <TableCell>現在の権限</TableCell>
-            <TableCell>権限の変更</TableCell>
-            <TableCell>回答投稿制限</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {users.map((user) => (
-            <UserRow
-              key={user.id}
-              user={user}
-              isSelf={user.id === currentUserId}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  </Box>
-);
+}) => {
+  const rows = toUserListRows(users, currentUserId);
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <UserListHeader count={rows.length} />
+      <TableContainer component={Paper} variant="outlined">
+        <Table>
+          <TableHead>
+            <TableRow sx={{ '& th': { fontWeight: 'bold' } }}>
+              <TableCell>ユーザー</TableCell>
+              <TableCell>UUID</TableCell>
+              <TableCell>現在の権限</TableCell>
+              <TableCell>権限の変更</TableCell>
+              <TableCell>回答投稿制限</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <UserRow key={row.user.id} row={row} />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
 
 export default UserList;

--- a/src/app/(protected)/admin/users/_components/UserRow.tsx
+++ b/src/app/(protected)/admin/users/_components/UserRow.tsx
@@ -4,40 +4,37 @@ import RoleChip from './RoleChip';
 import RoleSelectCell from './RoleSelectCell';
 import UserIdCell from './UserIdCell';
 import UserNameCell from './UserNameCell';
-import type { GetUserListResponse } from '@/lib/api-types';
+import type { UserListRow } from '../_lib/userListRows';
 
-const UserRow = ({
-  user,
-  isSelf,
-}: {
-  user: GetUserListResponse[number];
-  isSelf: boolean;
-}) => (
-  <TableRow hover sx={{ '&:last-child td': { border: 0 } }}>
-    <TableCell>
-      <UserNameCell id={user.id} name={user.name} />
-    </TableCell>
-    <TableCell>
-      <UserIdCell id={user.id} />
-    </TableCell>
-    <TableCell>
-      <RoleChip role={user.role} />
-    </TableCell>
-    <TableCell>
-      <RoleSelectCell
-        userId={user.id}
-        currentRole={user.role}
-        disabled={isSelf}
-      />
-    </TableCell>
-    <TableCell>
-      <RestrictionCell
-        userId={user.id}
-        userName={user.name}
-        disabled={isSelf}
-      />
-    </TableCell>
-  </TableRow>
-);
+const UserRow = ({ row }: { row: UserListRow }) => {
+  const { user } = row;
+  return (
+    <TableRow hover sx={{ '&:last-child td': { border: 0 } }}>
+      <TableCell>
+        <UserNameCell id={user.id} name={user.name} />
+      </TableCell>
+      <TableCell>
+        <UserIdCell id={user.id} />
+      </TableCell>
+      <TableCell>
+        <RoleChip role={user.role} />
+      </TableCell>
+      <TableCell>
+        <RoleSelectCell
+          userId={user.id}
+          currentRole={user.role}
+          disabled={!row.canManageRole}
+        />
+      </TableCell>
+      <TableCell>
+        <RestrictionCell
+          userId={user.id}
+          userName={user.name}
+          disabled={!row.canManageRestriction}
+        />
+      </TableCell>
+    </TableRow>
+  );
+};
 
 export default UserRow;

--- a/src/app/(protected)/admin/users/_lib/userListRows.ts
+++ b/src/app/(protected)/admin/users/_lib/userListRows.ts
@@ -1,0 +1,22 @@
+import type { GetUserListResponse } from '@/lib/api-types';
+
+export interface UserListRow {
+  user: GetUserListResponse[number];
+  isSelf: boolean;
+  canManageRole: boolean;
+  canManageRestriction: boolean;
+}
+
+export const toUserListRows = (
+  users: GetUserListResponse,
+  currentUserId: string
+): UserListRow[] =>
+  users.map((user) => {
+    const isSelf = user.id === currentUserId;
+    return {
+      user,
+      isSelf,
+      canManageRole: !isSelf,
+      canManageRestriction: !isSelf,
+    };
+  });

--- a/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -1,14 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { errorResponseSchema } from '@/lib/api/errors';
 import { proxyClient } from '@/lib/proxyClient';
-import { toRestrictionExpiration } from '@/lib/restrictions/expiration';
+import { parseSubmissionError } from '../_lib/submissionErrors';
 import { isTemporaryUserField, TEMPORARY_USER_FIELDS } from './answerFormTypes';
 import type { AnswerFormInput } from './answerFormTypes';
-import type { ErrorRestriction } from '@/lib/api/errors';
+import type { SubmissionError } from '../_lib/submissionErrors';
 import type { ApiPaths } from '@/lib/api/types';
-import type { RestrictionExpiration } from '@/lib/restrictions/expiration';
 
 type AnswerCreateBody =
   ApiPaths['/api/v1/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
@@ -16,15 +14,6 @@ type TemporaryAnswerCreateBody =
   ApiPaths['/api/v1/forms/{id}/temporary-answers']['post']['requestBody']['content']['application/json'];
 type AnswerContents = AnswerCreateBody['contents'];
 
-type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'RESTRICTED' | 'UNKNOWN';
-type SubmissionRestriction = {
-  reason: string;
-  expiration: RestrictionExpiration;
-};
-type SubmissionError =
-  | { kind: 'outOfPeriod' }
-  | { kind: 'restricted'; restriction?: SubmissionRestriction }
-  | { kind: 'unknown' };
 export type SubmissionState =
   | { kind: 'editing' }
   | { kind: 'submitted' }
@@ -75,47 +64,9 @@ const toTemporaryUser = (
   };
 };
 
-type ParsedSubmissionError = {
-  code: SubmissionErrorCode;
-  restriction?: SubmissionRestriction;
-};
-
-const toSubmissionRestriction = (
-  restriction: ErrorRestriction
-): SubmissionRestriction => ({
-  reason: restriction.reason,
-  expiration: toRestrictionExpiration(restriction.expires_at),
-});
-
-export const parseSubmissionError = (
-  error: unknown
-): ParsedSubmissionError | null => {
-  const parsed = errorResponseSchema.safeParse(error);
-
-  if (!parsed.success) {
-    return null;
-  }
-
-  // 回答投稿制限によるエラーは errorCode で判定する（restriction の有無に依存しない）。
-  if (parsed.data.errorCode === 'ANSWER_SUBMISSION_RESTRICTED') {
-    return {
-      code: 'RESTRICTED',
-      ...(parsed.data.restriction
-        ? { restriction: toSubmissionRestriction(parsed.data.restriction) }
-        : {}),
-    };
-  }
-
-  if (parsed.data.errorCode === 'OUT_OF_PERIOD') {
-    return { code: 'OUT_OF_PERIOD' };
-  }
-
-  return null;
-};
-
 /**
  * 回答送信の state と API interaction を UI から分離する hook。
- * payload 変換と API エラー解釈はここを正本にする。
+ * payload 変換と送信状態の更新はここを正本にする。
  */
 export const useAnswerSubmission = (
   formId: string,

--- a/src/app/(public)/forms/[formId]/_lib/submissionErrors.ts
+++ b/src/app/(public)/forms/[formId]/_lib/submissionErrors.ts
@@ -1,0 +1,53 @@
+import { errorResponseSchema } from '@/lib/api/errors';
+import { toRestrictionExpiration } from '@/lib/restrictions/expiration';
+import type { ErrorRestriction } from '@/lib/api/errors';
+import type { RestrictionExpiration } from '@/lib/restrictions/expiration';
+
+export type SubmissionErrorCode = 'OUT_OF_PERIOD' | 'RESTRICTED' | 'UNKNOWN';
+
+export type SubmissionRestriction = {
+  reason: string;
+  expiration: RestrictionExpiration;
+};
+
+export type SubmissionError =
+  | { kind: 'outOfPeriod' }
+  | { kind: 'restricted'; restriction?: SubmissionRestriction }
+  | { kind: 'unknown' };
+
+type ParsedSubmissionError = {
+  code: SubmissionErrorCode;
+  restriction?: SubmissionRestriction;
+};
+
+const toSubmissionRestriction = (
+  restriction: ErrorRestriction
+): SubmissionRestriction => ({
+  reason: restriction.reason,
+  expiration: toRestrictionExpiration(restriction.expires_at),
+});
+
+export const parseSubmissionError = (
+  error: unknown
+): ParsedSubmissionError | null => {
+  const parsed = errorResponseSchema.safeParse(error);
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  if (parsed.data.errorCode === 'ANSWER_SUBMISSION_RESTRICTED') {
+    return {
+      code: 'RESTRICTED',
+      ...(parsed.data.restriction
+        ? { restriction: toSubmissionRestriction(parsed.data.restriction) }
+        : {}),
+    };
+  }
+
+  if (parsed.data.errorCode === 'OUT_OF_PERIOD') {
+    return { code: 'OUT_OF_PERIOD' };
+  }
+
+  return null;
+};

--- a/tests/unit/answerSubmission.test.ts
+++ b/tests/unit/answerSubmission.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseSubmissionError } from '@/app/(public)/forms/[formId]/_components/useAnswerSubmission';
+import { parseSubmissionError } from '@/app/(public)/forms/[formId]/_lib/submissionErrors';
 
 describe('parseSubmissionError', () => {
   it('制限エラーの nullable な解除予定を送信用 model に変換する', () => {

--- a/tests/unit/formListFilters.test.ts
+++ b/tests/unit/formListFilters.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { filterForms } from '@/app/(protected)/admin/forms/_lib/formListFilters';
+import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+
+const labels = {
+  event: { id: 'label-event', name: 'イベント' },
+  support: { id: 'label-support', name: 'サポート' },
+  private: { id: 'label-private', name: '非公開' },
+} satisfies Record<string, GetFormLabelsResponse[number]>;
+
+const form = (
+  id: string,
+  title: string,
+  formLabels: GetFormLabelsResponse
+): GetFormsResponse[number] => ({
+  description: '',
+  id,
+  labels: formLabels,
+  metadata: {
+    created_at: '2026-06-01T00:00:00+09:00',
+    updated_at: '2026-06-01T00:00:00+09:00',
+  },
+  questions: [],
+  settings: {
+    allow_temporary_answers: false,
+    answer_settings: {
+      acceptance_period: {},
+      visibility: 'PUBLIC',
+    },
+    discord_webhook_url: null,
+    visibility: 'PUBLIC',
+  },
+  title,
+});
+
+const forms = [
+  form('form-1', 'イベント参加申請', [labels.event, labels.support]),
+  form('form-2', 'サポート問い合わせ', [labels.support]),
+  form('form-3', 'Private Application', [labels.private]),
+] satisfies GetFormsResponse;
+
+describe('filterForms', () => {
+  it('タイトル検索は前後空白と大文字小文字を無視して絞り込む', () => {
+    const filtered = filterForms(forms, {
+      titleSearch: '  private  ',
+      labels: [],
+    });
+
+    expect(filtered.map((form) => form.id)).toEqual(['form-3']);
+  });
+
+  it('選択したラベルをすべて持つフォームだけを残す', () => {
+    const filtered = filterForms(forms, {
+      titleSearch: '',
+      labels: [labels.event, labels.support],
+    });
+
+    expect(filtered.map((form) => form.id)).toEqual(['form-1']);
+  });
+
+  it('タイトル検索とラベル条件を同時に満たすフォームだけを残す', () => {
+    const filtered = filterForms(forms, {
+      titleSearch: 'サポート',
+      labels: [labels.event],
+    });
+
+    expect(filtered.map((form) => form.id)).toEqual([]);
+  });
+});

--- a/tests/unit/userListRows.test.ts
+++ b/tests/unit/userListRows.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { toUserListRows } from '@/app/(protected)/admin/users/_lib/userListRows';
+import type { GetUserListResponse } from '@/lib/api-types';
+
+const users = [
+  { id: 'self-user', name: '自分', role: 'ADMINISTRATOR' },
+  { id: 'other-user', name: '他のユーザー', role: 'STANDARD_USER' },
+] satisfies GetUserListResponse;
+
+describe('toUserListRows', () => {
+  it('現在のユーザーだけ権限変更と制限管理を無効にする', () => {
+    const rows = toUserListRows(users, 'self-user');
+
+    expect(rows).toEqual([
+      {
+        user: users[0],
+        isSelf: true,
+        canManageRole: false,
+        canManageRestriction: false,
+      },
+      {
+        user: users[1],
+        isSelf: false,
+        canManageRole: true,
+        canManageRestriction: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要
- フォーム一覧のタイトル・ラベル絞り込みを `_lib` の純粋関数へ切り出し、状態管理を小さな hook に分離しました。
- ユーザー一覧の自分自身に対する操作可否判定を表示用モデルへ切り出し、回答投稿エラー解釈も hook から `_lib` へ移しました。
- フォーム一覧フィルタとユーザー一覧モデルに unit test を追加し、既存の回答投稿エラー解釈テストは移動後の `_lib` を検証するよう更新しました。

## 確認事項
- `pnpm test:unit` で、追加したテストを含む unit test 全体が通ることを確認しました。
- `pnpm type-check` で、切り出し後も型エラーがないことを確認しました。
- `pnpm lint` と `pnpm fmt` で、lint とフォーマットが通ることを確認しました。
- `pnpm build` で、Next.js の production build が成功することを確認しました。

Closes #774

🤖 Generated with Codex