### PR TITLE
feat: 管理者向けユーザーページにユーザー検索機能を追加する

### DIFF
--- a/src/app/(protected)/admin/users/_components/UserListHeader.tsx
+++ b/src/app/(protected)/admin/users/_components/UserListHeader.tsx
@@ -1,11 +1,55 @@
-import { Box, Chip, Typography } from '@mui/material';
+import { Search } from '@mui/icons-material';
+import {
+  Box,
+  Chip,
+  InputAdornment,
+  TextField,
+  Typography,
+} from '@mui/material';
 
-const UserListHeader = ({ count }: { count: number }) => (
-  <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-    <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
-      ユーザー管理
-    </Typography>
-    <Chip label={`${count} 件`} size="small" color="primary" />
+const UserListHeader = ({
+  count,
+  search,
+  onSearchChange,
+}: {
+  count: number;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => (
+  <Box
+    sx={{
+      mb: 2,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 2,
+      flexWrap: 'wrap',
+    }}
+  >
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
+        ユーザー管理
+      </Typography>
+      <Chip label={`${count} 件`} size="small" color="primary" />
+    </Box>
+    <TextField
+      variant="standard"
+      size="small"
+      label="ユーザー検索"
+      value={search}
+      onChange={(e) => {
+        onSearchChange(e.target.value);
+      }}
+      sx={{ minWidth: 240, ml: 'auto' }}
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <Search fontSize="small" />
+            </InputAdornment>
+          ),
+        },
+      }}
+    />
   </Box>
 );
 

--- a/src/app/(protected)/admin/users/_components/UserNameCell.tsx
+++ b/src/app/(protected)/admin/users/_components/UserNameCell.tsx
@@ -3,17 +3,22 @@ import { Avatar, Box, Typography } from '@mui/material';
 import CopyButton from './CopyButton';
 
 const UserNameCell = ({ id, name }: { id: string; name: string }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
     <Avatar
       alt={name}
       src={`https://mc-heads.net/avatar/${id}/32`}
-      sx={{ width: 32, height: 32 }}
+      sx={{ width: 32, height: 32, flexShrink: 0 }}
     />
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
       <Typography
         variant="body2"
         component="span"
-        sx={{ fontWeight: 'medium' }}
+        sx={{
+          fontWeight: 'medium',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
       >
         {name}
       </Typography>

--- a/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
@@ -1,12 +1,17 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import InfiniteScrollSentinel from '@/app/_components/InfiniteScrollSentinel';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
 import type { GetUserListPageResponse } from '@/lib/api-types';
 
 import { toUserListRows } from '../_lib/userListRows';
 
 import UsersView from './UsersView';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const UsersPageContent = ({
   initialUsers,
@@ -15,6 +20,20 @@ const UsersPageContent = ({
   initialUsers: GetUserListPageResponse;
   currentUserId: string;
 }) => {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search.trim());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  const isSearching = debouncedSearch !== '';
+
   const {
     items: users,
     hasMore,
@@ -25,12 +44,20 @@ const UsersPageContent = ({
     (cursor) => ({ query: cursor === undefined ? {} : { cursor } }),
     initialUsers
   );
-  const rows = toUserListRows(users, currentUserId);
+
+  const { data: searchData } = useApiQuery(
+    '/api/v1/search/users',
+    isSearching ? { query: { query: debouncedSearch } } : null
+  );
+
+  const rows = isSearching
+    ? toUserListRows(searchData?.users ?? [], currentUserId)
+    : toUserListRows(users, currentUserId);
 
   return (
     <>
-      <UsersView rows={rows} />
-      {hasMore && (
+      <UsersView rows={rows} search={search} onSearchChange={setSearch} />
+      {!isSearching && hasMore && (
         <InfiniteScrollSentinel
           sentinelRef={sentinelRef}
           isLoadingMore={isLoadingMore}

--- a/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersPageContent.tsx
@@ -24,13 +24,25 @@ const UsersPageContent = ({
   const [debouncedSearch, setDebouncedSearch] = useState('');
 
   useEffect(() => {
+    const trimmed = search.trim();
+    if (trimmed === '') {
+      return;
+    }
+
     const timer = setTimeout(() => {
-      setDebouncedSearch(search.trim());
+      setDebouncedSearch(trimmed);
     }, SEARCH_DEBOUNCE_MS);
     return () => {
       clearTimeout(timer);
     };
   }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (value.trim() === '') {
+      setDebouncedSearch('');
+    }
+  };
 
   const isSearching = debouncedSearch !== '';
 
@@ -45,9 +57,10 @@ const UsersPageContent = ({
     initialUsers
   );
 
-  const { data: searchData } = useApiQuery(
+  const { data: searchData, isLoading: isSearchLoading } = useApiQuery(
     '/api/v1/search/users',
-    isSearching ? { query: { query: debouncedSearch } } : null
+    isSearching ? { query: { query: debouncedSearch } } : null,
+    { keepPreviousData: true }
   );
 
   const rows = isSearching
@@ -56,7 +69,12 @@ const UsersPageContent = ({
 
   return (
     <>
-      <UsersView rows={rows} search={search} onSearchChange={setSearch} />
+      <UsersView
+        rows={rows}
+        search={search}
+        onSearchChange={handleSearchChange}
+        isLoading={isSearching && isSearchLoading}
+      />
       {!isSearching && hasMore && (
         <InfiniteScrollSentinel
           sentinelRef={sentinelRef}

--- a/src/app/(protected)/admin/users/_components/UsersView.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersView.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  LinearProgress,
   Paper,
   Table,
   TableBody,
@@ -18,10 +19,12 @@ const UsersView = ({
   rows,
   search,
   onSearchChange,
+  isLoading = false,
 }: {
   rows: UserListRow[];
   search: string;
   onSearchChange: (value: string) => void;
+  isLoading?: boolean;
 }) => {
   return (
     <Box sx={{ p: 3 }}>
@@ -30,7 +33,16 @@ const UsersView = ({
         search={search}
         onSearchChange={onSearchChange}
       />
-      <TableContainer component={Paper} variant="outlined">
+      <TableContainer
+        component={Paper}
+        variant="outlined"
+        sx={{ position: 'relative' }}
+      >
+        {isLoading && (
+          <LinearProgress
+            sx={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1 }}
+          />
+        )}
         <Table sx={{ tableLayout: 'fixed' }}>
           <TableHead>
             <TableRow sx={{ '& th': { fontWeight: 'bold' } }}>

--- a/src/app/(protected)/admin/users/_components/UsersView.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersView.tsx
@@ -14,19 +14,31 @@ import type { UserListRow } from '../_lib/userListRows';
 import UserListHeader from './UserListHeader';
 import UserRow from './UserRow';
 
-const UsersView = ({ rows }: { rows: UserListRow[] }) => {
+const UsersView = ({
+  rows,
+  search,
+  onSearchChange,
+}: {
+  rows: UserListRow[];
+  search: string;
+  onSearchChange: (value: string) => void;
+}) => {
   return (
     <Box sx={{ p: 3 }}>
-      <UserListHeader count={rows.length} />
+      <UserListHeader
+        count={rows.length}
+        search={search}
+        onSearchChange={onSearchChange}
+      />
       <TableContainer component={Paper} variant="outlined">
-        <Table>
+        <Table sx={{ tableLayout: 'fixed' }}>
           <TableHead>
             <TableRow sx={{ '& th': { fontWeight: 'bold' } }}>
-              <TableCell>ユーザー</TableCell>
-              <TableCell>UUID</TableCell>
-              <TableCell>現在の権限</TableCell>
-              <TableCell>権限の変更</TableCell>
-              <TableCell>回答投稿制限</TableCell>
+              <TableCell sx={{ width: '24%' }}>ユーザー</TableCell>
+              <TableCell sx={{ width: '26%' }}>UUID</TableCell>
+              <TableCell sx={{ width: '14%' }}>現在の権限</TableCell>
+              <TableCell sx={{ width: '18%' }}>権限の変更</TableCell>
+              <TableCell sx={{ width: '18%' }}>回答投稿制限</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/src/app/_swr/useApiQuery.ts
+++ b/src/app/_swr/useApiQuery.ts
@@ -10,7 +10,7 @@ import type { GetPaths, GetParams, GetResponse } from './fetcher';
 
 export const useApiQuery = <P extends GetPaths>(
   path: P,
-  params?: GetParams<P>,
+  params?: GetParams<P> | null,
   options?: SWRConfiguration
 ) => {
   const hasHydrated = useHasHydrated();
@@ -24,11 +24,15 @@ export const useApiQuery = <P extends GetPaths>(
     pathObj && Object.values(pathObj).some((v) => !v && v !== 0);
 
   const key =
-    !hasHydrated || hasEmptyPathParam ? null : params ? [path, params] : [path];
+    !hasHydrated || params === null || hasEmptyPathParam
+      ? null
+      : params
+        ? [path, params]
+        : [path];
 
   return useSWR<GetResponse<P>, Error>(
     key,
-    () => typedFetcher(path, params),
+    () => typedFetcher(path, params ?? undefined),
     options
   );
 };

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -411,6 +411,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/search/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ユーザー検索を行う */
+        get: operations["search_users"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/session": {
         parameters: {
             query?: never;
@@ -907,6 +924,9 @@ export interface components {
             id: string;
             name: string;
             role: string;
+        };
+        UserSearchResult: {
+            users: components["schemas"]["UserSchema"][];
         };
         UserUpdateSchema: {
             /** Format: uuid */
@@ -3542,9 +3562,9 @@ export interface operations {
     };
     cross_search: {
         parameters: {
-            query?: {
+            query: {
                 /** @description Search query */
-                query?: string;
+                query: string;
             };
             header?: never;
             path?: never;
@@ -3559,6 +3579,65 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CrossSearchResult"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    search_users: {
+        parameters: {
+            query: {
+                /** @description Search query */
+                query: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSearchResult"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -30,6 +30,8 @@ export type {
   GetUserResponse,
   GetQuestionsResponse,
   GetUserListResponse,
+  GetUserSearchPageResponse,
+  GetUserSearchResponse,
   GetUsersResponse,
   PutAnswerSubmitterRestrictionSchema,
   SearchResponse,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -41,6 +41,9 @@ export type PutAnswerSubmitterRestrictionSchema =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['put']['requestBody']['content']['application/json'];
 export type SearchResponse =
   ApiPaths['/api/v1/search']['get']['responses'][200]['content']['application/json'];
+export type GetUserSearchPageResponse =
+  ApiPaths['/api/v1/search/users']['get']['responses'][200]['content']['application/json'];
+export type GetUserSearchResponse = GetUserSearchPageResponse['users'];
 export type GetNotificationSettingsResponse =
   ApiPaths['/api/v1/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserNotificationSettingsResponse =


### PR DESCRIPTION
## 概要
- Issue #785 対応の第一弾として、管理者向けユーザーページにユーザー検索機能を追加した。バックエンドに追加された `GET /api/v1/search/users` を `pnpm codegen` で取り込んで利用している。
- 検索欄・一覧テーブルを常に同じコンポーネントツリーで描画し、検索クエリの有無で `useApiQuery` のデータソースだけを切り替える構成にした（`useApiQuery` に `null` を渡すとフェッチをスキップするよう変更）。検索欄コンポーネント自体をアンマウントしないため、入力中に検索結果が切り替わってもフォーカスが外れない。
- 一致件数によってセル内の表示内容が変わってもテーブル幅が変わらないよう、`Table` に `tableLayout: fixed` と列幅指定を追加し、ユーザー名セルもはみ出し部分を省略表示にした。
- ユーザー個別情報（処罰履歴など）のモーダル拡張は別タスクとし、本 PR には含めていない。

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm fmt --check` / `pnpm test:unit`（53件）/ `pnpm test:component`（8件）がすべて通過することを確認した。
- `pnpm dev` でサーバ起動し、`/admin/users` への未認証アクセスがリダイレクト（307）することを確認した。MSAL 認証・バックエンドが必要なため、ブラウザでの実ログイン→検索操作までは未検証。実データでの動作確認をお願いしたい。

## 補足
- Issue #785 のうち、ユーザー個別情報（処罰履歴等）をモーダルで表示する対応は別タスクとする。

🤖 Generated with Claude Code