### PR TITLE
feat: フォームの削除機能をアーカイブ機能に置き換える

### DIFF
--- a/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { MoreVert, Restore } from '@mui/icons-material';
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import { useState } from 'react';
+
+import { useFormActions } from '@/hooks/useFormActions';
+
+interface Props {
+  formId: string;
+  onRestored?: (() => void) | undefined;
+}
+
+const ArchivedFormRowMenu = ({ formId, onRestored }: Props) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const { restoreForm } = useFormActions();
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleRestore = async () => {
+    handleClose();
+    if (!confirm('このフォームを復元しますか？')) return;
+    const result = await restoreForm(formId);
+    if (result.ok) {
+      onRestored?.();
+    } else {
+      alert('復元に失敗しました');
+    }
+  };
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={handleOpen}
+        aria-label="アーカイブ済みフォーム操作メニュー"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <MenuItem
+          onClick={() => {
+            void handleRestore();
+          }}
+        >
+          <ListItemIcon>
+            <Restore fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>復元</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+export default ArchivedFormRowMenu;

--- a/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
@@ -2,6 +2,12 @@
 
 import { MoreVert, Restore } from '@mui/icons-material';
 import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -14,54 +20,79 @@ import { useFormActions } from '@/hooks/useFormActions';
 
 interface Props {
   formId: string;
-  onRestored?: (() => void) | undefined;
+  onResult?: ((result: { ok: boolean }) => void) | undefined;
 }
 
-const ArchivedFormRowMenu = ({ formId, onRestored }: Props) => {
+const ArchivedFormRowMenu = ({ formId, onResult }: Props) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const { restoreForm } = useFormActions();
-  const open = Boolean(anchorEl);
+  const menuOpen = Boolean(anchorEl);
 
-  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleMenuClose = () => {
     setAnchorEl(null);
   };
 
-  const handleRestore = async () => {
-    handleClose();
-    if (!confirm('このフォームを復元しますか？')) return;
+  const handleRestoreClick = () => {
+    handleMenuClose();
+    setDialogOpen(true);
+  };
+
+  const handleRestoreConfirm = async () => {
+    setDialogOpen(false);
     const result = await restoreForm(formId);
-    if (result.ok) {
-      onRestored?.();
-    } else {
-      alert('復元に失敗しました');
-    }
+    onResult?.(result);
   };
 
   return (
     <>
       <IconButton
         size="small"
-        onClick={handleOpen}
+        onClick={handleMenuOpen}
         aria-label="アーカイブ済みフォーム操作メニュー"
       >
         <MoreVert />
       </IconButton>
-      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem
-          onClick={() => {
-            void handleRestore();
-          }}
-        >
+      <Menu anchorEl={anchorEl} open={menuOpen} onClose={handleMenuClose}>
+        <MenuItem onClick={handleRestoreClick}>
           <ListItemIcon>
             <Restore fontSize="small" />
           </ListItemIcon>
           <ListItemText>復元</ListItemText>
         </MenuItem>
       </Menu>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <DialogTitle>フォームの復元</DialogTitle>
+        <DialogContent>
+          <DialogContentText>このフォームを復元しますか？</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setDialogOpen(false);
+            }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={() => {
+              void handleRestoreConfirm();
+            }}
+            autoFocus
+          >
+            復元
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/ArchivedFormsView.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormsView.tsx
@@ -10,23 +10,19 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import dayjs from 'dayjs';
 
-import type { GetFormsResponse } from '@/lib/api-types';
-import {
-  formatResponsePeriod,
-  toResponsePeriod,
-} from '@/lib/forms/responsePeriod';
+import type { GetArchivedFormsResponse } from '@/lib/api-types';
 
-import FormRowMenu from './FormRowMenu';
+import ArchivedFormRowMenu from './ArchivedFormRowMenu';
 import LabelChips from './LabelChips';
 
 interface Props {
-  forms: GetFormsResponse;
-  onFormClick: (formId: string) => void;
-  onArchived?: (() => void) | undefined;
+  forms: GetArchivedFormsResponse;
+  onRestored?: (() => void) | undefined;
 }
 
-const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
+const ArchivedFormsView = ({ forms, onRestored }: Props) => {
   return (
     <TableContainer component={Paper} variant="outlined">
       <Table>
@@ -34,7 +30,7 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
           <TableRow>
             <TableCell>タイトル</TableCell>
             <TableCell>ラベル</TableCell>
-            <TableCell>回答期間</TableCell>
+            <TableCell>アーカイブ日</TableCell>
             <TableCell align="right" sx={{ width: 56 }} />
           </TableRow>
         </TableHead>
@@ -43,20 +39,13 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
             <TableRow>
               <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
                 <Typography color="text.secondary">
-                  条件に一致するフォームがありません
+                  アーカイブ済みのフォームはありません
                 </Typography>
               </TableCell>
             </TableRow>
           ) : (
             forms.map((form) => (
-              <TableRow
-                key={form.id}
-                hover
-                sx={{ cursor: 'pointer', height: 64 }}
-                onClick={() => {
-                  onFormClick(form.id);
-                }}
-              >
+              <TableRow key={form.id} sx={{ height: 64 }}>
                 <TableCell>
                   <Typography variant="body1">{form.title}</Typography>
                 </TableCell>
@@ -65,11 +54,7 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
                 </TableCell>
                 <TableCell>
                   <Typography variant="body2" color="text.secondary">
-                    {formatResponsePeriod(
-                      toResponsePeriod(
-                        form.settings.answer_settings.acceptance_period
-                      )
-                    )}
+                    {dayjs(form.archived_at).format('YYYY/MM/DD')}
                   </Typography>
                 </TableCell>
                 <TableCell
@@ -79,7 +64,10 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
                   }}
                   sx={{ width: 56 }}
                 >
-                  <FormRowMenu formId={form.id} onArchived={onArchived} />
+                  <ArchivedFormRowMenu
+                    formId={form.id}
+                    onRestored={onRestored}
+                  />
                 </TableCell>
               </TableRow>
             ))
@@ -90,4 +78,4 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
   );
 };
 
-export default FormsView;
+export default ArchivedFormsView;

--- a/src/app/(protected)/admin/forms/_components/ArchivedFormsView.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormsView.tsx
@@ -19,10 +19,10 @@ import LabelChips from './LabelChips';
 
 interface Props {
   forms: GetArchivedFormsResponse;
-  onRestored?: (() => void) | undefined;
+  onResult?: ((result: { ok: boolean }) => void) | undefined;
 }
 
-const ArchivedFormsView = ({ forms, onRestored }: Props) => {
+const ArchivedFormsView = ({ forms, onResult }: Props) => {
   return (
     <TableContainer component={Paper} variant="outlined">
       <Table>
@@ -64,10 +64,7 @@ const ArchivedFormsView = ({ forms, onRestored }: Props) => {
                   }}
                   sx={{ width: 56 }}
                 >
-                  <ArchivedFormRowMenu
-                    formId={form.id}
-                    onRestored={onRestored}
-                  />
+                  <ArchivedFormRowMenu formId={form.id} onResult={onResult} />
                 </TableCell>
               </TableRow>
             ))

--- a/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Delete, Edit, MoreVert } from '@mui/icons-material';
+import { Archive, Edit, MoreVert } from '@mui/icons-material';
 import {
   IconButton,
   ListItemIcon,
@@ -15,11 +15,12 @@ import { useFormActions } from '@/hooks/useFormActions';
 
 interface Props {
   formId: string;
+  onArchived?: (() => void) | undefined;
 }
 
-const FormRowMenu = ({ formId }: Props) => {
+const FormRowMenu = ({ formId, onArchived }: Props) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const { deleteForm } = useFormActions();
+  const { archiveForm } = useFormActions();
   const open = Boolean(anchorEl);
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -30,14 +31,14 @@ const FormRowMenu = ({ formId }: Props) => {
     setAnchorEl(null);
   };
 
-  const handleDelete = async () => {
+  const handleArchive = async () => {
     handleClose();
-    if (!confirm('本当に削除しますか？')) return;
-    const result = await deleteForm(formId);
+    if (!confirm('このフォームをアーカイブしますか？')) return;
+    const result = await archiveForm(formId);
     if (result.ok) {
-      alert('削除しました');
+      onArchived?.();
     } else {
-      alert('削除に失敗しました');
+      alert('アーカイブに失敗しました');
     }
   };
 
@@ -63,13 +64,13 @@ const FormRowMenu = ({ formId }: Props) => {
         </MenuItem>
         <MenuItem
           onClick={() => {
-            void handleDelete();
+            void handleArchive();
           }}
         >
           <ListItemIcon>
-            <Delete fontSize="small" />
+            <Archive fontSize="small" />
           </ListItemIcon>
-          <ListItemText>削除</ListItemText>
+          <ListItemText>アーカイブ</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
@@ -2,6 +2,12 @@
 
 import { Archive, Edit, MoreVert } from '@mui/icons-material';
 import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -15,64 +21,91 @@ import { useFormActions } from '@/hooks/useFormActions';
 
 interface Props {
   formId: string;
-  onArchived?: (() => void) | undefined;
+  onResult?: ((result: { ok: boolean }) => void) | undefined;
 }
 
-const FormRowMenu = ({ formId, onArchived }: Props) => {
+const FormRowMenu = ({ formId, onResult }: Props) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const { archiveForm } = useFormActions();
-  const open = Boolean(anchorEl);
+  const menuOpen = Boolean(anchorEl);
 
-  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleMenuClose = () => {
     setAnchorEl(null);
   };
 
-  const handleArchive = async () => {
-    handleClose();
-    if (!confirm('このフォームをアーカイブしますか？')) return;
+  const handleArchiveClick = () => {
+    handleMenuClose();
+    setDialogOpen(true);
+  };
+
+  const handleArchiveConfirm = async () => {
+    setDialogOpen(false);
     const result = await archiveForm(formId);
-    if (result.ok) {
-      onArchived?.();
-    } else {
-      alert('アーカイブに失敗しました');
-    }
+    onResult?.(result);
   };
 
   return (
     <>
       <IconButton
         size="small"
-        onClick={handleOpen}
+        onClick={handleMenuOpen}
         aria-label="フォーム操作メニュー"
       >
         <MoreVert />
       </IconButton>
-      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+      <Menu anchorEl={anchorEl} open={menuOpen} onClose={handleMenuClose}>
         <MenuItem
           component={NextLink}
           href={`/admin/forms/edit/${formId}`}
-          onClick={handleClose}
+          onClick={handleMenuClose}
         >
           <ListItemIcon>
             <Edit fontSize="small" />
           </ListItemIcon>
           <ListItemText>編集</ListItemText>
         </MenuItem>
-        <MenuItem
-          onClick={() => {
-            void handleArchive();
-          }}
-        >
+        <MenuItem onClick={handleArchiveClick}>
           <ListItemIcon>
             <Archive fontSize="small" />
           </ListItemIcon>
           <ListItemText>アーカイブ</ListItemText>
         </MenuItem>
       </Menu>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => {
+          setDialogOpen(false);
+        }}
+      >
+        <DialogTitle>フォームのアーカイブ</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            このフォームをアーカイブしますか？
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setDialogOpen(false);
+            }}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={() => {
+              void handleArchiveConfirm();
+            }}
+            autoFocus
+          >
+            アーカイブ
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -17,6 +17,12 @@ import ArchivedFormsView from './ArchivedFormsView';
 import FormsToolbar from './FormsToolbar';
 import FormsView from './FormsView';
 
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+};
+
 const FormsPageContent = ({
   forms,
   archivedForms,
@@ -29,7 +35,14 @@ const FormsPageContent = ({
   createdFormId?: string | undefined;
 }) => {
   const router = useRouter();
-  const [snackbarOpen, setSnackbarOpen] = useState(createdFormId != null);
+  const [createdSnackbarOpen, setCreatedSnackbarOpen] = useState(
+    createdFormId != null
+  );
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
   const [activeTab, setActiveTab] = useState(0);
   const { titleSearch, setTitleSearch, setLabelFilter, filteredForms } =
     useFormListFilters(forms);
@@ -40,8 +53,42 @@ const FormsPageContent = ({
     }
   }, [createdFormId, router]);
 
-  const handleMutated = () => {
-    router.refresh();
+  const handleArchiveResult = (result: { ok: boolean }) => {
+    if (result.ok) {
+      setSnackbar({
+        open: true,
+        message: 'フォームをアーカイブしました',
+        severity: 'success',
+      });
+      router.refresh();
+    } else {
+      setSnackbar({
+        open: true,
+        message: 'アーカイブに失敗しました',
+        severity: 'error',
+      });
+    }
+  };
+
+  const handleRestoreResult = (result: { ok: boolean }) => {
+    if (result.ok) {
+      setSnackbar({
+        open: true,
+        message: 'フォームを復元しました',
+        severity: 'success',
+      });
+      router.refresh();
+    } else {
+      setSnackbar({
+        open: true,
+        message: '復元に失敗しました',
+        severity: 'error',
+      });
+    }
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
   };
 
   return (
@@ -68,25 +115,28 @@ const FormsPageContent = ({
             onFormClick={(formId) => {
               router.push(`/forms/${formId}/answers`);
             }}
-            onArchived={handleMutated}
+            onResult={handleArchiveResult}
           />
         </>
       )}
       {activeTab === 1 && (
-        <ArchivedFormsView forms={archivedForms} onRestored={handleMutated} />
+        <ArchivedFormsView
+          forms={archivedForms}
+          onResult={handleRestoreResult}
+        />
       )}
       <Snackbar
-        open={snackbarOpen}
+        open={createdSnackbarOpen}
         autoHideDuration={10000}
         onClose={(_event, reason) => {
-          if (reason !== 'clickaway') setSnackbarOpen(false);
+          if (reason !== 'clickaway') setCreatedSnackbarOpen(false);
         }}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert
           severity="success"
           onClose={() => {
-            setSnackbarOpen(false);
+            setCreatedSnackbarOpen(false);
           }}
           action={
             <Button
@@ -100,6 +150,16 @@ const FormsPageContent = ({
           }
         >
           フォームを作成しました
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={5000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={handleCloseSnackbar}>
+          {snackbar.message}
         </Alert>
       </Snackbar>
     </Stack>

--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -1,28 +1,36 @@
 'use client';
 
-import { Alert, Button, Snackbar, Stack } from '@mui/material';
+import { Alert, Button, Snackbar, Stack, Tab, Tabs } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import type { GetFormLabelsResponse, GetFormsResponse } from '@/lib/api-types';
+import type {
+  GetArchivedFormsResponse,
+  GetFormLabelsResponse,
+  GetFormsResponse,
+} from '@/lib/api-types';
 
 import { useFormListFilters } from '../_hooks/useFormListFilters';
 
+import ArchivedFormsView from './ArchivedFormsView';
 import FormsToolbar from './FormsToolbar';
 import FormsView from './FormsView';
 
 const FormsPageContent = ({
   forms,
+  archivedForms,
   labels,
   createdFormId,
 }: {
   forms: GetFormsResponse;
+  archivedForms: GetArchivedFormsResponse;
   labels: GetFormLabelsResponse;
   createdFormId?: string | undefined;
 }) => {
   const router = useRouter();
   const [snackbarOpen, setSnackbarOpen] = useState(createdFormId != null);
+  const [activeTab, setActiveTab] = useState(0);
   const { titleSearch, setTitleSearch, setLabelFilter, filteredForms } =
     useFormListFilters(forms);
 
@@ -32,20 +40,41 @@ const FormsPageContent = ({
     }
   }, [createdFormId, router]);
 
+  const handleMutated = () => {
+    router.refresh();
+  };
+
   return (
     <Stack spacing={3}>
-      <FormsToolbar
-        labels={labels}
-        titleSearch={titleSearch}
-        onTitleSearchChange={setTitleSearch}
-        onLabelFilterChange={setLabelFilter}
-      />
-      <FormsView
-        forms={filteredForms}
-        onFormClick={(formId) => {
-          router.push(`/forms/${formId}/answers`);
+      <Tabs
+        value={activeTab}
+        onChange={(_event, newValue: number) => {
+          setActiveTab(newValue);
         }}
-      />
+      >
+        <Tab label="アクティブ" />
+        <Tab label={`アーカイブ済み（${archivedForms.length}）`} />
+      </Tabs>
+      {activeTab === 0 && (
+        <>
+          <FormsToolbar
+            labels={labels}
+            titleSearch={titleSearch}
+            onTitleSearchChange={setTitleSearch}
+            onLabelFilterChange={setLabelFilter}
+          />
+          <FormsView
+            forms={filteredForms}
+            onFormClick={(formId) => {
+              router.push(`/forms/${formId}/answers`);
+            }}
+            onArchived={handleMutated}
+          />
+        </>
+      )}
+      {activeTab === 1 && (
+        <ArchivedFormsView forms={archivedForms} onRestored={handleMutated} />
+      )}
       <Snackbar
         open={snackbarOpen}
         autoHideDuration={10000}

--- a/src/app/(protected)/admin/forms/_components/FormsView.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsView.tsx
@@ -23,10 +23,10 @@ import LabelChips from './LabelChips';
 interface Props {
   forms: GetFormsResponse;
   onFormClick: (formId: string) => void;
-  onArchived?: (() => void) | undefined;
+  onResult?: ((result: { ok: boolean }) => void) | undefined;
 }
 
-const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
+const FormsView = ({ forms, onFormClick, onResult }: Props) => {
   return (
     <TableContainer component={Paper} variant="outlined">
       <Table>
@@ -79,7 +79,7 @@ const FormsView = ({ forms, onFormClick, onArchived }: Props) => {
                   }}
                   sx={{ width: 56 }}
                 >
-                  <FormRowMenu formId={form.id} onArchived={onArchived} />
+                  <FormRowMenu formId={form.id} onResult={onResult} />
                 </TableCell>
               </TableRow>
             ))

--- a/src/app/(protected)/admin/forms/page.tsx
+++ b/src/app/(protected)/admin/forms/page.tsx
@@ -17,9 +17,14 @@ const Home = async (props: {
   searchParams: Promise<{ createdFormId?: string }>;
 }) => {
   const { session } = await getAdminAccess();
-  const [forms, labels, searchParams] = await Promise.all([
+  const [forms, archivedForms, labels, searchParams] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/archived-forms', {
         headers: authorizationHeader(session.token),
       })
     ),
@@ -34,6 +39,7 @@ const Home = async (props: {
   return (
     <FormsPageContent
       forms={forms}
+      archivedForms={archivedForms}
       labels={labels}
       createdFormId={searchParams.createdFormId}
     />

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -4,7 +4,7 @@ import { handleMutationResponse } from '@/hooks/useApiMutation';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useFormActions = () => {
-  const deleteForm = async (formId: string): Promise<{ ok: boolean }> => {
+  const archiveForm = async (formId: string): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.POST(
       '/api/v1/forms/{id}/archive',
       {
@@ -15,5 +15,16 @@ export const useFormActions = () => {
     return { ok: result.success };
   };
 
-  return { deleteForm };
+  const restoreForm = async (formId: string): Promise<{ ok: boolean }> => {
+    const { data, error, response } = await proxyClient.POST(
+      '/api/v1/archived-forms/{id}/restore',
+      {
+        params: { path: { id: formId } },
+      }
+    );
+    const result = handleMutationResponse(response, data, error);
+    return { ok: result.success };
+  };
+
+  return { archiveForm, restoreForm };
 };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -14,6 +14,7 @@ export type {
   GetAnswerResponse,
   GetAnswerSubmitterRestrictionResponse,
   GetAnswersResponse,
+  GetArchivedFormsResponse,
   GetFormAnswersResponse,
   GetFormLabelsResponse,
   GetFormResponse,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -45,3 +45,5 @@ export type CreateFormSchema =
   ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
 export type UpdateNotificationSettingsSchema =
   ApiPaths['/api/v1/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
+export type GetArchivedFormsResponse =
+  ApiPaths['/api/v1/archived-forms']['get']['responses'][200]['content']['application/json'];


### PR DESCRIPTION
## 概要
- バックエンド側でフォーム削除がアーカイブに変更されたため、フロントエンドの UI を対応させる
- 管理者フォーム一覧に「アクティブ」「アーカイブ済み」のタブ切り替えを追加し、アーカイブ済みフォームの閲覧と復元を可能にした
- 「削除」ボタンを「アーカイブ」に変更し、アイコン・確認ダイアログ・フック名も合わせてリネーム

## 確認事項
- TypeScript の型チェック（`tsc --noEmit`）、ESLint、Prettier をすべてパス
- ユニットテスト 51 件すべてパス
- バックエンドが未接続のためブラウザでの動作確認は未実施。API エンドポイント（`/api/v1/archived-forms`, `/api/v1/archived-forms/{id}/restore`）は生成済みの型定義に基づいて呼び出しているため、型レベルでの整合性は担保されている
- ユーザー側のフォーム一覧は `GET /api/v1/forms`（アクティブのみ）を使用しており変更不要

closes #786

🤖 Generated with Claude Code