### PR TITLE
単一選択の回答を未選択に戻せるようにする

### DIFF
--- a/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -10,7 +10,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -40,9 +39,6 @@ const AnswerSubmissionForm = ({
   isTemporary,
   onSubmitAnswers,
 }: Props) => {
-  const [selectedValues, setSelectedValues] = useState<Record<string, string>>(
-    {}
-  );
   const {
     control,
     register,
@@ -58,7 +54,6 @@ const AnswerSubmissionForm = ({
     }
 
     reset();
-    setSelectedValues({});
   };
 
   return (
@@ -138,8 +133,6 @@ const AnswerSubmissionForm = ({
                   control={control}
                   register={register}
                   errors={errors}
-                  selectedValues={selectedValues}
-                  setSelectedValues={setSelectedValues}
                 />
               </Stack>
             </Paper>

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -51,13 +51,20 @@ const QuestionFieldRenderer = ({
       );
     case 'SingleChoice':
       return (
-        <FormControl fullWidth sx={{ mt: 2 }}>
+        <FormControl
+          fullWidth
+          sx={{ mt: 2 }}
+          error={Boolean(errors[questionId])}
+        >
           <InputLabel id={`select-label-${questionId}`} shrink>
             選択してください
           </InputLabel>
           <Controller
             control={control}
             name={questionId}
+            rules={{
+              required: question.is_required ? '選択してください。' : false,
+            }}
             render={({ field }) => {
               const fieldValue =
                 typeof field.value === 'string' ? field.value : '';
@@ -65,11 +72,11 @@ const QuestionFieldRenderer = ({
               return (
                 <Select
                   {...field}
-                  required={question.is_required}
                   fullWidth
                   labelId={`select-label-${questionId}`}
                   label="選択してください"
                   value={fieldValue}
+                  inputProps={{ 'aria-required': question.is_required }}
                   onChange={(event) => {
                     const nextValue = event.target.value;
                     if (typeof nextValue !== 'string') {
@@ -95,6 +102,9 @@ const QuestionFieldRenderer = ({
               );
             }}
           />
+          {errors[questionId] && (
+            <FormHelperText>{errors[questionId].message}</FormHelperText>
+          )}
         </FormControl>
       );
     case 'MultipleChoice':

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -11,7 +11,6 @@ import {
   MenuItem,
   Select,
 } from '@mui/material';
-import type { Dispatch, SetStateAction } from 'react';
 import { Controller } from 'react-hook-form';
 import type { Control, FieldErrors, UseFormRegister } from 'react-hook-form';
 
@@ -22,8 +21,6 @@ type Props = {
   control: Control<AnswerFormInput>;
   register: UseFormRegister<AnswerFormInput>;
   errors: FieldErrors<AnswerFormInput>;
-  selectedValues: Record<string, string>;
-  setSelectedValues: Dispatch<SetStateAction<Record<string, string>>>;
 };
 
 const requiredMultiSelectMessage =
@@ -38,7 +35,6 @@ const QuestionFieldRenderer = ({
   control,
   register,
   errors,
-  setSelectedValues,
 }: Props) => {
   const questionId = question.id;
 
@@ -56,45 +52,48 @@ const QuestionFieldRenderer = ({
     case 'SingleChoice':
       return (
         <FormControl fullWidth sx={{ mt: 2 }}>
-          <InputLabel id={`select-label-${questionId}`}>
+          <InputLabel id={`select-label-${questionId}`} shrink>
             選択してください
           </InputLabel>
           <Controller
             control={control}
             name={questionId}
-            render={({ field }) => (
-              <Select
-                {...field}
-                required={question.is_required}
-                fullWidth
-                labelId={`select-label-${questionId}`}
-                label="選択してください"
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defaultValues 未指定のため初期レンダリング時に undefined になりうる
-                value={field.value ?? ''}
-                onChange={(event) => {
-                  const nextValue = event.target.value;
-                  if (typeof nextValue !== 'string') {
-                    return;
-                  }
+            render={({ field }) => {
+              const fieldValue =
+                typeof field.value === 'string' ? field.value : '';
 
-                  field.onChange(nextValue);
-                  setSelectedValues((current) => ({
-                    ...current,
-                    [questionId]: nextValue,
-                  }));
-                }}
-                displayEmpty
-              >
-                {question.choices.map((choice, index) => (
-                  <MenuItem
-                    key={`q-${questionId}.a-${index}`}
-                    value={choice.label}
-                  >
-                    {choice.label}
+              return (
+                <Select
+                  {...field}
+                  required={question.is_required}
+                  fullWidth
+                  labelId={`select-label-${questionId}`}
+                  label="選択してください"
+                  value={fieldValue}
+                  onChange={(event) => {
+                    const nextValue = event.target.value;
+                    if (typeof nextValue !== 'string') {
+                      return;
+                    }
+
+                    field.onChange(nextValue);
+                  }}
+                  displayEmpty
+                >
+                  <MenuItem value="">
+                    <em>未選択</em>
                   </MenuItem>
-                ))}
-              </Select>
-            )}
+                  {question.choices.map((choice, index) => (
+                    <MenuItem
+                      key={`q-${questionId}.a-${index}`}
+                      value={choice.label}
+                    >
+                      {choice.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              );
+            }}
           />
         </FormControl>
       );

--- a/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -24,11 +24,15 @@ export type SubmissionState =
 
 // 質問の回答（key は質問 UUID）だけを contents に変換する。
 // 未ログイン回答の投稿者情報フィールドは除外する。
-const toAnswerContents = (data: AnswerFormInput): AnswerContents =>
+export const toAnswerContents = (data: AnswerFormInput): AnswerContents =>
   Object.entries(data)
     .filter(([key]) => !isTemporaryUserField(key))
     .flatMap(([key, values]) => {
       if (typeof values === 'string') {
+        if (values === '') {
+          return [];
+        }
+
         return {
           question_id: key,
           answer: values,

--- a/tests/component/AnswerSubmissionForm.test.tsx
+++ b/tests/component/AnswerSubmissionForm.test.tsx
@@ -26,6 +26,22 @@ const questions: GetQuestionsResponse = [
   },
 ];
 
+const singleChoiceQuestions: GetQuestionsResponse = [
+  {
+    id: '0c2a6f9a-28c2-4116-835b-fdd7289a16f1',
+    template_key: 'contact_reason',
+    title: 'お問い合わせ種別',
+    description: '',
+    is_required: false,
+    position: 1,
+    question_type: 'SingleChoice',
+    choices: [
+      { id: 1, label: '申請について', position: 1 },
+      { id: 2, label: 'その他', position: 2 },
+    ],
+  },
+];
+
 describe('AnswerSubmissionForm', () => {
   it('一時回答者の入力値と質問の回答を submitter に渡す', async () => {
     const user = userEvent.setup();
@@ -61,6 +77,35 @@ describe('AnswerSubmissionForm', () => {
         [TEMPORARY_USER_FIELDS.name]: 'テスト太郎',
         [TEMPORARY_USER_FIELDS.contactText]: 'test-user@example.com',
         '8f98a37f-9070-4624-b161-f288769160d5': ['運営に相談したい'],
+      });
+    });
+  });
+
+  it('単一選択の回答を未選択へ戻せる', async () => {
+    const user = userEvent.setup();
+    const onSubmitAnswers = vi
+      .fn<(data: AnswerFormInput) => Promise<{ ok: boolean }>>()
+      .mockResolvedValue({ ok: true });
+
+    renderWithProviders(
+      <AnswerSubmissionForm
+        questions={singleChoiceQuestions}
+        title="お問い合わせ"
+        description=""
+        isTemporary={false}
+        onSubmitAnswers={onSubmitAnswers}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: '申請について' }));
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: '未選択' }));
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    await waitFor(() => {
+      expect(onSubmitAnswers).toHaveBeenCalledWith({
+        '0c2a6f9a-28c2-4116-835b-fdd7289a16f1': '',
       });
     });
   });

--- a/tests/component/AnswerSubmissionForm.test.tsx
+++ b/tests/component/AnswerSubmissionForm.test.tsx
@@ -42,6 +42,22 @@ const singleChoiceQuestions: GetQuestionsResponse = [
   },
 ];
 
+const requiredSingleChoiceQuestions: GetQuestionsResponse = [
+  {
+    id: '0c2a6f9a-28c2-4116-835b-fdd7289a16f1',
+    template_key: 'contact_reason',
+    title: 'お問い合わせ種別',
+    description: '',
+    is_required: true,
+    position: 1,
+    question_type: 'SingleChoice',
+    choices: [
+      { id: 1, label: '申請について', position: 1 },
+      { id: 2, label: 'その他', position: 2 },
+    ],
+  },
+];
+
 describe('AnswerSubmissionForm', () => {
   it('一時回答者の入力値と質問の回答を submitter に渡す', async () => {
     const user = userEvent.setup();
@@ -108,5 +124,27 @@ describe('AnswerSubmissionForm', () => {
         '0c2a6f9a-28c2-4116-835b-fdd7289a16f1': '',
       });
     });
+  });
+
+  it('必須の単一選択が未選択の場合は送信しない', async () => {
+    const user = userEvent.setup();
+    const onSubmitAnswers = vi
+      .fn<(data: AnswerFormInput) => Promise<{ ok: boolean }>>()
+      .mockResolvedValue({ ok: true });
+
+    renderWithProviders(
+      <AnswerSubmissionForm
+        questions={requiredSingleChoiceQuestions}
+        title="お問い合わせ"
+        description=""
+        isTemporary={false}
+        onSubmitAnswers={onSubmitAnswers}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(await screen.findByText('選択してください。')).toBeVisible();
+    expect(onSubmitAnswers).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/answerSubmission.test.ts
+++ b/tests/unit/answerSubmission.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { TEMPORARY_USER_FIELDS } from '@/app/(public)/forms/[formId]/_components/answerFormTypes';
+import { toAnswerContents } from '@/app/(public)/forms/[formId]/_components/useAnswerSubmission';
 import { parseSubmissionError } from '@/app/(public)/forms/[formId]/_lib/submissionErrors';
 
 describe('parseSubmissionError', () => {
@@ -48,5 +50,22 @@ describe('parseSubmissionError', () => {
         },
       },
     });
+  });
+});
+
+describe('toAnswerContents', () => {
+  it('未選択の単一選択回答を contents から除外する', () => {
+    expect(
+      toAnswerContents({
+        [TEMPORARY_USER_FIELDS.name]: 'テスト太郎',
+        '0c2a6f9a-28c2-4116-835b-fdd7289a16f1': '',
+        '8f98a37f-9070-4624-b161-f288769160d5': '申請について',
+      })
+    ).toEqual([
+      {
+        question_id: '8f98a37f-9070-4624-b161-f288769160d5',
+        answer: '申請について',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## 概要
- 選択式の任意回答で、回答後も未選択へ戻せるように `未選択` の項目を追加しました。
- 未選択へ戻した単一選択の空文字は API payload から除外し、未回答として扱うようにしました。
- 不要になった選択値管理の state と `eslint-disable` を削除し、操作と送信変換のテストを追加しました。

## 確認事項
- 単一選択を選んだ後に `未選択` へ戻せることを component test で確認しました。
- 未選択の空文字が API payload に含まれないことを unit test で確認しました。
- pre-commit で lint、type-check、fmt が通ることを確認しました。
- pre-push で unit test 全件が通ることを確認しました。

🤖 Generated with Codex