### PR TITLE
グループ詳細から所属ユーザー詳細へ遷移できるようにする

### DIFF
--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialog.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialog.tsx
@@ -8,15 +8,23 @@ import GroupDetailDialogBody from './GroupDetailDialogBody';
 
 const GroupDetailDialog = ({
   group,
+  currentUserId,
   onClose,
 }: {
   group: UserGroupSchema | null;
+  currentUserId: string;
   onClose: () => void;
 }) => (
   <Dialog open={group !== null} onClose={onClose} fullWidth maxWidth="sm">
     <DialogTitle>グループ詳細: {group?.name}</DialogTitle>
     {/* open のときだけ body を mount し、GET を開いたときだけ走らせる。 */}
-    {group && <GroupDetailDialogBody groupId={group.id} onClose={onClose} />}
+    {group && (
+      <GroupDetailDialogBody
+        groupId={group.id}
+        currentUserId={currentUserId}
+        onClose={onClose}
+      />
+    )}
   </Dialog>
 );
 

--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
@@ -42,6 +42,7 @@ const GroupDetailDialogBody = ({
     id: string;
     name: string;
   } | null>(null);
+  const [userDetailOpen, setUserDetailOpen] = useState(false);
 
   const renderContent = () => {
     if (isLoading) {
@@ -69,8 +70,10 @@ const GroupDetailDialogBody = ({
                 <Tooltip title="ユーザー詳細を表示" placement="top">
                   <IconButton
                     size="small"
+                    aria-label="ユーザー詳細を表示"
                     onClick={() => {
                       setSelectedMember(member);
+                      setUserDetailOpen(true);
                     }}
                   >
                     <InfoOutlinedIcon fontSize="small" />
@@ -113,11 +116,15 @@ const GroupDetailDialogBody = ({
       <UserDetailDialog
         uuid={selectedMember?.id ?? ''}
         userName={selectedMember?.name ?? ''}
-        canManageRole={selectedMember?.id !== currentUserId}
-        canManageRestriction={selectedMember?.id !== currentUserId}
-        open={selectedMember !== null}
+        canManageRole={
+          selectedMember ? selectedMember.id !== currentUserId : false
+        }
+        canManageRestriction={
+          selectedMember ? selectedMember.id !== currentUserId : false
+        }
+        open={userDetailOpen}
         onClose={() => {
-          setSelectedMember(null);
+          setUserDetailOpen(false);
         }}
       />
     </>

--- a/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/groups/_components/GroupDetailDialogBody.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Alert,
   Avatar,
@@ -8,20 +9,26 @@ import {
   Button,
   DialogActions,
   DialogContent,
+  IconButton,
   List,
   ListItem,
   ListItemAvatar,
   ListItemText,
+  Tooltip,
   Typography,
 } from '@mui/material';
+import { useState } from 'react';
 
+import UserDetailDialog from '@/app/(protected)/admin/users/_components/UserDetailDialog';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 
 const GroupDetailDialogBody = ({
   groupId,
+  currentUserId,
   onClose,
 }: {
   groupId: string;
+  currentUserId: string;
   onClose: () => void;
 }) => {
   const {
@@ -31,6 +38,10 @@ const GroupDetailDialogBody = ({
   } = useApiQuery('/api/v1/user-groups/{group_id}/users', {
     path: { group_id: groupId },
   });
+  const [selectedMember, setSelectedMember] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   const renderContent = () => {
     if (isLoading) {
@@ -51,7 +62,22 @@ const GroupDetailDialogBody = ({
       return (
         <List disablePadding>
           {members.map((member) => (
-            <ListItem key={member.id} disableGutters>
+            <ListItem
+              key={member.id}
+              disableGutters
+              secondaryAction={
+                <Tooltip title="ユーザー詳細を表示" placement="top">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setSelectedMember(member);
+                    }}
+                  >
+                    <InfoOutlinedIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              }
+            >
               <ListItemAvatar>
                 <Avatar
                   alt={member.name}
@@ -84,6 +110,16 @@ const GroupDetailDialogBody = ({
       <DialogActions>
         <Button onClick={onClose}>閉じる</Button>
       </DialogActions>
+      <UserDetailDialog
+        uuid={selectedMember?.id ?? ''}
+        userName={selectedMember?.name ?? ''}
+        canManageRole={selectedMember?.id !== currentUserId}
+        canManageRestriction={selectedMember?.id !== currentUserId}
+        open={selectedMember !== null}
+        onClose={() => {
+          setSelectedMember(null);
+        }}
+      />
     </>
   );
 };

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -35,7 +35,10 @@ type EditGroupSchema = {
   name: string;
 };
 
-const Groups = (props: { groups: UserGroupSchema[] }) => {
+const Groups = (props: {
+  groups: UserGroupSchema[];
+  currentUserId: string;
+}) => {
   const { data: groups = props.groups } = useApiQuery('/api/v1/user-groups');
   const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -202,6 +205,7 @@ const Groups = (props: { groups: UserGroupSchema[] }) => {
 
       <GroupDetailDialog
         group={detailGroup}
+        currentUserId={props.currentUserId}
         onClose={() => {
           setDetailGroup(null);
         }}

--- a/src/app/(protected)/admin/groups/page.tsx
+++ b/src/app/(protected)/admin/groups/page.tsx
@@ -36,7 +36,7 @@ const Home = async () => {
         <CreateGroupField />
       </Stack>
       <Suspense fallback={null}>
-        <Groups groups={groups} />
+        <Groups groups={groups} currentUserId={session.user.id} />
       </Suspense>
     </Stack>
   );

--- a/tests/component/GroupDetailDialogBody.test.tsx
+++ b/tests/component/GroupDetailDialogBody.test.tsx
@@ -31,7 +31,11 @@ describe('GroupDetailDialogBody', () => {
     };
 
     renderWithProviders(
-      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+      <GroupDetailDialogBody
+        groupId="group-1"
+        currentUserId="current-user"
+        onClose={vi.fn()}
+      />
     );
 
     expect(screen.getByText('ユーザーA')).toBeVisible();
@@ -43,7 +47,11 @@ describe('GroupDetailDialogBody', () => {
     queryState.current = { data: [], error: null, isLoading: false };
 
     renderWithProviders(
-      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+      <GroupDetailDialogBody
+        groupId="group-1"
+        currentUserId="current-user"
+        onClose={vi.fn()}
+      />
     );
 
     expect(screen.getByText('所属しているユーザーはいません')).toBeVisible();
@@ -57,7 +65,11 @@ describe('GroupDetailDialogBody', () => {
     };
 
     renderWithProviders(
-      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+      <GroupDetailDialogBody
+        groupId="group-1"
+        currentUserId="current-user"
+        onClose={vi.fn()}
+      />
     );
 
     expect(
@@ -70,7 +82,11 @@ describe('GroupDetailDialogBody', () => {
     queryState.current = { data: undefined, error: null, isLoading: true };
 
     renderWithProviders(
-      <GroupDetailDialogBody groupId="group-1" onClose={vi.fn()} />
+      <GroupDetailDialogBody
+        groupId="group-1"
+        currentUserId="current-user"
+        onClose={vi.fn()}
+      />
     );
 
     expect(screen.getByRole('button', { name: '閉じる' })).toBeVisible();

--- a/tests/component/Groups.test.tsx
+++ b/tests/component/Groups.test.tsx
@@ -43,7 +43,7 @@ describe('Groups', () => {
   });
 
   it('グループが無い場合は空メッセージを表示する', () => {
-    renderWithProviders(<Groups groups={[]} />);
+    renderWithProviders(<Groups groups={[]} currentUserId="current-user" />);
 
     expect(screen.getByText('グループが登録されていません。')).toBeVisible();
   });
@@ -52,7 +52,10 @@ describe('Groups', () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <Groups groups={[{ id: 'group-1', name: 'グループA' }]} />
+      <Groups
+        groups={[{ id: 'group-1', name: 'グループA' }]}
+        currentUserId="current-user"
+      />
     );
 
     await user.click(screen.getByRole('button', { name: '編集' }));
@@ -73,7 +76,10 @@ describe('Groups', () => {
     const user = userEvent.setup();
 
     renderWithProviders(
-      <Groups groups={[{ id: 'group-1', name: 'グループA' }]} />
+      <Groups
+        groups={[{ id: 'group-1', name: 'グループA' }]}
+        currentUserId="current-user"
+      />
     );
 
     await user.click(screen.getByRole('button', { name: '削除' }));


### PR DESCRIPTION
## 概要
- グループ管理画面のグループ詳細ダイアログで所属ユーザー一覧は表示できるが、そこからユーザー詳細（権限・回答投稿制限・処罰履歴など）を確認する導線がなかった
- 各ユーザー行に詳細ボタンを追加し、既存のユーザー詳細ダイアログ(`UserDetailDialog`)をグループ詳細ダイアログから開けるようにした
- 権限変更・回答投稿制限の操作可否は、ユーザー一覧画面と同様に自分自身かどうかで判定するため、`currentUserId` をページからダイアログ末端まで受け渡すよう変更した

## 確認事項
- `pnpm tsc --noEmit`、`pnpm eslint`、`pnpm prettier --check` がすべて成功することを確認
- 影響を受けた既存テスト(`tests/component/GroupDetailDialogBody.test.tsx`, `tests/component/Groups.test.tsx`)を新しいプロパティに合わせて更新し、`pnpm vitest run --config vitest.component.config.ts` で全件パスすることを確認
- ブラウザでの実機確認は未実施。レビューでは、グループ詳細から開いたユーザー詳細ダイアログの表示内容・権限操作可否が意図通りかを確認してほしい

🤖 Generated with Claude Code