### PR TITLE
フォームの回答可能グループ設定をフロントエンドから編集できるようにする

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormGroupField.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormGroupField.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import { useController } from 'react-hook-form';
+import type { Control } from 'react-hook-form';
+
+import type { GetUserGroupsResponse } from '@/lib/api-types';
+
+import type { FormEditorValues } from '../_schema/formEditorSchema';
+
+const FormGroupField = (props: {
+  control: Control<FormEditorValues>;
+  name: 'settings.allowed_group_ids' | 'settings.answer_group_ids';
+  label: string;
+  helperText: string;
+  groupOptions: GetUserGroupsResponse;
+}) => {
+  const { field } = useController({
+    control: props.control,
+    name: props.name,
+  });
+
+  const selectedGroups = props.groupOptions.filter((group) =>
+    field.value.includes(group.id)
+  );
+
+  return (
+    <Autocomplete
+      multiple
+      id={props.name}
+      options={props.groupOptions}
+      getOptionLabel={(option) => option.name}
+      value={selectedGroups}
+      isOptionEqualToValue={(option, value) => option.id === value.id}
+      renderOption={(renderProps, option) => (
+        <Box {...renderProps} key={option.id} component="span">
+          {option.name}
+        </Box>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={props.label}
+          helperText={props.helperText}
+        />
+      )}
+      onChange={(_event, value) => {
+        field.onChange(value.map((group) => group.id));
+      }}
+    />
+  );
+};
+
+export default FormGroupField;

--- a/src/app/(protected)/admin/forms/_components/FormGroupField.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormGroupField.tsx
@@ -34,11 +34,15 @@ const FormGroupField = (props: {
       getOptionLabel={(option) => option.name}
       value={selectedGroups}
       isOptionEqualToValue={(option, value) => option.id === value.id}
-      renderOption={(renderProps, option) => (
-        <Box {...renderProps} key={option.id} component="span">
-          {option.name}
-        </Box>
-      )}
+      renderOption={(renderProps, option) => {
+        const { key, ...optionProps } = renderProps;
+
+        return (
+          <Box {...optionProps} key={key} component="span">
+            {option.name}
+          </Box>
+        );
+      }}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/src/app/(protected)/admin/forms/_components/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormSettings.tsx
@@ -117,8 +117,8 @@ const FormSettings = (props: {
       <FormGroupField
         control={props.control}
         name="settings.allowed_group_ids"
-        label="回答可能なユーザーグループ"
-        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームに回答できるようになります。未指定の場合は全員が対象になります。"
+        label="フォームを閲覧できるユーザーグループ"
+        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームを閲覧・回答できるようになります（公開設定が「公開」の場合に適用されます）。未指定の場合は全員が対象になります。"
         groupOptions={props.groupOptions}
       />
       <TextField
@@ -135,8 +135,8 @@ const FormSettings = (props: {
       <FormGroupField
         control={props.control}
         name="settings.answer_group_ids"
-        label="回答を閲覧できるユーザーグループ"
-        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームの回答を閲覧できるようになります。未指定の場合は全員が対象になります。"
+        label="回答を投稿・閲覧できるユーザーグループ"
+        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームに回答したり、回答（公開設定が「公開」の場合）を閲覧したりできるようになります。未指定の場合は全員が対象になります。"
         groupOptions={props.groupOptions}
       />
       <FormControlLabel

--- a/src/app/(protected)/admin/forms/_components/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormSettings.tsx
@@ -15,10 +15,14 @@ import type {
   UseFormSetValue,
 } from 'react-hook-form';
 
-import type { GetFormLabelsResponse } from '@/lib/api-types';
+import type {
+  GetFormLabelsResponse,
+  GetUserGroupsResponse,
+} from '@/lib/api-types';
 
 import type { FormEditorValues } from '../_schema/formEditorSchema';
 
+import FormGroupField from './FormGroupField';
 import FormLabelField from './FormLabelField';
 
 const FormSettings = (props: {
@@ -26,6 +30,7 @@ const FormSettings = (props: {
   control: Control<FormEditorValues>;
   setValue: UseFormSetValue<FormEditorValues>;
   labelOptions: GetFormLabelsResponse;
+  groupOptions: GetUserGroupsResponse;
 }) => {
   const { field: visibilityField } = useController({
     control: props.control,
@@ -109,6 +114,13 @@ const FormSettings = (props: {
         <MenuItem value="PUBLIC">公開</MenuItem>
         <MenuItem value="PRIVATE">非公開</MenuItem>
       </TextField>
+      <FormGroupField
+        control={props.control}
+        name="settings.allowed_group_ids"
+        label="回答可能なユーザーグループ"
+        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームに回答できるようになります。未指定の場合は全員が対象になります。"
+        groupOptions={props.groupOptions}
+      />
       <TextField
         {...answerVisibilityField}
         value={answerVisibilityField.value}
@@ -120,6 +132,13 @@ const FormSettings = (props: {
         <MenuItem value="PUBLIC">公開</MenuItem>
         <MenuItem value="PRIVATE">非公開</MenuItem>
       </TextField>
+      <FormGroupField
+        control={props.control}
+        name="settings.answer_group_ids"
+        label="回答を閲覧できるユーザーグループ"
+        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームの回答を閲覧できるようになります。未指定の場合は全員が対象になります。"
+        groupOptions={props.groupOptions}
+      />
       <FormControlLabel
         label="未ログインユーザーの回答を許可する"
         control={

--- a/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
@@ -14,7 +14,10 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
-import type { GetFormLabelsResponse } from '@/lib/api-types';
+import type {
+  GetFormLabelsResponse,
+  GetUserGroupsResponse,
+} from '@/lib/api-types';
 
 import FormEditorLayout from '../../_components/FormEditorLayout';
 import FormSettings from '../../_components/FormSettings';
@@ -28,7 +31,10 @@ import type { FormEditorValues } from '../../_schema/formEditorSchema';
 import { formEditorSchema } from '../../_schema/formEditorSchema';
 import { useCreateForm } from '../_hooks/useCreateForm';
 
-const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
+const FormCreateForm = (props: {
+  labelOptions: GetFormLabelsResponse;
+  groupOptions: GetUserGroupsResponse;
+}) => {
   const {
     control,
     handleSubmit,
@@ -83,6 +89,7 @@ const FormCreateForm = (props: { labelOptions: GetFormLabelsResponse }) => {
               register={register}
               setValue={setValue}
               labelOptions={props.labelOptions}
+              groupOptions={props.groupOptions}
             />
           </CardContent>
           <QuestionList

--- a/src/app/(protected)/admin/forms/create/page.tsx
+++ b/src/app/(protected)/admin/forms/create/page.tsx
@@ -15,13 +15,20 @@ export const metadata: Metadata = {
 
 const Home = async () => {
   const { session } = await getAdminAccess();
-  const labels = await requireBackendData(
-    serverApiClient.GET('/api/v1/labels/forms', {
-      headers: authorizationHeader(session.token),
-    })
-  );
+  const [labels, groups] = await Promise.all([
+    requireBackendData(
+      serverApiClient.GET('/api/v1/labels/forms', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/user-groups', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
+  ]);
 
-  return <FormCreateForm labelOptions={labels} />;
+  return <FormCreateForm labelOptions={labels} groupOptions={groups} />;
 };
 
 export default Home;

--- a/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -12,7 +12,11 @@ import {
 } from '@mui/material';
 import { useFieldArray, useForm } from 'react-hook-form';
 
-import type { GetFormLabelsResponse, GetFormResponse } from '@/lib/api-types';
+import type {
+  GetFormLabelsResponse,
+  GetFormResponse,
+  GetUserGroupsResponse,
+} from '@/lib/api-types';
 
 import FormEditorLayout from '../../../_components/FormEditorLayout';
 import FormSettings from '../../../_components/FormSettings';
@@ -27,6 +31,7 @@ import { formEditorSchema } from '../../../_schema/formEditorSchema';
 const FormEditForm = (props: {
   form: GetFormResponse;
   labelOptions: GetFormLabelsResponse;
+  groupOptions: GetUserGroupsResponse;
 }) => {
   const {
     control,
@@ -84,6 +89,7 @@ const FormEditForm = (props: {
                 control={control}
                 setValue={setValue}
                 labelOptions={props.labelOptions}
+                groupOptions={props.groupOptions}
               />
             </CardContent>
             <QuestionList

--- a/src/app/(protected)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
   const { session } = await getAdminAccess();
   const { id } = await params;
-  const [form, labels] = await Promise.all([
+  const [form, labels, groups] = await Promise.all([
     requireBackendData(
       serverApiClient.GET('/api/v1/forms/{id}', {
         headers: authorizationHeader(session.token),
@@ -30,9 +30,16 @@ const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
         headers: authorizationHeader(session.token),
       })
     ),
+    requireBackendData(
+      serverApiClient.GET('/api/v1/user-groups', {
+        headers: authorizationHeader(session.token),
+      })
+    ),
   ]);
 
-  return <FormEditForm form={form} labelOptions={labels} />;
+  return (
+    <FormEditForm form={form} labelOptions={labels} groupOptions={groups} />
+  );
 };
 
 export default Home;


### PR DESCRIPTION
## 概要
- ユーザーグループ機能の追加後も、フォームの回答・回答閲覧をグループ制限する設定 (`allowed_group_ids`, `answer_group_ids`) はAPIには存在するがフロントエンドの編集画面に対応するUIが無く、設定も既存値の確認もできなかった。
- フォーム作成・編集画面 (`FormSettings.tsx`) に「回答可能なユーザーグループ」「回答を閲覧できるユーザーグループ」の複数選択フィールドを追加し、既存のラベル選択 (`FormLabelField`) と同じ Autocomplete パターンで実装した。
- グループ一覧はフォーム作成/編集ページのサーバーコンポーネントで `/api/v1/user-groups` から取得し、既存の `labelOptions` と同様に props で渡す形にした。
- スキーマ・デフォルト値・APIリクエスト変換層 (`formEditorSchema.ts` / `formEditorDefaults.ts` / `formEditorMappers.ts`) はすでに両フィールドに対応済みだったため変更していない。

## 確認事項
- `tsc --noEmit` と `eslint` が通ることを確認した。
- コミット時の pre-commit/pre-push フック（lint / type-check / fmt / unit test）がすべて成功した。
- 実際のブラウザ操作による確認は未実施。このアプリは MSAL 認証と実バックエンドが必須で、今回のサンドボックス環境には認証情報も `.env` もなく、管理者としてログインして編集画面を開く検証ができなかった。レビュー時に管理画面でフォーム編集を開き、グループ選択・保存・再読み込みでの反映を確認してほしい。
- フォーム作成画面 (`create`) でも同じ `FormSettings` を共有しているためグループ選択フィールドは表示されるが、フォーム作成APIは元々 `settings` を受け付けない仕様（既存の公開設定等も同様）のため、作成時点ではこの設定は反映されない。編集画面で設定する運用になる。

## 補足
- 一般ユーザー向けのフォーム一覧・回答画面側の表示は変更していない。グループ制限に該当しないユーザーへのアクセス制御はバックエンドAPI側で行われている前提のため。

🤖 Generated with Claude Code