### PR TITLE
Discord 通知設定変更時の alert を Snackbar に変更する

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -73,7 +73,7 @@ const DiscordNotificationSettings = (props: {
           void handleSubmit(onSubmit)(e);
         }}
       >
-        <Typography variant="h6" gutterBottom>
+        <Typography variant="h6" component="h2" gutterBottom>
           通知設定
         </Typography>
         <Divider sx={{ mb: 2 }} />

--- a/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -2,14 +2,17 @@
 
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import {
+  Alert,
   Button,
   CardContent,
   Divider,
   FormControlLabel,
+  Snackbar,
   Stack,
   Typography,
 } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { useNotificationSettings } from '@/hooks/useNotificationSettings';
@@ -20,6 +23,12 @@ import {
   toNotificationSettingsUpdateBody,
 } from './notificationSettingsForm';
 import type { NotificationSettingsFormValues } from './notificationSettingsForm';
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
 
 const DiscordNotificationSettings = (props: {
   currentSettings: GetUserNotificationSettingsResponse;
@@ -33,56 +42,89 @@ const DiscordNotificationSettings = (props: {
 
   const { updateSettings } = useNotificationSettings();
 
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
   const onSubmit = async (data: NotificationSettingsFormValues) => {
     const result = await updateSettings(toNotificationSettingsUpdateBody(data));
     if (result.ok) {
-      alert('設定を更新しました');
+      setSnackbar({
+        open: true,
+        message: '設定を更新しました',
+        severity: 'success',
+      });
     } else {
-      alert('通知設定の更新に失敗しました');
+      setSnackbar({
+        open: true,
+        message: '通知設定の更新に失敗しました',
+        severity: 'error',
+      });
     }
   };
 
   return (
-    <CardContent
-      component="form"
-      onSubmit={(e) => {
-        void handleSubmit(onSubmit)(e);
-      }}
-    >
-      <Typography variant="h6" gutterBottom>
-        通知設定
-      </Typography>
-      <Divider sx={{ mb: 2 }} />
-      <Stack spacing={2}>
-        <Controller
-          name="isSendMessageNotificationEnabled"
-          control={control}
-          render={({ field }) => (
-            <FormControlLabel
-              label="自身の回答に対するメッセージ通知を受け取る"
-              control={
-                <Checkbox
-                  checked={field.value}
-                  onChange={(_, checked) => {
-                    field.onChange(checked);
-                  }}
-                  onBlur={field.onBlur}
-                  ref={field.ref}
-                />
-              }
-            />
-          )}
-        />
-        <Button
-          variant="contained"
-          endIcon={<SaveAltIcon />}
-          type="submit"
-          sx={{ alignSelf: 'flex-start' }}
+    <>
+      <CardContent
+        component="form"
+        onSubmit={(e) => {
+          void handleSubmit(onSubmit)(e);
+        }}
+      >
+        <Typography variant="h6" gutterBottom>
+          通知設定
+        </Typography>
+        <Divider sx={{ mb: 2 }} />
+        <Stack spacing={2}>
+          <Controller
+            name="isSendMessageNotificationEnabled"
+            control={control}
+            render={({ field }) => (
+              <FormControlLabel
+                label="自身の回答に対するメッセージ通知を受け取る"
+                control={
+                  <Checkbox
+                    checked={field.value}
+                    onChange={(_, checked) => {
+                      field.onChange(checked);
+                    }}
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                  />
+                }
+              />
+            )}
+          />
+          <Button
+            variant="contained"
+            endIcon={<SaveAltIcon />}
+            type="submit"
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            保存
+          </Button>
+        </Stack>
+      </CardContent>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={(_, reason) => {
+          if (reason !== 'clickaway')
+            setSnackbar((prev) => ({ ...prev, open: false }));
+        }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => {
+            setSnackbar((prev) => ({ ...prev, open: false }));
+          }}
         >
-          保存
-        </Button>
-      </Stack>
-    </CardContent>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
   );
 };
 

--- a/tests/component/DiscordNotificationSettings.test.tsx
+++ b/tests/component/DiscordNotificationSettings.test.tsx
@@ -37,8 +37,6 @@ const currentSettings = {
 describe('DiscordNotificationSettings', () => {
   beforeEach(() => {
     notificationSettingsMocks.updateSettings.mockResolvedValue({ ok: true });
-    vi.spyOn(window, 'alert').mockImplementation(() => {});
-    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -67,6 +65,6 @@ describe('DiscordNotificationSettings', () => {
         is_send_message_notification: true,
       });
     });
-    expect(window.alert).toHaveBeenCalledWith('設定を更新しました');
+    await screen.findByText('設定を更新しました');
   });
 });


### PR DESCRIPTION
## 概要
- Discord 通知設定の保存結果通知を `window.alert` から MUI の `Snackbar` + `Alert` に変更
- ユーザー操作をブロックしない非同期通知にすることで、MUI ベースの UI と一貫性を持たせる
- テストも `window.alert` のスパイから Snackbar のテキスト表示検証に変更

## 確認事項
- `tsc --noEmit` で型チェック通過を確認
- ESLint / Prettier のチェック通過を確認（lefthook の pre-commit フックで検証済み）
- コンポーネントテストは MUI + react-transition-group のモジュール解決問題で既存テストも含め実行不可（今回の変更とは無関係の環境問題）

closes #784

🤖 Generated with Claude Code