### PR TITLE
Snackbar 通知と確認ダイアログを共通コンポーネントに抽出

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -2,19 +2,17 @@
 
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import {
-  Alert,
   Button,
   CardContent,
   Divider,
   FormControlLabel,
-  Snackbar,
   Stack,
   Typography,
 } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useNotificationSettings } from '@/hooks/useNotificationSettings';
 import type { GetUserNotificationSettingsResponse } from '@/lib/api-types';
 
@@ -23,12 +21,6 @@ import {
   toNotificationSettingsUpdateBody,
 } from './notificationSettingsForm';
 import type { NotificationSettingsFormValues } from './notificationSettingsForm';
-
-type SnackbarState = {
-  open: boolean;
-  message: string;
-  severity: 'success' | 'error';
-};
 
 const DiscordNotificationSettings = (props: {
   currentSettings: GetUserNotificationSettingsResponse;
@@ -41,27 +33,14 @@ const DiscordNotificationSettings = (props: {
   });
 
   const { updateSettings } = useNotificationSettings();
-
-  const [snackbar, setSnackbar] = useState<SnackbarState>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
 
   const onSubmit = async (data: NotificationSettingsFormValues) => {
     const result = await updateSettings(toNotificationSettingsUpdateBody(data));
     if (result.ok) {
-      setSnackbar({
-        open: true,
-        message: '設定を更新しました',
-        severity: 'success',
-      });
+      showSnackbar('設定を更新しました', 'success');
     } else {
-      setSnackbar({
-        open: true,
-        message: '通知設定の更新に失敗しました',
-        severity: 'error',
-      });
+      showSnackbar('通知設定の更新に失敗しました', 'error');
     }
   };
 
@@ -107,23 +86,12 @@ const DiscordNotificationSettings = (props: {
           </Button>
         </Stack>
       </CardContent>
-      <Snackbar
+      <SnackbarAlert
         open={snackbar.open}
-        autoHideDuration={3000}
-        onClose={(_, reason) => {
-          if (reason !== 'clickaway')
-            setSnackbar((prev) => ({ ...prev, open: false }));
-        }}
-      >
-        <Alert
-          severity={snackbar.severity}
-          onClose={() => {
-            setSnackbar((prev) => ({ ...prev, open: false }));
-          }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
     </>
   );
 };

--- a/src/app/(protected)/_components/CreateLabelField.tsx
+++ b/src/app/(protected)/_components/CreateLabelField.tsx
@@ -2,37 +2,26 @@
 
 import { AddCircle } from '@mui/icons-material';
 import {
-  Alert,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Snackbar,
   TextField,
 } from '@mui/material';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useLabelCRUD } from '@/hooks/useLabelCRUD';
 
 type CreateLabelSchema = {
   name: string;
 };
 
-type SnackbarState = {
-  open: boolean;
-  message: string;
-  severity: 'success' | 'error';
-};
-
 const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [snackbar, setSnackbar] = useState<SnackbarState>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
 
   const { handleSubmit, register, reset } = useForm<CreateLabelSchema>();
   const { createLabel } = useLabelCRUD(props.labelType);
@@ -45,25 +34,13 @@ const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
     reset();
   };
 
-  const handleCloseSnackbar = () => {
-    setSnackbar((prev) => ({ ...prev, open: false }));
-  };
-
   const onSubmit = async (data: CreateLabelSchema) => {
     const result = await createLabel(data.name);
     if (result.ok) {
-      setSnackbar({
-        open: true,
-        message: 'ラベルを作成しました。',
-        severity: 'success',
-      });
+      showSnackbar('ラベルを作成しました。', 'success');
       handleClose();
     } else {
-      setSnackbar({
-        open: true,
-        message: 'ラベルの作成に失敗しました。',
-        severity: 'error',
-      });
+      showSnackbar('ラベルの作成に失敗しました。', 'error');
     }
   };
 
@@ -103,20 +80,12 @@ const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
         </form>
       </Dialog>
 
-      <Snackbar
+      <SnackbarAlert
         open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={handleCloseSnackbar}
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
     </>
   );
 };

--- a/src/app/(protected)/_components/Labels.tsx
+++ b/src/app/(protected)/_components/Labels.tsx
@@ -2,17 +2,14 @@
 
 import { Delete, Edit } from '@mui/icons-material';
 import {
-  Alert,
   Box,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
   IconButton,
   Paper,
-  Snackbar,
   Table,
   TableBody,
   TableCell,
@@ -25,6 +22,8 @@ import {
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import ConfirmDialog from '@/app/_components/ConfirmDialog';
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useLabelCRUD } from '@/hooks/useLabelCRUD';
 
 type Label = {
@@ -37,18 +36,8 @@ type EditLabelSchema = {
   name: string;
 };
 
-type SnackbarState = {
-  open: boolean;
-  message: string;
-  severity: 'success' | 'error';
-};
-
 const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
-  const [snackbar, setSnackbar] = useState<SnackbarState>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState<Label | null>(null);
@@ -59,14 +48,6 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
   const { deleteLabel, editLabel: editLabelAction } = useLabelCRUD(
     props.labelType
   );
-
-  const showSnackbar = (message: string, severity: 'success' | 'error') => {
-    setSnackbar({ open: true, message, severity });
-  };
-
-  const handleCloseSnackbar = () => {
-    setSnackbar((prev) => ({ ...prev, open: false }));
-  };
 
   const handleOpenEdit = (label: Label) => {
     setSelectedLabel(label);
@@ -120,20 +101,12 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
             ラベルが登録されていません。
           </Typography>
         </Paper>
-        <Snackbar
+        <SnackbarAlert
           open={snackbar.open}
-          autoHideDuration={6000}
-          onClose={handleCloseSnackbar}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        >
-          <Alert
-            onClose={handleCloseSnackbar}
-            severity={snackbar.severity}
-            sx={{ width: '100%' }}
-          >
-            {snackbar.message}
-          </Alert>
-        </Snackbar>
+          message={snackbar.message}
+          severity={snackbar.severity}
+          onClose={closeSnackbar}
+        />
       </Box>
     );
   }
@@ -180,7 +153,6 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
         </Table>
       </TableContainer>
 
-      {/* 編集ダイアログ */}
       <Dialog open={editDialogOpen} onClose={handleCloseEdit} fullWidth>
         <DialogTitle>ラベルを編集</DialogTitle>
         <Box
@@ -209,43 +181,23 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
         </Box>
       </Dialog>
 
-      {/* 削除確認ダイアログ */}
-      <Dialog open={deleteDialogOpen} onClose={handleCloseDelete}>
-        <DialogTitle>ラベルを削除</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            「{selectedLabel?.name}
-            」を削除してもよろしいですか？この操作は元に戻せません。
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete}>キャンセル</Button>
-          <Button
-            onClick={() => {
-              void onDelete();
-            }}
-            color="error"
-            variant="contained"
-          >
-            削除
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        title="ラベルを削除"
+        description={`「${selectedLabel?.name ?? ''}」を削除してもよろしいですか？この操作は元に戻せません。`}
+        confirmLabel="削除"
+        onConfirm={() => {
+          void onDelete();
+        }}
+        onCancel={handleCloseDelete}
+      />
 
-      <Snackbar
+      <SnackbarAlert
         open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={handleCloseSnackbar}
-          severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
     </Box>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
@@ -2,12 +2,6 @@
 
 import { MoreVert, Restore } from '@mui/icons-material';
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -16,6 +10,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 
+import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import { useFormActions } from '@/hooks/useFormActions';
 
 interface Props {
@@ -65,34 +60,18 @@ const ArchivedFormRowMenu = ({ formId, onResult }: Props) => {
           <ListItemText>復元</ListItemText>
         </MenuItem>
       </Menu>
-      <Dialog
+      <ConfirmDialog
         open={dialogOpen}
-        onClose={() => {
+        title="フォームの復元"
+        description="このフォームを復元しますか？"
+        confirmLabel="復元"
+        onConfirm={() => {
+          void handleRestoreConfirm();
+        }}
+        onCancel={() => {
           setDialogOpen(false);
         }}
-      >
-        <DialogTitle>フォームの復元</DialogTitle>
-        <DialogContent>
-          <DialogContentText>このフォームを復元しますか？</DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setDialogOpen(false);
-            }}
-          >
-            キャンセル
-          </Button>
-          <Button
-            onClick={() => {
-              void handleRestoreConfirm();
-            }}
-            autoFocus
-          >
-            復元
-          </Button>
-        </DialogActions>
-      </Dialog>
+      />
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
@@ -2,12 +2,6 @@
 
 import { Archive, Edit, MoreVert } from '@mui/icons-material';
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -17,6 +11,7 @@ import {
 import NextLink from 'next/link';
 import { useState } from 'react';
 
+import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import { useFormActions } from '@/hooks/useFormActions';
 
 interface Props {
@@ -76,36 +71,18 @@ const FormRowMenu = ({ formId, onResult }: Props) => {
           <ListItemText>アーカイブ</ListItemText>
         </MenuItem>
       </Menu>
-      <Dialog
+      <ConfirmDialog
         open={dialogOpen}
-        onClose={() => {
+        title="フォームのアーカイブ"
+        description="このフォームをアーカイブしますか？"
+        confirmLabel="アーカイブ"
+        onConfirm={() => {
+          void handleArchiveConfirm();
+        }}
+        onCancel={() => {
           setDialogOpen(false);
         }}
-      >
-        <DialogTitle>フォームのアーカイブ</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            このフォームをアーカイブしますか？
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setDialogOpen(false);
-            }}
-          >
-            キャンセル
-          </Button>
-          <Button
-            onClick={() => {
-              void handleArchiveConfirm();
-            }}
-            autoFocus
-          >
-            アーカイブ
-          </Button>
-        </DialogActions>
-      </Dialog>
+      />
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsPageContent.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import type {
   GetArchivedFormsResponse,
   GetFormLabelsResponse,
@@ -16,12 +17,6 @@ import { useFormListFilters } from '../_hooks/useFormListFilters';
 import ArchivedFormsView from './ArchivedFormsView';
 import FormsToolbar from './FormsToolbar';
 import FormsView from './FormsView';
-
-type SnackbarState = {
-  open: boolean;
-  message: string;
-  severity: 'success' | 'error';
-};
 
 const FormsPageContent = ({
   forms,
@@ -38,11 +33,7 @@ const FormsPageContent = ({
   const [createdSnackbarOpen, setCreatedSnackbarOpen] = useState(
     createdFormId != null
   );
-  const [snackbar, setSnackbar] = useState<SnackbarState>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
   const [activeTab, setActiveTab] = useState(0);
   const { titleSearch, setTitleSearch, setLabelFilter, filteredForms } =
     useFormListFilters(forms);
@@ -55,40 +46,20 @@ const FormsPageContent = ({
 
   const handleArchiveResult = (result: { ok: boolean }) => {
     if (result.ok) {
-      setSnackbar({
-        open: true,
-        message: 'フォームをアーカイブしました',
-        severity: 'success',
-      });
+      showSnackbar('フォームをアーカイブしました', 'success');
       router.refresh();
     } else {
-      setSnackbar({
-        open: true,
-        message: 'アーカイブに失敗しました',
-        severity: 'error',
-      });
+      showSnackbar('アーカイブに失敗しました', 'error');
     }
   };
 
   const handleRestoreResult = (result: { ok: boolean }) => {
     if (result.ok) {
-      setSnackbar({
-        open: true,
-        message: 'フォームを復元しました',
-        severity: 'success',
-      });
+      showSnackbar('フォームを復元しました', 'success');
       router.refresh();
     } else {
-      setSnackbar({
-        open: true,
-        message: '復元に失敗しました',
-        severity: 'error',
-      });
+      showSnackbar('復元に失敗しました', 'error');
     }
-  };
-
-  const handleCloseSnackbar = () => {
-    setSnackbar((prev) => ({ ...prev, open: false }));
   };
 
   return (
@@ -152,16 +123,12 @@ const FormsPageContent = ({
           フォームを作成しました
         </Alert>
       </Snackbar>
-      <Snackbar
+      <SnackbarAlert
         open={snackbar.open}
-        autoHideDuration={5000}
-        onClose={handleCloseSnackbar}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert severity={snackbar.severity} onClose={handleCloseSnackbar}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
     </Stack>
   );
 };

--- a/src/app/_components/ConfirmDialog.tsx
+++ b/src/app/_components/ConfirmDialog.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+
+const ConfirmDialog = ({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) => (
+  <Dialog open={open} onClose={onCancel}>
+    <DialogTitle>{title}</DialogTitle>
+    <DialogContent>
+      <DialogContentText>{description}</DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onCancel}>キャンセル</Button>
+      <Button onClick={onConfirm} autoFocus>
+        {confirmLabel}
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default ConfirmDialog;

--- a/src/app/_components/SnackbarAlert.tsx
+++ b/src/app/_components/SnackbarAlert.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { AlertColor } from '@mui/material';
+import { Alert, Snackbar } from '@mui/material';
+import { useCallback, useState } from 'react';
+
+type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: AlertColor;
+};
+
+export const useSnackbar = () => {
+  const [state, setState] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const showSnackbar = useCallback(
+    (message: string, severity: AlertColor = 'success') => {
+      setState({ open: true, message, severity });
+    },
+    []
+  );
+
+  const closeSnackbar = useCallback(() => {
+    setState((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return { snackbar: state, showSnackbar, closeSnackbar } as const;
+};
+
+const SnackbarAlert = ({
+  open,
+  message,
+  severity,
+  onClose,
+}: {
+  open: boolean;
+  message: string;
+  severity: AlertColor;
+  onClose: () => void;
+}) => (
+  <Snackbar
+    open={open}
+    autoHideDuration={5000}
+    onClose={(_, reason) => {
+      if (reason !== 'clickaway') onClose();
+    }}
+    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+  >
+    <Alert severity={severity} onClose={onClose} sx={{ width: '100%' }}>
+      {message}
+    </Alert>
+  </Snackbar>
+);
+
+export default SnackbarAlert;


### PR DESCRIPTION
## 概要
- 4箇所に重複していた `SnackbarState` 型・`useState`・close ハンドラ・`<Snackbar><Alert>` の JSX を `useSnackbar` フック + `SnackbarAlert` コンポーネントに集約
- 3箇所に重複していた確認ダイアログ（タイトル・説明・キャンセル/実行ボタン）を `ConfirmDialog` コンポーネントに集約
- `autoHideDuration` が 3000/5000/6000 とバラついていた設定を 5000ms に統一
- AI Agent が新規 UI を実装する際、ブラウザ標準の `alert()` / `confirm()` ではなく、これらの共通部品を自然に参照できるようにする目的

## 確認事項
- `tsc --noEmit` で型エラーなし
- ESLint / Prettier 通過（lefthook pre-commit で確認）
- ユニットテスト 51 件全パス（lefthook pre-push で確認）
- 振る舞いの変更はなく、既存の Snackbar / Dialog の表示ロジックをそのまま移行しているため、UI の実動作確認は未実施

🤖 Generated with Claude Code