### PR TITLE
chore: バックエンド OpenAPI スキーマの更新に追従する

### DIFF
--- a/src/app/(protected)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/page.tsx
@@ -35,7 +35,7 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
     ),
   ]);
 
-  return <AnswersPageContent form={form} answers={answers} />;
+  return <AnswersPageContent form={form} answers={answers.items} />;
 };
 
 export default Home;

--- a/src/app/(protected)/(standard)/forms/page.tsx
+++ b/src/app/(protected)/(standard)/forms/page.tsx
@@ -21,7 +21,7 @@ const Home = async () => {
     })
   );
 
-  return <FormsPageContent forms={forms} />;
+  return <FormsPageContent forms={forms.items} />;
 };
 
 export default Home;

--- a/src/app/(protected)/admin/answer/[answerId]/_components/AdminAnswerPageContent.tsx
+++ b/src/app/(protected)/admin/answer/[answerId]/_components/AdminAnswerPageContent.tsx
@@ -17,7 +17,7 @@ const AdminAnswerPageContent = ({ answerId }: { answerId: string }) => {
   });
 
   const { data: allAnswers } = allAnswersQuery;
-  const answers = allAnswers?.find((a) => a.id === answerId);
+  const answers = allAnswers?.items.find((a) => a.id === answerId);
 
   const formQuery = useApiQuery(
     '/api/v1/forms/{id}',
@@ -62,7 +62,7 @@ const AdminAnswerPageContent = ({ answerId }: { answerId: string }) => {
     return <LoadingCircular />;
   }
 
-  const answer = answerListQueries.allAnswers.data.find(
+  const answer = answerListQueries.allAnswers.data.items.find(
     (a) => a.id === answerId
   );
 

--- a/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
@@ -24,7 +24,9 @@ export const createEmptyFormEditorValues = (): FormEditorValues => ({
     discord_webhook_url: '',
     default_answer_title: '',
     visibility: 'PRIVATE',
+    allowed_group_ids: [],
     answer_visibility: 'PRIVATE',
+    answer_group_ids: [],
     allow_temporary_answers: false,
   },
 });

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -123,6 +123,8 @@ export const fromFormResponseToEditorValues = (
       default_answer_title:
         form.settings.answer_settings.default_answer_title ?? '',
       answer_visibility: toVisibility(form.settings.answer_settings.visibility),
+      answer_group_ids: form.settings.answer_settings.answer_group_ids,
+      allowed_group_ids: form.settings.allowed_group_ids,
       allow_temporary_answers: form.settings.allow_temporary_answers,
     },
   };
@@ -157,6 +159,7 @@ export const toFormUpdateBody = (
     labels: data.labels.map((label) => label.id),
     settings: {
       visibility: data.settings.visibility,
+      allowed_group_ids: data.settings.allowed_group_ids,
       allow_temporary_answers: data.settings.allow_temporary_answers,
       discord_webhook_url: toNullableNonEmptyString(
         data.settings.discord_webhook_url
@@ -167,6 +170,7 @@ export const toFormUpdateBody = (
         ),
         acceptance_period: acceptancePeriod,
         visibility: data.settings.answer_visibility,
+        answer_group_ids: data.settings.answer_group_ids,
       },
     },
   };

--- a/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
@@ -69,7 +69,9 @@ export const formEditorSchema = z.object({
     discord_webhook_url: z.string(),
     default_answer_title: z.string(),
     visibility: visibilitySchema,
+    allowed_group_ids: z.array(z.string()),
     answer_visibility: visibilitySchema,
+    answer_group_ids: z.array(z.string()),
     allow_temporary_answers: z.boolean(),
   }),
 });

--- a/src/app/(protected)/admin/forms/page.tsx
+++ b/src/app/(protected)/admin/forms/page.tsx
@@ -38,8 +38,8 @@ const Home = async (props: {
 
   return (
     <FormsPageContent
-      forms={forms}
-      archivedForms={archivedForms}
+      forms={forms.items}
+      archivedForms={archivedForms.items}
       labels={labels}
       createdFormId={searchParams.createdFormId}
     />

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -30,11 +30,11 @@ const Home = async () => {
 
   return (
     <DataTable
-      answerResponseWithFormTitle={answers.map((answer) => {
+      answerResponseWithFormTitle={answers.items.map((answer) => {
         return {
           ...answer,
           form_title:
-            forms.find((form) => form.id === answer.form_id)?.title ??
+            forms.items.find((form) => form.id === answer.form_id)?.title ??
             'unknown form',
         };
       })}

--- a/src/app/(protected)/admin/users/page.tsx
+++ b/src/app/(protected)/admin/users/page.tsx
@@ -21,7 +21,9 @@ const Home = async () => {
     })
   );
 
-  return <UsersPageContent users={users} currentUserId={session.user.id} />;
+  return (
+    <UsersPageContent users={users.items} currentUserId={session.user.id} />
+  );
 };
 
 export default Home;

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -13,7 +13,7 @@ const fetchPublicForms = async (): Promise<GetFormsResponse> => {
       console.error('Failed to fetch public forms:', error);
       return [];
     }
-    return data.filter((f) => f.settings.allow_temporary_answers);
+    return data.items.filter((f) => f.settings.allow_temporary_answers);
   } catch (err) {
     console.error('Network error while fetching public forms:', err);
     return [];

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -429,6 +429,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/user-groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ユーザーグループの一覧取得 */
+        get: operations["user_group_list"];
+        put?: never;
+        /** ユーザーグループの作成 */
+        post: operations["create_user_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/user-groups/{group_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** ユーザーグループの削除 */
+        delete: operations["delete_user_group"];
+        options?: never;
+        head?: never;
+        /** ユーザーグループの更新 */
+        patch: operations["update_user_group"];
+        trace?: never;
+    };
+    "/api/v1/user-groups/{group_id}/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** ユーザーをグループに追加 */
+        put: operations["add_user_to_group"];
+        post?: never;
+        /** ユーザーをグループから削除 */
+        delete: operations["remove_user_from_group"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/users": {
         parameters: {
             query?: never;
@@ -557,8 +611,13 @@ export interface components {
             id: string;
             name: string;
         };
+        AnswerListPageResponse: {
+            items: components["schemas"]["FormAnswer"][];
+            next_cursor?: string | null;
+        };
         AnswerSettingsSchema: {
             acceptance_period: components["schemas"]["AnswerAcceptancePeriodSchema"];
+            answer_group_ids: string[];
             default_answer_title?: string | null;
             visibility: components["schemas"]["AnswerVisibility"];
         };
@@ -582,6 +641,10 @@ export interface components {
         };
         /** @enum {string} */
         AnswerVisibility: "PUBLIC" | "PRIVATE";
+        ArchivedFormListPageResponse: {
+            items: components["schemas"]["ArchivedFormSchema"][];
+            next_cursor?: string | null;
+        };
         ArchivedFormSchema: {
             /** Format: date-time */
             archived_at: string;
@@ -677,6 +740,10 @@ export interface components {
         FormLabelUpdateSchema: {
             name?: null | components["schemas"]["NonEmptyString"];
         };
+        FormListPageResponse: {
+            items: components["schemas"]["FormSchema"][];
+            next_cursor?: string | null;
+        };
         FormMetaSchema: {
             /** Format: date-time */
             created_at: string;
@@ -695,6 +762,7 @@ export interface components {
         };
         FormSettingsSchema: {
             allow_temporary_answers: boolean;
+            allowed_group_ids: string[];
             answer_settings: components["schemas"]["AnswerSettingsSchema"];
             discord_webhook_url?: string | null;
             visibility: string;
@@ -815,14 +883,27 @@ export interface components {
             role: components["schemas"]["Role"];
             uuid: string;
         };
+        UserGroupRequest: {
+            name: string;
+        };
+        UserGroupSchema: {
+            id: string;
+            name: string;
+        };
         UserInfoResponse: {
             discord_user_id?: string | null;
             discord_username?: string | null;
+            groups: components["schemas"]["UserGroupSchema"][];
             id: string;
             name: string;
             role: string;
         };
+        UserListPageResponse: {
+            items: components["schemas"]["UserSchema"][];
+            next_cursor?: string | null;
+        };
         UserSchema: {
+            groups: components["schemas"]["UserGroupSchema"][];
             id: string;
             name: string;
             role: string;
@@ -845,11 +926,10 @@ export interface operations {
     archived_form_list_handler: {
         parameters: {
             query?: {
-                /** @description Offset for pagination */
-                offset?: number;
-                /** @description Limit for pagination */
+                /** @description Maximum number of forms to return */
                 limit?: number;
-                /** @description Search query */
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
                 query?: string;
             };
             header?: never;
@@ -864,7 +944,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ArchivedFormSchema"][];
+                    "application/json": components["schemas"]["ArchivedFormListPageResponse"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */
@@ -1042,10 +1122,10 @@ export interface operations {
     form_list_handler: {
         parameters: {
             query?: {
-                /** @description Offset for pagination */
-                offset?: number;
-                /** @description Limit for pagination */
+                /** @description Maximum number of forms to return */
                 limit?: number;
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
             };
             header?: never;
             path?: never;
@@ -1059,7 +1139,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FormSchema"][];
+                    "application/json": components["schemas"]["FormListPageResponse"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */
@@ -1171,7 +1251,12 @@ export interface operations {
     };
     get_all_answers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of answers to return */
+                limit?: number;
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1184,7 +1269,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FormAnswer"][];
+                    "application/json": components["schemas"]["AnswerListPageResponse"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */
@@ -2243,7 +2328,12 @@ export interface operations {
     };
     get_answer_by_form_id_handler: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of answers to return */
+                limit?: number;
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
+            };
             header?: never;
             path: {
                 /** @description Form ID */
@@ -2259,7 +2349,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FormAnswer"][];
+                    "application/json": components["schemas"]["AnswerListPageResponse"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */
@@ -3639,7 +3729,7 @@ export interface operations {
             };
         };
     };
-    user_list: {
+    user_group_list: {
         parameters: {
             query?: never;
             header?: never;
@@ -3654,7 +3744,442 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserSchema"][];
+                    "application/json": components["schemas"]["UserGroupSchema"][];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    create_user_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserGroupRequest"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserGroupSchema"];
+                };
+            };
+            /** @description The resource has been created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserGroupSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Client error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    delete_user_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User group UUID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The resource has been deleted. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    update_user_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User group UUID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserGroupRequest"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserGroupSchema"];
+                };
+            };
+            /** @description The resource has been created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserGroupSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Client error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    add_user_to_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User group UUID */
+                group_id: string;
+                /** @description User UUID */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    remove_user_from_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User group UUID */
+                group_id: string;
+                /** @description User UUID */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    user_list: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of users to return */
+                limit?: number;
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserListPageResponse"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -8,15 +8,15 @@ export type AnswerComment = components['schemas']['AnswerComment'];
 export type GetQuestionsResponse =
   components['schemas']['QuestionResponseSchema'][];
 export type GetFormsResponse =
-  ApiPaths['/api/v1/forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms']['get']['responses'][200]['content']['application/json']['items'];
 export type GetFormResponse =
   ApiPaths['/api/v1/forms/{id}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormResponse =
   ApiPaths['/api/v1/forms']['post']['responses'][201]['content']['application/json'];
 export type GetFormAnswersResponse =
-  ApiPaths['/api/v1/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{id}/answers']['get']['responses'][200]['content']['application/json']['items'];
 export type GetAnswersResponse =
-  ApiPaths['/api/v1/forms/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/answers']['get']['responses'][200]['content']['application/json']['items'];
 export type GetAnswerResponse =
   ApiPaths['/api/v1/forms/{form_id}/answers/{answer_id}']['get']['responses'][200]['content']['application/json'];
 export type GetFormLabelsResponse =
@@ -30,7 +30,7 @@ export type GetUsersResponse =
 export type GetUserResponse =
   ApiPaths['/api/v1/users/{uuid}']['get']['responses'][200]['content']['application/json'];
 export type GetUserListResponse =
-  ApiPaths['/api/v1/users']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/users']['get']['responses'][200]['content']['application/json']['items'];
 export type GetAnswerSubmitterRestrictionResponse =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['get']['responses'][200]['content']['application/json'];
 export type PutAnswerSubmitterRestrictionSchema =
@@ -46,4 +46,4 @@ export type CreateFormSchema =
 export type UpdateNotificationSettingsSchema =
   ApiPaths['/api/v1/notifications/settings/me']['patch']['requestBody']['content']['application/json'];
 export type GetArchivedFormsResponse =
-  ApiPaths['/api/v1/archived-forms']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/archived-forms']['get']['responses'][200]['content']['application/json']['items'];

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -32,7 +32,9 @@ const baseValues: FormEditorValues = {
     discord_webhook_url: '',
     default_answer_title: '',
     visibility: 'PUBLIC',
+    allowed_group_ids: [],
     answer_visibility: 'PUBLIC',
+    answer_group_ids: [],
     allow_temporary_answers: false,
   },
 };
@@ -116,6 +118,7 @@ describe('form request builders', () => {
       },
       settings: {
         visibility: 'PUBLIC',
+        allowed_group_ids: [],
         allow_temporary_answers: false,
         discord_webhook_url: null,
         answer_settings: {
@@ -125,6 +128,7 @@ describe('form request builders', () => {
             end_at: null,
           },
           visibility: 'PUBLIC',
+          answer_group_ids: [],
         },
       },
       questions: [

--- a/tests/unit/formListFilters.test.ts
+++ b/tests/unit/formListFilters.test.ts
@@ -24,8 +24,10 @@ const form = (
   questions: [],
   settings: {
     allow_temporary_answers: false,
+    allowed_group_ids: [],
     answer_settings: {
       acceptance_period: {},
+      answer_group_ids: [],
       visibility: 'PUBLIC',
     },
     discord_webhook_url: null,

--- a/tests/unit/userListRows.test.ts
+++ b/tests/unit/userListRows.test.ts
@@ -4,8 +4,8 @@ import { toUserListRows } from '@/app/(protected)/admin/users/_lib/userListRows'
 import type { GetUserListResponse } from '@/lib/api-types';
 
 const users = [
-  { id: 'self-user', name: '自分', role: 'ADMINISTRATOR' },
-  { id: 'other-user', name: '他のユーザー', role: 'STANDARD_USER' },
+  { id: 'self-user', name: '自分', role: 'ADMINISTRATOR', groups: [] },
+  { id: 'other-user', name: '他のユーザー', role: 'STANDARD_USER', groups: [] },
 ] satisfies GetUserListResponse;
 
 describe('toUserListRows', () => {


### PR DESCRIPTION
## 概要
- backend 側 OpenAPI スキーマの不備（#1165 で報告・修正済み）が解消されたため `pnpm codegen` で `src/generated/api-types.ts` を再生成した
- 追従した破壊的変更は2点
  - 一覧系4エンドポイント（`GET /api/v1/forms`, `/archived-forms`, `/forms/answers`, `/forms/{id}/answers`, `/users`）のレスポンスが配列から `{ items, next_cursor }` のページネーション形式に変わった → `src/lib/api/types.ts` の型エイリアスを `items` を指す形にし、生のレスポンスを扱う各 `page.tsx` / `AdminAnswerPageContent.tsx` で `.items` を取り出すよう修正
  - フォーム更新・回答設定に必須フィールド `answer_group_ids`（回答対象グループ）・`allowed_group_ids`（フォーム閲覧許可グループ）が追加された → グループ選択 UI は未実装のため、直近の選択肢 ID 保持 (#791) と同じ方針で GET → PUT へ既存値をラウンドトリップ保持するのみに留めた

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm test`（unit・component・e2e）がすべて通ることを確認した
- 影響を受けたテストフィクスチャ（`formEditorMappers.test.ts`, `formListFilters.test.ts`, `userListRows.test.ts`）を新しい必須フィールドに合わせて更新した

## 補足
- グループ単位のアクセス制御（回答対象グループ・閲覧許可グループの選択 UI）は別タスクとして対応予定

🤖 Generated with Claude Code