### PR TITLE
feat: ユーザー詳細モーダルに回答投稿制限の処罰履歴を表示する

### DIFF
--- a/src/app/(protected)/admin/users/_components/RestrictionHistorySection.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionHistorySection.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  CircularProgress,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { formatString } from '@/generic/DateFormatter';
+import {
+  formatRestrictionExpiration,
+  toRestrictionExpiration,
+} from '@/lib/restrictions/expiration';
+
+const RestrictionHistorySection = ({ uuid }: { uuid: string }) => {
+  const {
+    data: history,
+    error,
+    isLoading,
+  } = useApiQuery('/api/v1/users/{uuid}/answer-submitter-restriction/history', {
+    path: { uuid },
+  });
+
+  const count = history?.length ?? 0;
+
+  return (
+    <Accordion disableGutters>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle2">処罰履歴（{count}件）</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        {isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+        {error && (
+          <Alert severity="error">処罰履歴の取得に失敗しました。</Alert>
+        )}
+        {history && count === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            処罰履歴はありません
+          </Typography>
+        )}
+        {history && count > 0 && (
+          <Stack divider={<Divider />} spacing={1.5}>
+            {history.map((item) => {
+              const expiration = toRestrictionExpiration(item.expires_at);
+
+              return (
+                <Stack key={item.id} spacing={0.5}>
+                  <Typography component="p">
+                    <strong>理由:</strong> {item.reason}
+                  </Typography>
+                  <Typography component="p">
+                    <strong>制限日時:</strong>{' '}
+                    {formatString(item.restricted_at)}
+                  </Typography>
+                  <Typography component="p">
+                    <strong>解除予定:</strong>{' '}
+                    {formatRestrictionExpiration(expiration)}
+                  </Typography>
+                  <Typography component="p">
+                    <strong>状態:</strong>{' '}
+                    {item.lifted_at
+                      ? `解除済み（${formatString(item.lifted_at)}）`
+                      : '制限中'}
+                  </Typography>
+                </Stack>
+              );
+            })}
+          </Stack>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default RestrictionHistorySection;

--- a/src/app/(protected)/admin/users/_components/RestrictionHistorySection.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionHistorySection.tsx
@@ -34,7 +34,9 @@ const RestrictionHistorySection = ({ uuid }: { uuid: string }) => {
   return (
     <Accordion disableGutters>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography variant="subtitle2">処罰履歴（{count}件）</Typography>
+        <Typography variant="subtitle2" component="h3">
+          処罰履歴（{count}件）
+        </Typography>
       </AccordionSummary>
       <AccordionDetails>
         {isLoading && (
@@ -46,7 +48,7 @@ const RestrictionHistorySection = ({ uuid }: { uuid: string }) => {
           <Alert severity="error">処罰履歴の取得に失敗しました。</Alert>
         )}
         {history && count === 0 && (
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" component="p" color="text.secondary">
             処罰履歴はありません
           </Typography>
         )}

--- a/src/app/(protected)/admin/users/_components/UserDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/UserDetailDialogBody.tsx
@@ -16,6 +16,7 @@ import {
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 
 import CopyButton from './CopyButton';
+import RestrictionHistorySection from './RestrictionHistorySection';
 import RestrictionManagementSection from './RestrictionManagementSection';
 import RoleChip from './RoleChip';
 import RoleSelectCell from './RoleSelectCell';
@@ -131,6 +132,8 @@ const UserDetailDialogBody = ({
               disabled={!canManageRestriction}
             />
           </Stack>
+
+          <RestrictionHistorySection uuid={user.id} />
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -588,6 +588,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/{uuid}/answer-submitter-restriction/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 回答投稿者の回答投稿制限履歴の取得 */
+        get: operations["get_answer_submitter_restriction_history"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -654,6 +671,19 @@ export interface components {
             answer_group_ids: string[];
             default_answer_title?: string | null;
             visibility: components["schemas"]["AnswerVisibility"];
+        };
+        AnswerSubmitterRestrictionHistoryResponse: {
+            /** Format: date-time */
+            expires_at?: string | null;
+            id: string;
+            /** Format: date-time */
+            lifted_at?: string | null;
+            lifted_by?: string | null;
+            reason: string;
+            /** Format: date-time */
+            restricted_at: string;
+            restricted_by: string;
+            submitter_id: string;
         };
         AnswerSubmitterRestrictionRequest: {
             /** Format: date-time */
@@ -4747,6 +4777,74 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_answer_submitter_restriction_history: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID */
+                uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnswerSubmitterRestrictionHistoryResponse"][];
+                };
             };
             /** @description The server could not understand the request due to invalid syntax. */
             400: {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -13,6 +13,7 @@ export type {
   CreateUserGroupSchema,
   GetAnswerLabelsResponse,
   GetAnswerResponse,
+  GetAnswerSubmitterRestrictionHistoryResponse,
   GetAnswerSubmitterRestrictionResponse,
   GetAnswersPageResponse,
   GetAnswersResponse,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -39,6 +39,8 @@ export type GetAnswerSubmitterRestrictionResponse =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['get']['responses'][200]['content']['application/json'];
 export type PutAnswerSubmitterRestrictionSchema =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['put']['requestBody']['content']['application/json'];
+export type GetAnswerSubmitterRestrictionHistoryResponse =
+  ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction/history']['get']['responses'][200]['content']['application/json'];
 export type SearchResponse =
   ApiPaths['/api/v1/search']['get']['responses'][200]['content']['application/json'];
 export type GetUserSearchPageResponse =


### PR DESCRIPTION
## 概要
- バックエンドAPIに処罰履歴取得エンドポイント（`GET /api/v1/users/{uuid}/answer-submitter-restriction/history`）が追加されたため、`pnpm codegen` で型定義を再生成した
- 管理者向けユーザー詳細モーダルに「処罰履歴」セクションを追加。件数を常時表示し、クリックで展開すると理由・制限日時・解除予定・状態（制限中／解除済み）の一覧を確認できる
- 影響範囲は `UserDetailDialogBody` およびその配下のみ

## 確認事項
- `pnpm tsc --noEmit`、`eslint`、`prettier`、単体テストはすべて通過
- 実ブラウザでのE2E確認は未実施。管理者ページはAzure AD (MSAL) 認証が必須で、この作業環境には実クレデンシャルがないため確認できなかった。レビュー時にローカル環境でログイン後、`/admin/users` からユーザー詳細モーダルを開き、処罰履歴アコーディオンの表示・展開・件数表示を確認してほしい

## 補足
- 表示項目は既存の「回答投稿制限」セクション（`RestrictionManagementSection`）に合わせ、理由・日時・状態のみとし、`restricted_by` / `lifted_by` の UUID はそのままでは可読性が低いため表示していない。ユーザー名解決が必要であれば別途対応が必要

🤖 Generated with Claude Code