### PR TITLE
chore: renovate でマイナー追従と lockfile 更新を自動化する

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>GiganticMinecraft/renovate-config"
-  ]
+  ],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## 概要
- dependabot が推移依存の脆弱性を検知することが多いため、renovate 側で範囲内の更新も取り込めるようにする
- `rangeStrategy: "bump"` を追加し、`^x.y.z` 範囲内のマイナー/パッチでも package.json の表記ごと追従する PR が出るようにする
- `lockFileMaintenance` を `automerge: true` 付きで有効化し、pnpm-lock.yaml 全体（推移依存含む）を定期更新・自動マージする

## 確認事項
- 設定ファイル（`.github/renovate.json`）のみの変更で、renovate-config 側の automerge（minor/patch, `minimumReleaseAge: 7 days`）と組み合わせて動作する想定
- 実際の挙動は renovate 実行時に確認が必要。自動マージは CI のステータスチェック通過が前提となるため、ブランチ保護ルールが効いていることを確認したい

🤖 Generated with Claude Code