### PR TITLE
ページ責務分担の代表例を整える

### DIFF
--- a/src/app/(protected)/(standard)/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormsPageContent.tsx
@@ -4,7 +4,7 @@ import type { GetFormsResponse } from '@/lib/api-types';
 
 const FormsPageContent = ({ forms }: { forms: GetFormsResponse }) => (
   <Box sx={{ width: '100%' }}>
-    <Typography variant="h5" sx={{ mb: 3 }}>
+    <Typography variant="h5" component="h1" sx={{ mb: 3 }}>
       フォーム一覧
     </Typography>
     <FormsView forms={forms} />

--- a/src/app/(protected)/(standard)/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormsPageContent.tsx
@@ -1,0 +1,14 @@
+import { Box, Typography } from '@mui/material';
+import FormsView from './FormsView';
+import type { GetFormsResponse } from '@/lib/api-types';
+
+const FormsPageContent = ({ forms }: { forms: GetFormsResponse }) => (
+  <Box sx={{ width: '100%' }}>
+    <Typography variant="h5" sx={{ mb: 3 }}>
+      フォーム一覧
+    </Typography>
+    <FormsView forms={forms} />
+  </Box>
+);
+
+export default FormsPageContent;

--- a/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
@@ -78,11 +78,11 @@ const EachForm = ({ form }: { form: FormItem }) => {
   );
 };
 
-interface Props {
+interface FormsViewProps {
   forms: GetFormsResponse;
 }
 
-const FormList = ({ forms }: Props) => {
+const FormsView = ({ forms }: FormsViewProps) => {
   return (
     <Box sx={{ width: '100%' }}>
       {forms.length === 0 ? (
@@ -103,4 +103,4 @@ const FormList = ({ forms }: Props) => {
   );
 };
 
-export default FormList;
+export default FormsView;

--- a/src/app/(protected)/(standard)/forms/page.tsx
+++ b/src/app/(protected)/(standard)/forms/page.tsx
@@ -1,5 +1,4 @@
-import { Box, Typography } from '@mui/material';
-import FormList from './_components/FormList';
+import FormsPageContent from './_components/FormsPageContent';
 import {
   authorizationHeader,
   requireBackendData,
@@ -20,14 +19,7 @@ const Home = async () => {
     })
   );
 
-  return (
-    <Box sx={{ width: '100%' }}>
-      <Typography variant="h5" sx={{ mb: 3 }}>
-        フォーム一覧
-      </Typography>
-      <FormList forms={forms} />
-    </Box>
-  );
+  return <FormsPageContent forms={forms} />;
 };
 
 export default Home;

--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -4,7 +4,7 @@ import { Alert, Button, Snackbar, Stack } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import FormsTable from './FormsTable';
+import FormsView from './FormsView';
 import FormsToolbar from './FormsToolbar';
 import { useFormListFilters } from '../_hooks/useFormListFilters';
 import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
@@ -37,7 +37,10 @@ const FormsPageContent = ({
         onTitleSearchChange={setTitleSearch}
         onLabelFilterChange={setLabelFilter}
       />
-      <FormsTable forms={filteredForms} />
+      <FormsView
+        forms={filteredForms}
+        onFormClick={(formId) => router.push(`/forms/${formId}/answers`)}
+      />
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={10000}

--- a/src/app/(protected)/admin/forms/_components/FormsView.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsView.tsx
@@ -10,7 +10,6 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { useRouter } from 'next/navigation';
 import FormRowMenu from './FormRowMenu';
 import LabelChips from './LabelChips';
 import {
@@ -21,11 +20,10 @@ import type { GetFormsResponse } from '@/lib/api-types';
 
 interface Props {
   forms: GetFormsResponse;
+  onFormClick: (formId: string) => void;
 }
 
-const FormsTable = ({ forms }: Props) => {
-  const router = useRouter();
-
+const FormsView = ({ forms, onFormClick }: Props) => {
   return (
     <TableContainer component={Paper} variant="outlined">
       <Table>
@@ -52,7 +50,7 @@ const FormsTable = ({ forms }: Props) => {
                 key={form.id}
                 hover
                 sx={{ cursor: 'pointer', height: 64 }}
-                onClick={() => router.push(`/forms/${form.id}/answers`)}
+                onClick={() => onFormClick(form.id)}
               >
                 <TableCell>
                   <Typography variant="body1">{form.title}</Typography>
@@ -85,4 +83,4 @@ const FormsTable = ({ forms }: Props) => {
   );
 };
 
-export default FormsTable;
+export default FormsView;

--- a/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
@@ -1,0 +1,17 @@
+import UsersView from './UsersView';
+import { toUserListRows } from '../_lib/userListRows';
+import type { GetUserListResponse } from '@/lib/api-types';
+
+const UsersPageContent = ({
+  users,
+  currentUserId,
+}: {
+  users: GetUserListResponse;
+  currentUserId: string;
+}) => {
+  const rows = toUserListRows(users, currentUserId);
+
+  return <UsersView rows={rows} />;
+};
+
+export default UsersPageContent;

--- a/src/app/(protected)/admin/users/_components/UsersView.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersView.tsx
@@ -10,18 +10,9 @@ import {
 } from '@mui/material';
 import UserListHeader from './UserListHeader';
 import UserRow from './UserRow';
-import { toUserListRows } from '../_lib/userListRows';
-import type { GetUserListResponse } from '@/lib/api-types';
+import type { UserListRow } from '../_lib/userListRows';
 
-const UserList = ({
-  users,
-  currentUserId,
-}: {
-  users: GetUserListResponse;
-  currentUserId: string;
-}) => {
-  const rows = toUserListRows(users, currentUserId);
-
+const UsersView = ({ rows }: { rows: UserListRow[] }) => {
   return (
     <Box sx={{ p: 3 }}>
       <UserListHeader count={rows.length} />
@@ -47,4 +38,4 @@ const UserList = ({
   );
 };
 
-export default UserList;
+export default UsersView;

--- a/src/app/(protected)/admin/users/page.tsx
+++ b/src/app/(protected)/admin/users/page.tsx
@@ -1,4 +1,4 @@
-import UserList from './_components/UserList';
+import UsersPageContent from './_components/UsersPageContent';
 import {
   authorizationHeader,
   requireBackendData,
@@ -19,7 +19,7 @@ const Home = async () => {
     })
   );
 
-  return <UserList users={users} currentUserId={session.user.id} />;
+  return <UsersPageContent users={users} currentUserId={session.user.id} />;
 };
 
 export default Home;


### PR DESCRIPTION
## 概要
- Issue #775 の代表例として、フォーム一覧とユーザー管理を `page.tsx` / `XxxPageContent` / `XxxView` の構成へ整理しました。
- `page.tsx` は認証と server side の API 取得に寄せ、見出しや行データ変換は PageContent 側、表示 JSX は View 側へ分けています。
- 管理フォーム一覧では一覧行クリックの router 依存を `FormsPageContent` に移し、`FormsView` は props と callback を受け取る表示 component に寄せました。

Closes #775

## 確認事項
- `pnpm type-check` により、分離後も型エラーがないことを確認しました。
- `pnpm lint` と `pnpm fmt` により、変更ファイルを含む lint/format が通ることを確認しました。
- `pnpm build` により、Next.js App Router の production build が成功することを確認しました。
- push 時の pre-push hook で `pnpm test:unit` が実行され、10 files / 50 tests が通ることを確認しました。

🤖 Generated with Codex