### PR TITLE
管理者向けユーザーグループ管理UIを追加する

### DIFF
--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -48,10 +48,6 @@ const DashboardMenu = () => {
             label: 'Users',
             url: '/admin/users',
           },
-          {
-            label: 'Groups',
-            url: '/admin/groups',
-          },
         ].map((value) => {
           return (
             <MenuItem

--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -48,6 +48,10 @@ const DashboardMenu = () => {
             label: 'Users',
             url: '/admin/users',
           },
+          {
+            label: 'Groups',
+            url: '/admin/groups',
+          },
         ].map((value) => {
           return (
             <MenuItem

--- a/src/app/(protected)/admin/groups/_components/CreateGroupField.tsx
+++ b/src/app/(protected)/admin/groups/_components/CreateGroupField.tsx
@@ -23,7 +23,12 @@ const CreateGroupField = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
 
-  const { handleSubmit, register, reset } = useForm<CreateGroupSchema>();
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<CreateGroupSchema>();
   const { createGroup } = useUserGroupCRUD();
 
   const handleOpen = () => {
@@ -35,7 +40,12 @@ const CreateGroupField = () => {
   };
 
   const onSubmit = async (data: CreateGroupSchema) => {
-    const result = await createGroup(data.name);
+    const trimmedName = data.name.trim();
+    if (!trimmedName) {
+      showSnackbar('グループ名を入力してください。', 'error');
+      return;
+    }
+    const result = await createGroup(trimmedName);
     if (result.ok) {
       showSnackbar('グループを作成しました。', 'success');
       handleClose();
@@ -72,8 +82,10 @@ const CreateGroupField = () => {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose}>キャンセル</Button>
-            <Button type="submit" variant="contained">
+            <Button onClick={handleClose} disabled={isSubmitting}>
+              キャンセル
+            </Button>
+            <Button type="submit" variant="contained" disabled={isSubmitting}>
               作成
             </Button>
           </DialogActions>

--- a/src/app/(protected)/admin/groups/_components/CreateGroupField.tsx
+++ b/src/app/(protected)/admin/groups/_components/CreateGroupField.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { AddCircle } from '@mui/icons-material';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@mui/material';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
+import { useUserGroupCRUD } from '@/hooks/useUserGroupCRUD';
+
+type CreateGroupSchema = {
+  name: string;
+};
+
+const CreateGroupField = () => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+
+  const { handleSubmit, register, reset } = useForm<CreateGroupSchema>();
+  const { createGroup } = useUserGroupCRUD();
+
+  const handleOpen = () => {
+    setDialogOpen(true);
+  };
+  const handleClose = () => {
+    setDialogOpen(false);
+    reset();
+  };
+
+  const onSubmit = async (data: CreateGroupSchema) => {
+    const result = await createGroup(data.name);
+    if (result.ok) {
+      showSnackbar('グループを作成しました。', 'success');
+      handleClose();
+    } else {
+      showSnackbar('グループの作成に失敗しました。', 'error');
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        startIcon={<AddCircle />}
+        onClick={handleOpen}
+      >
+        新規作成
+      </Button>
+
+      <Dialog open={dialogOpen} onClose={handleClose} fullWidth>
+        <DialogTitle>新規グループ作成</DialogTitle>
+        <form
+          onSubmit={(e) => {
+            void handleSubmit(onSubmit)(e);
+          }}
+        >
+          <DialogContent>
+            <TextField
+              {...register('name')}
+              autoFocus
+              margin="dense"
+              label="グループ名"
+              fullWidth
+              required
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose}>キャンセル</Button>
+            <Button type="submit" variant="contained">
+              作成
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </>
+  );
+};
+
+export default CreateGroupField;

--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialog.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialog.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Dialog, DialogTitle } from '@mui/material';
+
+import type { UserGroupSchema } from '@/lib/api-types';
+
+import GroupDetailDialogBody from './GroupDetailDialogBody';
+
+const GroupDetailDialog = ({
+  group,
+  onClose,
+}: {
+  group: UserGroupSchema | null;
+  onClose: () => void;
+}) => (
+  <Dialog open={group !== null} onClose={onClose} fullWidth maxWidth="sm">
+    <DialogTitle>グループ詳細: {group?.name}</DialogTitle>
+    {/* open のときだけ body を mount し、GET を開いたときだけ走らせる。 */}
+    {group && <GroupDetailDialogBody groupId={group.id} onClose={onClose} />}
+  </Dialog>
+);
+
+export default GroupDetailDialog;

--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
@@ -32,53 +32,55 @@ const GroupDetailDialogBody = ({
     path: { group_id: groupId },
   });
 
-  if (isLoading) {
-    return (
-      <DialogContent>
+  const renderContent = () => {
+    if (isLoading) {
+      return (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress />
         </Box>
-      </DialogContent>
-    );
-  }
+      );
+    }
 
-  if (error || !members) {
-    return (
-      <DialogContent>
+    if (error || !members) {
+      return (
         <Alert severity="error">所属ユーザー一覧の取得に失敗しました。</Alert>
-      </DialogContent>
+      );
+    }
+
+    if (members.length > 0) {
+      return (
+        <List disablePadding>
+          {members.map((member) => (
+            <ListItem key={member.id} disableGutters>
+              <ListItemAvatar>
+                <Avatar
+                  alt={member.name}
+                  src={`https://mc-heads.net/avatar/${member.id}/48`}
+                />
+              </ListItemAvatar>
+              <ListItemText
+                primary={member.name}
+                secondary={member.id}
+                slotProps={{
+                  secondary: { sx: { fontFamily: 'monospace' } },
+                }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      );
+    }
+
+    return (
+      <Typography variant="body2" color="text.secondary" component="p">
+        所属しているユーザーはいません
+      </Typography>
     );
-  }
+  };
 
   return (
     <>
-      <DialogContent>
-        {members.length > 0 ? (
-          <List disablePadding>
-            {members.map((member) => (
-              <ListItem key={member.id} disableGutters>
-                <ListItemAvatar>
-                  <Avatar
-                    alt={member.name}
-                    src={`https://mc-heads.net/avatar/${member.id}/48`}
-                  />
-                </ListItemAvatar>
-                <ListItemText
-                  primary={member.name}
-                  secondary={member.id}
-                  slotProps={{
-                    secondary: { sx: { fontFamily: 'monospace' } },
-                  }}
-                />
-              </ListItem>
-            ))}
-          </List>
-        ) : (
-          <Typography variant="body2" color="text.secondary">
-            所属しているユーザーはいません
-          </Typography>
-        )}
-      </DialogContent>
+      <DialogContent>{renderContent()}</DialogContent>
       <DialogActions>
         <Button onClick={onClose}>閉じる</Button>
       </DialogActions>

--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import {
+  Alert,
+  Avatar,
+  Box,
+  CircularProgress,
+  Button,
+  DialogActions,
+  DialogContent,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+
+const GroupDetailDialogBody = ({
+  groupId,
+  onClose,
+}: {
+  groupId: string;
+  onClose: () => void;
+}) => {
+  const {
+    data: members,
+    error,
+    isLoading,
+  } = useApiQuery('/api/v1/user-groups/{group_id}/users', {
+    path: { group_id: groupId },
+  });
+
+  if (isLoading) {
+    return (
+      <DialogContent>
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      </DialogContent>
+    );
+  }
+
+  if (error || !members) {
+    return (
+      <DialogContent>
+        <Alert severity="error">所属ユーザー一覧の取得に失敗しました。</Alert>
+      </DialogContent>
+    );
+  }
+
+  return (
+    <>
+      <DialogContent>
+        {members.length > 0 ? (
+          <List disablePadding>
+            {members.map((member) => (
+              <ListItem key={member.id} disableGutters>
+                <ListItemAvatar>
+                  <Avatar
+                    alt={member.name}
+                    src={`https://mc-heads.net/avatar/${member.id}/48`}
+                  />
+                </ListItemAvatar>
+                <ListItemText
+                  primary={member.name}
+                  secondary={member.id}
+                  slotProps={{
+                    secondary: { sx: { fontFamily: 'monospace' } },
+                  }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            所属しているユーザーはいません
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>閉じる</Button>
+      </DialogActions>
+    </>
+  );
+};
+
+export default GroupDetailDialogBody;

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -24,6 +24,7 @@ import { useForm } from 'react-hook-form';
 
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useUserGroupCRUD } from '@/hooks/useUserGroupCRUD';
 import type { UserGroupSchema } from '@/lib/api-types';
 
@@ -35,6 +36,7 @@ type EditGroupSchema = {
 };
 
 const Groups = (props: { groups: UserGroupSchema[] }) => {
+  const { data: groups = props.groups } = useApiQuery('/api/v1/user-groups');
   const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -43,15 +45,13 @@ const Groups = (props: { groups: UserGroupSchema[] }) => {
   );
   const [detailGroup, setDetailGroup] = useState<UserGroupSchema | null>(null);
 
-  const { handleSubmit, register, reset, setValue } =
-    useForm<EditGroupSchema>();
+  const { handleSubmit, register, reset } = useForm<EditGroupSchema>();
 
   const { deleteGroup, editGroup } = useUserGroupCRUD();
 
   const handleOpenEdit = (group: UserGroupSchema) => {
     setSelectedGroup(group);
-    setValue('id', group.id);
-    setValue('name', group.name);
+    reset({ id: group.id, name: group.name });
     setEditDialogOpen(true);
   };
 
@@ -92,7 +92,7 @@ const Groups = (props: { groups: UserGroupSchema[] }) => {
     }
   };
 
-  if (props.groups.length === 0) {
+  if (groups.length === 0) {
     return (
       <Box>
         <Paper sx={{ p: 4, textAlign: 'center' }}>
@@ -121,7 +121,7 @@ const Groups = (props: { groups: UserGroupSchema[] }) => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {props.groups.map((group) => (
+            {groups.map((group) => (
               <TableRow key={group.id}>
                 <TableCell component="th" scope="row">
                   {group.name}
@@ -170,7 +170,7 @@ const Groups = (props: { groups: UserGroupSchema[] }) => {
           }}
         >
           <DialogContent>
-            <TextField {...register('id')} type="hidden" />
+            <input {...register('id')} type="hidden" />
             <TextField
               {...register('name')}
               autoFocus

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { Delete, Edit, Visibility } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import ConfirmDialog from '@/app/_components/ConfirmDialog';
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
+import { useUserGroupCRUD } from '@/hooks/useUserGroupCRUD';
+import type { UserGroupSchema } from '@/lib/api-types';
+
+import GroupDetailDialog from './GroupDetailDialog';
+
+type EditGroupSchema = {
+  id: string;
+  name: string;
+};
+
+const Groups = (props: { groups: UserGroupSchema[] }) => {
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [selectedGroup, setSelectedGroup] = useState<UserGroupSchema | null>(
+    null
+  );
+  const [detailGroup, setDetailGroup] = useState<UserGroupSchema | null>(null);
+
+  const { handleSubmit, register, reset, setValue } =
+    useForm<EditGroupSchema>();
+
+  const { deleteGroup, editGroup } = useUserGroupCRUD();
+
+  const handleOpenEdit = (group: UserGroupSchema) => {
+    setSelectedGroup(group);
+    setValue('id', group.id);
+    setValue('name', group.name);
+    setEditDialogOpen(true);
+  };
+
+  const handleCloseEdit = () => {
+    setEditDialogOpen(false);
+    setSelectedGroup(null);
+    reset();
+  };
+
+  const handleOpenDelete = (group: UserGroupSchema) => {
+    setSelectedGroup(group);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleCloseDelete = () => {
+    setDeleteDialogOpen(false);
+    setSelectedGroup(null);
+  };
+
+  const onEdit = async (data: EditGroupSchema) => {
+    const result = await editGroup(data.id, data.name);
+    if (result.ok) {
+      showSnackbar('グループを編集しました。', 'success');
+      handleCloseEdit();
+    } else {
+      showSnackbar('グループの編集に失敗しました。', 'error');
+    }
+  };
+
+  const onDelete = async () => {
+    if (!selectedGroup) return;
+    const result = await deleteGroup(selectedGroup.id);
+    if (result.ok) {
+      showSnackbar('グループを削除しました。', 'success');
+      handleCloseDelete();
+    } else {
+      showSnackbar('グループの削除に失敗しました。', 'error');
+    }
+  };
+
+  if (props.groups.length === 0) {
+    return (
+      <Box>
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body1" color="text.secondary">
+            グループが登録されていません。
+          </Typography>
+        </Paper>
+        <SnackbarAlert
+          open={snackbar.open}
+          message={snackbar.message}
+          severity={snackbar.severity}
+          onClose={closeSnackbar}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>グループ名</TableCell>
+              <TableCell align="right">アクション</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {props.groups.map((group) => (
+              <TableRow key={group.id}>
+                <TableCell component="th" scope="row">
+                  {group.name}
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    color="default"
+                    onClick={() => {
+                      setDetailGroup(group);
+                    }}
+                    aria-label="詳細"
+                  >
+                    <Visibility />
+                  </IconButton>
+                  <IconButton
+                    color="primary"
+                    onClick={() => {
+                      handleOpenEdit(group);
+                    }}
+                    aria-label="編集"
+                  >
+                    <Edit />
+                  </IconButton>
+                  <IconButton
+                    color="error"
+                    onClick={() => {
+                      handleOpenDelete(group);
+                    }}
+                    aria-label="削除"
+                  >
+                    <Delete />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={editDialogOpen} onClose={handleCloseEdit} fullWidth>
+        <DialogTitle>グループを編集</DialogTitle>
+        <Box
+          component="form"
+          onSubmit={(e) => {
+            void handleSubmit(onEdit)(e);
+          }}
+        >
+          <DialogContent>
+            <TextField {...register('id')} type="hidden" />
+            <TextField
+              {...register('name')}
+              autoFocus
+              margin="dense"
+              label="グループ名"
+              fullWidth
+              required
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseEdit}>キャンセル</Button>
+            <Button type="submit" variant="contained">
+              保存
+            </Button>
+          </DialogActions>
+        </Box>
+      </Dialog>
+
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        title="グループを削除"
+        description={`「${selectedGroup?.name ?? ''}」を削除してもよろしいですか？この操作は元に戻せません。`}
+        confirmLabel="削除"
+        onConfirm={() => {
+          void onDelete();
+        }}
+        onCancel={handleCloseDelete}
+      />
+
+      <GroupDetailDialog
+        group={detailGroup}
+        onClose={() => {
+          setDetailGroup(null);
+        }}
+      />
+
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </Box>
+  );
+};
+
+export default Groups;

--- a/src/app/(protected)/admin/groups/page.tsx
+++ b/src/app/(protected)/admin/groups/page.tsx
@@ -1,0 +1,45 @@
+import { Stack, Typography } from '@mui/material';
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
+import { getAdminAccess } from '@/lib/server/session';
+
+import CreateGroupField from './_components/CreateGroupField';
+import Groups from './_components/Groups';
+
+export const metadata: Metadata = {
+  title: 'グループ管理 | Seichi Portal',
+};
+
+const Home = async () => {
+  const { session } = await getAdminAccess();
+  const groups = await requireBackendData(
+    serverApiClient.GET('/api/v1/user-groups', {
+      headers: authorizationHeader(session.token),
+    })
+  );
+
+  return (
+    <Stack spacing={3} sx={{ width: '100%' }}>
+      <Stack
+        direction="row"
+        sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+      >
+        <Typography variant="h4" component="h1">
+          グループ管理
+        </Typography>
+        <CreateGroupField />
+      </Stack>
+      <Suspense fallback={null}>
+        <Groups groups={groups} />
+      </Suspense>
+    </Stack>
+  );
+};
+
+export default Home;

--- a/src/app/(protected)/admin/users/_components/ToManageUserGroupsButton.tsx
+++ b/src/app/(protected)/admin/users/_components/ToManageUserGroupsButton.tsx
@@ -1,0 +1,18 @@
+import { Groups } from '@mui/icons-material';
+import Button from '@mui/material/Button';
+import NextLink from 'next/link';
+
+const ToManageUserGroupsButton = () => {
+  return (
+    <Button
+      component={NextLink}
+      variant="outlined"
+      startIcon={<Groups />}
+      href="/admin/groups"
+    >
+      グループの管理
+    </Button>
+  );
+};
+
+export default ToManageUserGroupsButton;

--- a/src/app/(protected)/admin/users/_components/UserDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/UserDetailDialogBody.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   Avatar,
   Box,
-  Chip,
   CircularProgress,
   DialogActions,
   DialogContent,
@@ -20,6 +19,7 @@ import CopyButton from './CopyButton';
 import RestrictionManagementSection from './RestrictionManagementSection';
 import RoleChip from './RoleChip';
 import RoleSelectCell from './RoleSelectCell';
+import UserGroupMembershipSection from './UserGroupMembershipSection';
 
 const UserDetailDialogBody = ({
   uuid,
@@ -36,6 +36,7 @@ const UserDetailDialogBody = ({
     data: user,
     error: userError,
     isLoading: isUserLoading,
+    mutate: mutateUser,
   } = useApiQuery('/api/v1/users/{uuid}', { path: { uuid } });
 
   if (isUserLoading) {
@@ -85,17 +86,12 @@ const UserDetailDialogBody = ({
 
           <Stack spacing={1}>
             <Typography variant="subtitle2">所属グループ</Typography>
-            {user.groups.length > 0 ? (
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                {user.groups.map((group) => (
-                  <Chip key={group.id} label={group.name} size="small" />
-                ))}
-              </Box>
-            ) : (
-              <Typography variant="body2" color="text.secondary">
-                所属しているグループはありません
-              </Typography>
-            )}
+            <UserGroupMembershipSection
+              uuid={user.id}
+              currentGroups={user.groups}
+              disabled={!canManageRestriction}
+              onChanged={mutateUser}
+            />
           </Stack>
 
           <Stack spacing={1}>

--- a/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
@@ -27,7 +27,9 @@ const UserGroupMembershipSection = ({
 }) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const { data: allGroups } = useApiQuery('/api/v1/user-groups');
+  const { data: allGroups, isLoading: isGroupsLoading } = useApiQuery(
+    '/api/v1/user-groups'
+  );
   const { addUserToGroup, removeUserFromGroup } =
     useUserGroupMembershipActions();
 
@@ -89,7 +91,7 @@ const UserGroupMembershipSection = ({
         options={joinableGroups}
         getOptionLabel={(group) => group.name}
         value={null}
-        disabled={disabled}
+        disabled={disabled || isGroupsLoading}
         onChange={(_event, group) => {
           if (group) {
             void handleAdd(group);

--- a/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Chip,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { useUserGroupMembershipActions } from '@/hooks/useUserGroupMembershipActions';
+import type { UserGroupSchema } from '@/lib/api-types';
+
+const UserGroupMembershipSection = ({
+  uuid,
+  currentGroups,
+  disabled,
+  onChanged,
+}: {
+  uuid: string;
+  currentGroups: UserGroupSchema[];
+  disabled: boolean;
+  onChanged: () => Promise<unknown>;
+}) => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const { data: allGroups } = useApiQuery('/api/v1/user-groups');
+  const { addUserToGroup, removeUserFromGroup } =
+    useUserGroupMembershipActions();
+
+  const joinableGroups = (allGroups ?? []).filter(
+    (group) => !currentGroups.some((current) => current.id === group.id)
+  );
+
+  const handleAdd = async (group: UserGroupSchema) => {
+    setSubmitError(null);
+    const result = await addUserToGroup(group.id, uuid);
+    if (result.success) {
+      await onChanged();
+    } else {
+      setSubmitError('グループへの追加に失敗しました。');
+    }
+  };
+
+  const handleRemove = async (group: UserGroupSchema) => {
+    setSubmitError(null);
+    const result = await removeUserFromGroup(group.id, uuid);
+    if (result.success) {
+      await onChanged();
+    } else {
+      setSubmitError('グループからの削除に失敗しました。');
+    }
+  };
+
+  return (
+    <Box>
+      {submitError && (
+        <Alert severity="error" sx={{ mb: 1 }}>
+          {submitError}
+        </Alert>
+      )}
+      {currentGroups.length > 0 ? (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+          {currentGroups.map((group) => (
+            <Chip
+              key={group.id}
+              label={group.name}
+              size="small"
+              disabled={disabled}
+              onDelete={
+                disabled
+                  ? undefined
+                  : () => {
+                      void handleRemove(group);
+                    }
+              }
+            />
+          ))}
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          所属しているグループはありません
+        </Typography>
+      )}
+      <Autocomplete
+        options={joinableGroups}
+        getOptionLabel={(group) => group.name}
+        value={null}
+        disabled={disabled}
+        onChange={(_event, group) => {
+          if (group) {
+            void handleAdd(group);
+          }
+        }}
+        renderInput={(params) => (
+          <TextField {...params} size="small" label="グループを追加" />
+        )}
+      />
+    </Box>
+  );
+};
+
+export default UserGroupMembershipSection;

--- a/src/app/(protected)/admin/users/_components/UserListHeader.tsx
+++ b/src/app/(protected)/admin/users/_components/UserListHeader.tsx
@@ -7,6 +7,8 @@ import {
   Typography,
 } from '@mui/material';
 
+import ToManageUserGroupsButton from './ToManageUserGroupsButton';
+
 const UserListHeader = ({
   count,
   search,
@@ -31,6 +33,7 @@ const UserListHeader = ({
       </Typography>
       <Chip label={`${count} 件`} size="small" color="primary" />
     </Box>
+    <ToManageUserGroupsButton />
     <TextField
       variant="standard"
       size="small"

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -482,6 +482,23 @@ export interface paths {
         patch: operations["update_user_group"];
         trace?: never;
     };
+    "/api/v1/user-groups/{group_id}/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ユーザーグループに所属するユーザーの一覧取得 */
+        get: operations["user_group_user_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/user-groups/{group_id}/users/{user_id}": {
         parameters: {
             query?: never;
@@ -4080,6 +4097,74 @@ export interface operations {
             };
             /** @description Client error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    user_group_user_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User group UUID */
+                group_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSchema"][];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/hooks/useUserGroupCRUD.ts
+++ b/src/hooks/useUserGroupCRUD.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useSWRConfig } from 'swr';
+
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useUserGroupCRUD = () => {
+  const { mutate } = useSWRConfig();
+  const key = ['/api/v1/user-groups'];
+
+  const createGroup = async (name: string): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.POST('/api/v1/user-groups', {
+      body: { name },
+    });
+    if (response.ok) await mutate(key);
+    return { ok: response.ok };
+  };
+
+  const editGroup = async (
+    id: string,
+    name: string
+  ): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.PATCH(
+      '/api/v1/user-groups/{group_id}',
+      {
+        params: { path: { group_id: id } },
+        body: { name },
+      }
+    );
+    if (response.ok) await mutate(key);
+    return { ok: response.ok };
+  };
+
+  const deleteGroup = async (id: string): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.DELETE(
+      '/api/v1/user-groups/{group_id}',
+      {
+        params: { path: { group_id: id } },
+      }
+    );
+    if (response.ok) await mutate(key);
+    return { ok: response.ok };
+  };
+
+  return { createGroup, editGroup, deleteGroup };
+};

--- a/src/hooks/useUserGroupMembershipActions.ts
+++ b/src/hooks/useUserGroupMembershipActions.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { handleMutationResponse } from '@/hooks/useApiMutation';
+import type { MutationResult } from '@/hooks/useApiMutation';
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useUserGroupMembershipActions = () => {
+  const addUserToGroup = async (
+    groupId: string,
+    userId: string
+  ): Promise<MutationResult> => {
+    const { data, error, response } = await proxyClient.PUT(
+      '/api/v1/user-groups/{group_id}/users/{user_id}',
+      {
+        params: { path: { group_id: groupId, user_id: userId } },
+      }
+    );
+    return handleMutationResponse(response, data, error);
+  };
+
+  const removeUserFromGroup = async (
+    groupId: string,
+    userId: string
+  ): Promise<MutationResult> => {
+    const { data, error, response } = await proxyClient.DELETE(
+      '/api/v1/user-groups/{group_id}/users/{user_id}',
+      {
+        params: { path: { group_id: groupId, user_id: userId } },
+      }
+    );
+    return handleMutationResponse(response, data, error);
+  };
+
+  return { addUserToGroup, removeUserFromGroup };
+};

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -10,6 +10,7 @@ export type {
   AnswerComment,
   CreateFormResponse,
   CreateFormSchema,
+  CreateUserGroupSchema,
   GetAnswerLabelsResponse,
   GetAnswerResponse,
   GetAnswerSubmitterRestrictionResponse,
@@ -25,6 +26,8 @@ export type {
   GetFormsResponse,
   GetMessagesResponse,
   GetNotificationSettingsResponse,
+  GetUserGroupMembersResponse,
+  GetUserGroupsResponse,
   GetUserListPageResponse,
   GetUserNotificationSettingsResponse,
   GetUserResponse,
@@ -36,4 +39,5 @@ export type {
   PutAnswerSubmitterRestrictionSchema,
   SearchResponse,
   UpdateNotificationSettingsSchema,
+  UserGroupSchema,
 } from '@/lib/api/types';

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -55,3 +55,10 @@ export type UpdateNotificationSettingsSchema =
 export type GetArchivedFormsPageResponse =
   ApiPaths['/api/v1/archived-forms']['get']['responses'][200]['content']['application/json'];
 export type GetArchivedFormsResponse = GetArchivedFormsPageResponse['items'];
+export type UserGroupSchema = ApiComponents['schemas']['UserGroupSchema'];
+export type GetUserGroupsResponse =
+  ApiPaths['/api/v1/user-groups']['get']['responses'][200]['content']['application/json'];
+export type CreateUserGroupSchema =
+  ApiPaths['/api/v1/user-groups']['post']['requestBody']['content']['application/json'];
+export type GetUserGroupMembersResponse =
+  ApiPaths['/api/v1/user-groups/{group_id}/users']['get']['responses'][200]['content']['application/json'];

--- a/tests/component/CreateGroupField.test.tsx
+++ b/tests/component/CreateGroupField.test.tsx
@@ -1,0 +1,53 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CreateGroupField from '@/app/(protected)/admin/groups/_components/CreateGroupField';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+const createGroupMock = vi.hoisted<
+  ReturnType<typeof vi.fn<(name: string) => Promise<{ ok: boolean }>>>
+>(() => vi.fn<(name: string) => Promise<{ ok: boolean }>>());
+
+vi.mock('@/hooks/useUserGroupCRUD', () => ({
+  useUserGroupCRUD: () => ({ createGroup: createGroupMock }),
+}));
+
+describe('CreateGroupField', () => {
+  beforeEach(() => {
+    createGroupMock.mockReset();
+    createGroupMock.mockResolvedValue({ ok: true });
+  });
+
+  it('前後の空白をトリムしてグループを作成する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CreateGroupField />);
+
+    await user.click(screen.getByRole('button', { name: '新規作成' }));
+    await user.type(
+      screen.getByRole('textbox', { name: 'グループ名' }),
+      '  グループA  '
+    );
+    await user.click(screen.getByRole('button', { name: '作成' }));
+
+    await waitFor(() => {
+      expect(createGroupMock).toHaveBeenCalledWith('グループA');
+    });
+  });
+
+  it('空白のみの場合は作成せずエラーを表示する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<CreateGroupField />);
+
+    await user.click(screen.getByRole('button', { name: '新規作成' }));
+    await user.type(screen.getByRole('textbox', { name: 'グループ名' }), '   ');
+    await user.click(screen.getByRole('button', { name: '作成' }));
+
+    expect(
+      await screen.findByText('グループ名を入力してください。')
+    ).toBeVisible();
+    expect(createGroupMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/component/GroupDetailDialogBody.test.tsx
+++ b/tests/component/GroupDetailDialogBody.test.tsx
@@ -36,6 +36,7 @@ describe('GroupDetailDialogBody', () => {
 
     expect(screen.getByText('ユーザーA')).toBeVisible();
     expect(screen.getByText('ユーザーB')).toBeVisible();
+    expect(screen.getByRole('button', { name: '閉じる' })).toBeVisible();
   });
 
   it('所属ユーザーがいない場合は空メッセージを表示する', () => {
@@ -62,5 +63,16 @@ describe('GroupDetailDialogBody', () => {
     expect(
       screen.getByText('所属ユーザー一覧の取得に失敗しました。')
     ).toBeVisible();
+    expect(screen.getByRole('button', { name: '閉じる' })).toBeVisible();
+  });
+
+  it('読み込み中でも閉じるボタンを表示する', () => {
+    queryState.current = { data: undefined, error: null, isLoading: true };
+
+    renderWithProviders(
+      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: '閉じる' })).toBeVisible();
   });
 });

--- a/tests/component/GroupDetailDialogBody.test.tsx
+++ b/tests/component/GroupDetailDialogBody.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import GroupDetailDialogBody from '@/app/(protected)/admin/groups/_components/GroupDetailDialogBody';
+import type { GetUserGroupMembersResponse } from '@/lib/api-types';
+
+import { renderWithProviders, screen } from './render';
+
+type MembersQueryState = {
+  data: GetUserGroupMembersResponse | undefined;
+  error: Error | null;
+  isLoading: boolean;
+};
+
+const queryState = vi.hoisted<{ current: MembersQueryState }>(() => ({
+  current: { data: undefined, error: null, isLoading: false },
+}));
+
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: () => queryState.current,
+}));
+
+describe('GroupDetailDialogBody', () => {
+  it('所属ユーザーがいる場合は一覧表示する', () => {
+    queryState.current = {
+      data: [
+        { groups: [], id: 'user-1', name: 'ユーザーA', role: 'user' },
+        { groups: [], id: 'user-2', name: 'ユーザーB', role: 'user' },
+      ],
+      error: null,
+      isLoading: false,
+    };
+
+    renderWithProviders(
+      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+    );
+
+    expect(screen.getByText('ユーザーA')).toBeVisible();
+    expect(screen.getByText('ユーザーB')).toBeVisible();
+  });
+
+  it('所属ユーザーがいない場合は空メッセージを表示する', () => {
+    queryState.current = { data: [], error: null, isLoading: false };
+
+    renderWithProviders(
+      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+    );
+
+    expect(screen.getByText('所属しているユーザーはいません')).toBeVisible();
+  });
+
+  it('取得に失敗した場合はエラーを表示する', () => {
+    queryState.current = {
+      data: undefined,
+      error: new Error('failed'),
+      isLoading: false,
+    };
+
+    renderWithProviders(
+      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('所属ユーザー一覧の取得に失敗しました。')
+    ).toBeVisible();
+  });
+});

--- a/tests/component/Groups.test.tsx
+++ b/tests/component/Groups.test.tsx
@@ -1,0 +1,83 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Groups from '@/app/(protected)/admin/groups/_components/Groups';
+
+import { renderWithProviders, screen, waitFor, within } from './render';
+
+type GroupCRUDMocks = {
+  editGroup: ReturnType<
+    typeof vi.fn<(id: string, name: string) => Promise<{ ok: boolean }>>
+  >;
+  deleteGroup: ReturnType<
+    typeof vi.fn<(id: string) => Promise<{ ok: boolean }>>
+  >;
+};
+
+const groupCRUDMocks = vi.hoisted<GroupCRUDMocks>(() => ({
+  editGroup: vi.fn<(id: string, name: string) => Promise<{ ok: boolean }>>(),
+  deleteGroup: vi.fn<(id: string) => Promise<{ ok: boolean }>>(),
+}));
+
+vi.mock('@/hooks/useUserGroupCRUD', () => ({
+  useUserGroupCRUD: () => ({
+    createGroup: vi.fn(),
+    editGroup: groupCRUDMocks.editGroup,
+    deleteGroup: groupCRUDMocks.deleteGroup,
+  }),
+}));
+
+vi.mock('@/app/(protected)/admin/groups/_components/GroupDetailDialog', () => ({
+  default: () => null,
+}));
+
+describe('Groups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    groupCRUDMocks.editGroup.mockResolvedValue({ ok: true });
+    groupCRUDMocks.deleteGroup.mockResolvedValue({ ok: true });
+  });
+
+  it('グループが無い場合は空メッセージを表示する', () => {
+    renderWithProviders(<Groups groups={[]} />);
+
+    expect(screen.getByText('グループが登録されていません。')).toBeVisible();
+  });
+
+  it('グループ名を編集する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Groups groups={[{ id: 'group-1', name: 'グループA' }]} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '編集' }));
+    const nameInput = screen.getByRole('textbox', { name: 'グループ名' });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'グループA改');
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(groupCRUDMocks.editGroup).toHaveBeenCalledWith(
+        'group-1',
+        'グループA改'
+      );
+    });
+  });
+
+  it('確認ダイアログで承認するとグループを削除する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Groups groups={[{ id: 'group-1', name: 'グループA' }]} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: '削除' }));
+
+    await waitFor(() => {
+      expect(groupCRUDMocks.deleteGroup).toHaveBeenCalledWith('group-1');
+    });
+  });
+});

--- a/tests/component/Groups.test.tsx
+++ b/tests/component/Groups.test.tsx
@@ -27,6 +27,10 @@ vi.mock('@/hooks/useUserGroupCRUD', () => ({
   }),
 }));
 
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: () => ({ data: undefined, error: null, isLoading: false }),
+}));
+
 vi.mock('@/app/(protected)/admin/groups/_components/GroupDetailDialog', () => ({
   default: () => null,
 }));

--- a/tests/component/UserGroupMembershipSection.test.tsx
+++ b/tests/component/UserGroupMembershipSection.test.tsx
@@ -1,0 +1,136 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UserGroupMembershipSection from '@/app/(protected)/admin/users/_components/UserGroupMembershipSection';
+import type { UserGroupSchema } from '@/lib/api-types';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+type GroupListQueryState = {
+  data: UserGroupSchema[] | undefined;
+  error: Error | null;
+  isLoading: boolean;
+};
+
+type MembershipMocks = {
+  queryState: GroupListQueryState;
+  addUserToGroup: ReturnType<
+    typeof vi.fn<
+      (groupId: string, userId: string) => Promise<{ success: boolean }>
+    >
+  >;
+  removeUserFromGroup: ReturnType<
+    typeof vi.fn<
+      (groupId: string, userId: string) => Promise<{ success: boolean }>
+    >
+  >;
+};
+
+const membershipMocks = vi.hoisted<MembershipMocks>(() => ({
+  queryState: {
+    data: [
+      { id: 'group-1', name: 'グループA' },
+      { id: 'group-2', name: 'グループB' },
+    ],
+    error: null,
+    isLoading: false,
+  },
+  addUserToGroup:
+    vi.fn<(groupId: string, userId: string) => Promise<{ success: boolean }>>(),
+  removeUserFromGroup:
+    vi.fn<(groupId: string, userId: string) => Promise<{ success: boolean }>>(),
+}));
+
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: () => membershipMocks.queryState,
+}));
+
+vi.mock('@/hooks/useUserGroupMembershipActions', () => ({
+  useUserGroupMembershipActions: () => ({
+    addUserToGroup: membershipMocks.addUserToGroup,
+    removeUserFromGroup: membershipMocks.removeUserFromGroup,
+  }),
+}));
+
+describe('UserGroupMembershipSection', () => {
+  const onChanged = vi.fn<() => Promise<void>>();
+
+  beforeEach(() => {
+    membershipMocks.queryState.data = [
+      { id: 'group-1', name: 'グループA' },
+      { id: 'group-2', name: 'グループB' },
+    ];
+    membershipMocks.addUserToGroup.mockResolvedValue({ success: true });
+    membershipMocks.removeUserFromGroup.mockResolvedValue({ success: true });
+    onChanged.mockResolvedValue();
+    vi.clearAllMocks();
+  });
+
+  it('未所属のグループを選択して追加する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[]}
+        disabled={false}
+        onChanged={onChanged}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'グループを追加' }));
+    await user.click(await screen.findByRole('option', { name: 'グループA' }));
+
+    await waitFor(() => {
+      expect(membershipMocks.addUserToGroup).toHaveBeenCalledWith(
+        'group-1',
+        'user-uuid'
+      );
+      expect(onChanged).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('所属済みグループのChipを削除するとグループから外す', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[{ id: 'group-1', name: 'グループA' }]}
+        disabled={false}
+        onChanged={onChanged}
+      />
+    );
+
+    const chip = screen.getByText('グループA').closest('.MuiChip-root');
+    if (!chip) throw new Error('Chip not found');
+    const deleteIcon = chip.querySelector('.MuiChip-deleteIcon');
+    if (!deleteIcon) throw new Error('delete icon not found');
+    await user.click(deleteIcon);
+
+    await waitFor(() => {
+      expect(membershipMocks.removeUserFromGroup).toHaveBeenCalledWith(
+        'group-1',
+        'user-uuid'
+      );
+      expect(onChanged).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('disabled のときは追加・削除の操作ができない', () => {
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[{ id: 'group-1', name: 'グループA' }]}
+        disabled
+        onChanged={onChanged}
+      />
+    );
+
+    expect(
+      screen.getByRole('combobox', { name: 'グループを追加' })
+    ).toBeDisabled();
+    const chip = screen.getByText('グループA').closest('.MuiChip-root');
+    expect(chip?.querySelector('.MuiChip-deleteIcon')).toBeNull();
+  });
+});

--- a/tests/component/UserGroupMembershipSection.test.tsx
+++ b/tests/component/UserGroupMembershipSection.test.tsx
@@ -60,6 +60,7 @@ describe('UserGroupMembershipSection', () => {
       { id: 'group-1', name: 'グループA' },
       { id: 'group-2', name: 'グループB' },
     ];
+    membershipMocks.queryState.isLoading = false;
     membershipMocks.addUserToGroup.mockResolvedValue({ success: true });
     membershipMocks.removeUserFromGroup.mockResolvedValue({ success: true });
     onChanged.mockResolvedValue();
@@ -132,5 +133,23 @@ describe('UserGroupMembershipSection', () => {
     ).toBeDisabled();
     const chip = screen.getByText('グループA').closest('.MuiChip-root');
     expect(chip?.querySelector('.MuiChip-deleteIcon')).toBeNull();
+  });
+
+  it('グループ一覧の読み込み中は追加欄を無効化する', () => {
+    membershipMocks.queryState.isLoading = true;
+    membershipMocks.queryState.data = undefined;
+
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[]}
+        disabled={false}
+        onChanged={onChanged}
+      />
+    );
+
+    expect(
+      screen.getByRole('combobox', { name: 'グループを追加' })
+    ).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- グループの一覧・作成・改名・削除・所属ユーザー一覧の閲覧を行える `/admin/groups` ページを追加
- ユーザー詳細モーダル(`/admin/users`)の「所属グループ」表示を、グループの追加・削除ができるUIに変更
- バックエンドAPIの更新(`GET /api/v1/user-groups/{group_id}/users` の追加等)に合わせて `pnpm codegen` を実行し `src/generated/api-types.ts` を更新

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:unit`
- [x] `pnpm test:component`
- [ ] `pnpm dev` で実ブラウザ動作確認(バックエンド・MSAL認証が必要なため未実施、レビュー時に確認をお願いします)
  - `/admin/groups` でグループの作成・改名・削除ができる
  - グループの「詳細」を開くと所属ユーザー一覧が表示される
  - `/admin/users` のユーザー詳細モーダルでグループの追加・削除ができる
  - 権限のないユーザーでは操作ボタンが無効化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)