### PR TITLE
主要コンポーネントの操作テストを追加

### DIFF
--- a/tests/component/ChoiceEditor.test.tsx
+++ b/tests/component/ChoiceEditor.test.tsx
@@ -1,0 +1,46 @@
+import userEvent from '@testing-library/user-event';
+import { useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import ChoiceEditor from '@/app/(protected)/admin/forms/_components/ChoiceEditor';
+import { createEmptyFormEditorValues } from '@/app/(protected)/admin/forms/_lib/formEditorDefaults';
+import type { FormEditorValues } from '@/app/(protected)/admin/forms/_schema/formEditorSchema';
+
+import { renderWithProviders, screen } from './render';
+
+const ChoiceEditorExample = () => {
+  const { control, register } = useForm<FormEditorValues>({
+    defaultValues: createEmptyFormEditorValues(),
+  });
+
+  return (
+    <ChoiceEditor control={control} register={register} questionIndex={0} />
+  );
+};
+
+describe('ChoiceEditor', () => {
+  it('質問種別に合わせて選択肢入力を追加・削除する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<ChoiceEditorExample />);
+
+    expect(screen.getByRole('button', { name: '選択肢の追加' })).toBeDisabled();
+
+    await user.click(screen.getByRole('combobox', { name: /質問の種類/ }));
+    await user.click(screen.getByRole('option', { name: '単一選択' }));
+
+    expect(screen.getByRole('textbox', { name: '選択肢1' })).toBeVisible();
+    expect(screen.getByRole('button', { name: '選択肢の追加' })).toBeEnabled();
+
+    await user.type(screen.getByRole('textbox', { name: '選択肢1' }), 'はい');
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('textbox', { name: '選択肢2' })).toBeVisible();
+
+    await user.click(screen.getByRole('combobox', { name: /質問の種類/ }));
+    await user.click(screen.getByRole('option', { name: 'テキスト' }));
+
+    expect(screen.queryByRole('textbox', { name: '選択肢1' })).toBeNull();
+    expect(screen.getByRole('button', { name: '選択肢の追加' })).toBeDisabled();
+  });
+});

--- a/tests/component/DiscordNotificationSettings.test.tsx
+++ b/tests/component/DiscordNotificationSettings.test.tsx
@@ -1,0 +1,72 @@
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DiscordNotificationSettings from '@/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings';
+import type {
+  GetUserNotificationSettingsResponse,
+  UpdateNotificationSettingsSchema,
+} from '@/lib/api-types';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+type NotificationSettingsMocks = {
+  updateSettings: ReturnType<
+    typeof vi.fn<
+      (data: UpdateNotificationSettingsSchema) => Promise<{ ok: boolean }>
+    >
+  >;
+};
+
+const notificationSettingsMocks = vi.hoisted<NotificationSettingsMocks>(() => ({
+  updateSettings:
+    vi.fn<
+      (data: UpdateNotificationSettingsSchema) => Promise<{ ok: boolean }>
+    >(),
+}));
+
+vi.mock('@/hooks/useNotificationSettings', () => ({
+  useNotificationSettings: () => ({
+    updateSettings: notificationSettingsMocks.updateSettings,
+  }),
+}));
+
+const currentSettings = {
+  is_send_message_notification: false,
+} satisfies GetUserNotificationSettingsResponse;
+
+describe('DiscordNotificationSettings', () => {
+  beforeEach(() => {
+    notificationSettingsMocks.updateSettings.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('チェック状態を通知設定更新 body に変換して保存する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <DiscordNotificationSettings
+        currentSettings={currentSettings}
+        userId="user-id"
+      />
+    );
+
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: '自身の回答に対するメッセージ通知を受け取る',
+      })
+    );
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(notificationSettingsMocks.updateSettings).toHaveBeenCalledWith({
+        is_send_message_notification: true,
+      });
+    });
+    expect(window.alert).toHaveBeenCalledWith('設定を更新しました');
+  });
+});

--- a/tests/component/RestrictionDialogBody.test.tsx
+++ b/tests/component/RestrictionDialogBody.test.tsx
@@ -85,9 +85,9 @@ describe('RestrictionDialogBody', () => {
       expect(restrictionMocks.restrictUser).toHaveBeenCalledWith('user-uuid', {
         reason: '迷惑投稿',
       });
+      expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
+      expect(onClose).toHaveBeenCalledOnce();
     });
-    expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
-    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it('理由が空白だけなら制限を付与せず validation error を表示する', async () => {
@@ -127,8 +127,8 @@ describe('RestrictionDialogBody', () => {
 
     await waitFor(() => {
       expect(restrictionMocks.unrestrictUser).toHaveBeenCalledWith('user-uuid');
+      expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
+      expect(onClose).toHaveBeenCalledOnce();
     });
-    expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
-    expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/tests/component/RestrictionDialogBody.test.tsx
+++ b/tests/component/RestrictionDialogBody.test.tsx
@@ -1,0 +1,134 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RestrictionDialogBody from '@/app/(protected)/admin/users/_components/RestrictionDialogBody';
+import type {
+  GetAnswerSubmitterRestrictionResponse,
+  PutAnswerSubmitterRestrictionSchema,
+} from '@/lib/api-types';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+type RestrictionQueryState = {
+  data: GetAnswerSubmitterRestrictionResponse;
+  error: Error | null;
+  isLoading: boolean;
+  mutate: ReturnType<typeof vi.fn<() => Promise<void>>>;
+};
+
+type RestrictionMocks = {
+  queryState: RestrictionQueryState;
+  restrictUser: ReturnType<
+    typeof vi.fn<
+      (
+        uuid: string,
+        body: PutAnswerSubmitterRestrictionSchema
+      ) => Promise<{ success: boolean }>
+    >
+  >;
+  unrestrictUser: ReturnType<
+    typeof vi.fn<(uuid: string) => Promise<{ success: boolean }>>
+  >;
+};
+
+const restrictionMocks = vi.hoisted<RestrictionMocks>(() => ({
+  queryState: {
+    data: null,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn<() => Promise<void>>(),
+  },
+  restrictUser:
+    vi.fn<
+      (
+        uuid: string,
+        body: PutAnswerSubmitterRestrictionSchema
+      ) => Promise<{ success: boolean }>
+    >(),
+  unrestrictUser: vi.fn<(uuid: string) => Promise<{ success: boolean }>>(),
+}));
+
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: () => restrictionMocks.queryState,
+}));
+
+vi.mock('@/hooks/useAnswerSubmitterRestrictionActions', () => ({
+  useAnswerSubmitterRestrictionActions: () => ({
+    restrictUser: restrictionMocks.restrictUser,
+    unrestrictUser: restrictionMocks.unrestrictUser,
+  }),
+}));
+
+describe('RestrictionDialogBody', () => {
+  beforeEach(() => {
+    restrictionMocks.queryState.data = null;
+    restrictionMocks.queryState.error = null;
+    restrictionMocks.queryState.isLoading = false;
+    restrictionMocks.queryState.mutate.mockResolvedValue();
+    restrictionMocks.restrictUser.mockResolvedValue({ success: true });
+    restrictionMocks.unrestrictUser.mockResolvedValue({ success: true });
+    vi.clearAllMocks();
+  });
+
+  it('未制限ユーザーに理由を入力して制限を付与する', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderWithProviders(
+      <RestrictionDialogBody uuid="user-uuid" onClose={onClose} />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: /理由/ }), '迷惑投稿');
+    await user.click(screen.getByRole('button', { name: '制限する' }));
+
+    await waitFor(() => {
+      expect(restrictionMocks.restrictUser).toHaveBeenCalledWith('user-uuid', {
+        reason: '迷惑投稿',
+      });
+    });
+    expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('理由が空白だけなら制限を付与せず validation error を表示する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <RestrictionDialogBody uuid="user-uuid" onClose={vi.fn()} />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: /理由/ }), '   ');
+    await user.click(screen.getByRole('button', { name: '制限する' }));
+
+    expect(await screen.findByText('理由を入力してください')).toBeVisible();
+    expect(restrictionMocks.restrictUser).not.toHaveBeenCalled();
+  });
+
+  it('制限中ユーザーは現在の制限を表示して解除できる', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    restrictionMocks.queryState.data = {
+      expires_at: null,
+      id: 'restriction-id',
+      reason: '迷惑投稿',
+      restricted_at: '2026-06-29T10:00:00+09:00',
+      restricted_by: 'operator-id',
+      submitter_id: 'user-uuid',
+    };
+
+    renderWithProviders(
+      <RestrictionDialogBody uuid="user-uuid" onClose={onClose} />
+    );
+
+    expect(screen.getByText(/理由:/)).toBeVisible();
+    expect(screen.getByText(/迷惑投稿/)).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: '制限を解除する' }));
+
+    await waitFor(() => {
+      expect(restrictionMocks.unrestrictUser).toHaveBeenCalledWith('user-uuid');
+    });
+    expect(restrictionMocks.queryState.mutate).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/component/setup.ts
+++ b/tests/component/setup.ts
@@ -1,8 +1,13 @@
 import '@testing-library/jest-dom/vitest';
 
+import { cleanup } from '@testing-library/react';
 import { createElement } from 'react';
 import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 
 vi.mock('next/navigation', () => ({
   redirect: vi.fn(),


### PR DESCRIPTION
## 概要
- PR #782 で追加した component test 基盤のフォローアップとして、制限ダイアログ、質問選択肢エディタ、通知設定フォームの操作テストを追加しました。
- React Hook Form、MUI、hook 境界を通る submit payload や表示状態を確認し、unit test だけでは守りにくい UI 経路を固定しました。
- component test 間で DOM が残らないよう、setup で Testing Library の cleanup を実行します。

## 確認事項
- `pnpm test:component` で component test 4 ファイル / 6 件が通ることを確認しました。
- `pnpm test:unit` で既存 unit test 10 ファイル / 50 件が通ることを確認しました。
- `pnpm type-check`、`pnpm lint`、`pnpm fmt` が通ることを確認しました。
- commit 時の pre-commit で lint / type-check / fmt が通り、push 時の pre-push で unit test が通ることを確認しました。

🤖 Generated with Codex