### PR TITLE
フォーム更新時に選択肢 ID を保持する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
@@ -132,7 +132,7 @@ const ChoiceEditor = (props: {
   );
 
   const appendChoice = () => {
-    append({ choice: '' });
+    append({ id: null, choice: '' });
   };
 
   const clearChoices = () => {

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -52,7 +52,10 @@ const toEditorQuestion = (
   question_type: question.question_type,
   choices:
     'choices' in question
-      ? question.choices.map((choice) => ({ choice: choice.label }))
+      ? question.choices.map((choice) => ({
+          id: choice.id ?? null,
+          choice: choice.label,
+        }))
       : [],
   is_required: question.is_required,
   position: question.position,
@@ -83,6 +86,7 @@ const toApiQuestion = (
     ...base,
     question_type: question.question_type,
     choices: question.choices.map((choice, choiceIndex) => ({
+      id: choice.id ?? null,
       label: choice.choice.trim(),
       position: choiceIndex,
     })),

--- a/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
@@ -9,6 +9,7 @@ export const questionTypeSchema = z.enum([
 ]);
 
 const choiceSchema = z.object({
+  id: z.number().int().nullable().optional(),
   choice: requiredStringSchema,
 });
 

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  fromFormResponseToEditorValues,
   toCreateFormBody,
   toFormUpdateBody,
 } from '@/app/(protected)/admin/forms/_lib/formRequestBuilders';
@@ -8,6 +9,7 @@ import type {
   FormEditorQuestion,
   FormEditorValues,
 } from '@/app/(protected)/admin/forms/_schema/formEditorSchema';
+import type { GetFormResponse } from '@/lib/api-types';
 
 const baseQuestion: FormEditorQuestion = {
   identity: { kind: 'new' },
@@ -73,6 +75,73 @@ describe('form request builders', () => {
     );
 
     expect(body.questions?.[0]?.id).toBe('question-id');
+  });
+
+  it('既存選択肢の ID を API の選択肢 ID へ変換する', () => {
+    const body = toFormUpdateBody(
+      {
+        ...baseValues,
+        questions: [
+          {
+            ...baseQuestion,
+            question_type: 'SingleChoice',
+            choices: [
+              { id: 1, choice: ' First choice ' },
+              { choice: 'New choice' },
+            ],
+          },
+        ],
+      },
+      true
+    );
+
+    expect(body.questions?.[0]).toMatchObject({
+      question_type: 'SingleChoice',
+      choices: [
+        { id: 1, label: 'First choice', position: 0 },
+        { id: null, label: 'New choice', position: 1 },
+      ],
+    });
+  });
+
+  it('フォーム取得レスポンスの選択肢 ID を画面内部表現へ保持する', () => {
+    const values = fromFormResponseToEditorValues({
+      id: 'form-id',
+      title: 'Form title',
+      description: 'Form description',
+      labels: [],
+      metadata: {
+        created_at: '2026-06-01T00:00:00+09:00',
+        updated_at: '2026-06-01T00:00:00+09:00',
+      },
+      settings: {
+        visibility: 'PUBLIC',
+        allow_temporary_answers: false,
+        discord_webhook_url: null,
+        answer_settings: {
+          default_answer_title: null,
+          acceptance_period: {
+            start_at: null,
+            end_at: null,
+          },
+          visibility: 'PUBLIC',
+        },
+      },
+      questions: [
+        {
+          id: 'question-id',
+          title: 'Question title',
+          description: null,
+          question_type: 'SingleChoice',
+          choices: [{ id: 1, label: 'First choice', position: 0 }],
+          is_required: false,
+          position: 0,
+          template_key: 'question_1',
+        },
+      ],
+    } satisfies GetFormResponse);
+
+    expect(values.questions[0]?.choices[0]?.id).toBe(1);
   });
 
   it('空の Webhook URL は null に正規化する', () => {


### PR DESCRIPTION
## 概要
- フォーム編集画面の内部値で既存選択肢の `id` を保持するようにしました。
- 更新 payload の `questions[].choices[].id` に既存 choice id を含め、新規選択肢は `id: null` として送るようにしました。
- 取得レスポンスから更新 payload まで choice id が落ちないことを unit test で確認できるようにしました。

## 確認事項
- `pnpm vitest run --config vitest.unit.config.ts tests/unit/formEditorMappers.test.ts` で、フォーム編集値と更新 payload の変換が期待通りであることを確認しました。
- `pnpm type-check` で、変更後の型が既存コードと整合していることを確認しました。
- `pnpm lint` と `pnpm fmt` で、lint とフォーマットに問題がないことを確認しました。
- `pnpm test:unit` で、unit test 全体が通ることを確認しました。
- pre-commit hook でも lint、type-check、fmt が通り、pre-push hook でも unit test 全体が通っています。

🤖 Generated with Codex
