### PR TITLE
ページ内コンポーネントの責務を分離する

### DIFF
--- a/src/app/(protected)/_components/Labels.tsx
+++ b/src/app/(protected)/_components/Labels.tsx
@@ -1,24 +1,6 @@
 'use client';
 
-import { Delete, Edit } from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Box, Paper, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -26,13 +8,11 @@ import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useLabelCRUD } from '@/hooks/useLabelCRUD';
 
+import NameEditDialog, { type NameEditFormValues } from './NameEditDialog';
+import NameManagementTable from './NameManagementTable';
+
 type Label = {
   id: string | number;
-  name: string;
-};
-
-type EditLabelSchema = {
-  id: string;
   name: string;
 };
 
@@ -42,8 +22,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState<Label | null>(null);
 
-  const { handleSubmit, register, reset, setValue } =
-    useForm<EditLabelSchema>();
+  const { handleSubmit, register, reset } = useForm<NameEditFormValues>();
 
   const { deleteLabel, editLabel: editLabelAction } = useLabelCRUD(
     props.labelType
@@ -51,8 +30,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
 
   const handleOpenEdit = (label: Label) => {
     setSelectedLabel(label);
-    setValue('id', String(label.id));
-    setValue('name', label.name);
+    reset({ id: String(label.id), name: label.name });
     setEditDialogOpen(true);
   };
 
@@ -72,7 +50,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
     setSelectedLabel(null);
   };
 
-  const onEdit = async (data: EditLabelSchema) => {
+  const onEdit = async (data: NameEditFormValues) => {
     const result = await editLabelAction(data.id, data.name);
     if (result.ok) {
       showSnackbar('ラベルを編集しました。', 'success');
@@ -113,73 +91,23 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
 
   return (
     <Box>
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>ラベル名</TableCell>
-              <TableCell align="right">アクション</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {props.labels.map((label) => (
-              <TableRow key={label.id}>
-                <TableCell component="th" scope="row">
-                  {label.name}
-                </TableCell>
-                <TableCell align="right">
-                  <IconButton
-                    color="primary"
-                    onClick={() => {
-                      handleOpenEdit(label);
-                    }}
-                    aria-label="編集"
-                  >
-                    <Edit />
-                  </IconButton>
-                  <IconButton
-                    color="error"
-                    onClick={() => {
-                      handleOpenDelete(label);
-                    }}
-                    aria-label="削除"
-                  >
-                    <Delete />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <NameManagementTable
+        items={props.labels}
+        nameHeader="ラベル名"
+        onEdit={handleOpenEdit}
+        onDelete={handleOpenDelete}
+      />
 
-      <Dialog open={editDialogOpen} onClose={handleCloseEdit} fullWidth>
-        <DialogTitle>ラベルを編集</DialogTitle>
-        <Box
-          component="form"
-          onSubmit={(e) => {
-            void handleSubmit(onEdit)(e);
-          }}
-        >
-          <DialogContent>
-            <TextField {...register('id')} type="hidden" />
-            <TextField
-              {...register('name')}
-              autoFocus
-              margin="dense"
-              label="ラベル名"
-              fullWidth
-              required
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseEdit}>キャンセル</Button>
-            <Button type="submit" variant="contained">
-              保存
-            </Button>
-          </DialogActions>
-        </Box>
-      </Dialog>
+      <NameEditDialog
+        open={editDialogOpen}
+        title="ラベルを編集"
+        nameLabel="ラベル名"
+        register={register}
+        onClose={handleCloseEdit}
+        onSubmit={(e) => {
+          void handleSubmit(onEdit)(e);
+        }}
+      />
 
       <ConfirmDialog
         open={deleteDialogOpen}

--- a/src/app/(protected)/_components/NameEditDialog.tsx
+++ b/src/app/(protected)/_components/NameEditDialog.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@mui/material';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { UseFormRegister } from 'react-hook-form';
+
+export type NameEditFormValues = {
+  id: string;
+  name: string;
+};
+
+const NameEditDialog = (props: {
+  open: boolean;
+  title: ReactNode;
+  nameLabel: string;
+  register: UseFormRegister<NameEditFormValues>;
+  onClose: () => void;
+  onSubmit: NonNullable<ComponentPropsWithoutRef<'form'>['onSubmit']>;
+}) => (
+  <Dialog open={props.open} onClose={props.onClose} fullWidth>
+    <DialogTitle>{props.title}</DialogTitle>
+    <Box component="form" onSubmit={props.onSubmit}>
+      <DialogContent>
+        <input {...props.register('id')} type="hidden" />
+        <TextField
+          {...props.register('name')}
+          autoFocus
+          margin="dense"
+          label={props.nameLabel}
+          fullWidth
+          required
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}>キャンセル</Button>
+        <Button type="submit" variant="contained">
+          保存
+        </Button>
+      </DialogActions>
+    </Box>
+  </Dialog>
+);
+
+export default NameEditDialog;

--- a/src/app/(protected)/_components/NameManagementTable.tsx
+++ b/src/app/(protected)/_components/NameManagementTable.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Delete, Edit, Visibility } from '@mui/icons-material';
+import {
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import type { ReactNode } from 'react';
+
+type NameManagementItem = {
+  id: string | number;
+  name: string;
+};
+
+const NameManagementTable = <Item extends NameManagementItem>(props: {
+  items: Item[];
+  nameHeader: ReactNode;
+  onView?: (item: Item) => void;
+  onEdit: (item: Item) => void;
+  onDelete: (item: Item) => void;
+}) => (
+  <TableContainer component={Paper}>
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>{props.nameHeader}</TableCell>
+          <TableCell align="right">アクション</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {props.items.map((item) => (
+          <TableRow key={item.id}>
+            <TableCell component="th" scope="row">
+              {item.name}
+            </TableCell>
+            <TableCell align="right">
+              {props.onView ? (
+                <IconButton
+                  color="default"
+                  onClick={() => {
+                    props.onView?.(item);
+                  }}
+                  aria-label="詳細"
+                >
+                  <Visibility />
+                </IconButton>
+              ) : null}
+              <IconButton
+                color="primary"
+                onClick={() => {
+                  props.onEdit(item);
+                }}
+                aria-label="編集"
+              >
+                <Edit />
+              </IconButton>
+              <IconButton
+                color="error"
+                onClick={() => {
+                  props.onDelete(item);
+                }}
+                aria-label="削除"
+              >
+                <Delete />
+              </IconButton>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </TableContainer>
+);
+
+export default NameManagementTable;

--- a/src/app/(protected)/_components/NameManagementTable.tsx
+++ b/src/app/(protected)/_components/NameManagementTable.tsx
@@ -24,57 +24,61 @@ const NameManagementTable = <Item extends NameManagementItem>(props: {
   onView?: (item: Item) => void;
   onEdit: (item: Item) => void;
   onDelete: (item: Item) => void;
-}) => (
-  <TableContainer component={Paper}>
-    <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>{props.nameHeader}</TableCell>
-          <TableCell align="right">アクション</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {props.items.map((item) => (
-          <TableRow key={item.id}>
-            <TableCell component="th" scope="row">
-              {item.name}
-            </TableCell>
-            <TableCell align="right">
-              {props.onView ? (
-                <IconButton
-                  color="default"
-                  onClick={() => {
-                    props.onView?.(item);
-                  }}
-                  aria-label="詳細"
-                >
-                  <Visibility />
-                </IconButton>
-              ) : null}
-              <IconButton
-                color="primary"
-                onClick={() => {
-                  props.onEdit(item);
-                }}
-                aria-label="編集"
-              >
-                <Edit />
-              </IconButton>
-              <IconButton
-                color="error"
-                onClick={() => {
-                  props.onDelete(item);
-                }}
-                aria-label="削除"
-              >
-                <Delete />
-              </IconButton>
-            </TableCell>
+}) => {
+  const { items, nameHeader, onView, onEdit, onDelete } = props;
+
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>{nameHeader}</TableCell>
+            <TableCell align="right">アクション</TableCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  </TableContainer>
-);
+        </TableHead>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell component="th" scope="row">
+                {item.name}
+              </TableCell>
+              <TableCell align="right">
+                {onView ? (
+                  <IconButton
+                    color="default"
+                    onClick={() => {
+                      onView(item);
+                    }}
+                    aria-label="詳細"
+                  >
+                    <Visibility />
+                  </IconButton>
+                ) : null}
+                <IconButton
+                  color="primary"
+                  onClick={() => {
+                    onEdit(item);
+                  }}
+                  aria-label="編集"
+                >
+                  <Edit />
+                </IconButton>
+                <IconButton
+                  color="error"
+                  onClick={() => {
+                    onDelete(item);
+                  }}
+                  aria-label="削除"
+                >
+                  <Delete />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
 
 export default NameManagementTable;

--- a/src/app/(protected)/admin/_components/SearchResult.tsx
+++ b/src/app/(protected)/admin/_components/SearchResult.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import assert from 'assert';
-
 import { Box, Modal, Stack, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import type {
@@ -11,14 +9,12 @@ import type {
 } from '@mui/x-data-grid';
 import { useRouter } from 'next/navigation';
 
+import {
+  toSearchResultRows,
+  type SearchResultRow,
+} from '@/app/(protected)/admin/_lib/searchResultRows';
 import ErrorDialog from '@/app/_components/ErrorDialog';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
-import {
-  searchAnswerItemSchema,
-  searchFormItemSchema,
-  searchLabelItemSchema,
-  searchUserItemSchema,
-} from '@/lib/api-types';
 
 const SearchResult = (props: {
   searchContent: string;
@@ -43,94 +39,10 @@ const SearchResult = (props: {
     { field: 'title', headerName: 'タイトル', width: 200 },
   ];
 
-  interface Row {
-    id: number;
-    category:
-      | 'フォーム'
-      | '回答'
-      | 'ユーザー'
-      | 'フォーム用ラベル'
-      | '回答用ラベル';
-    title: string;
-    url: string;
-  }
-
-  const prepareRows = () => {
-    assert(data);
-
-    return [
-      data.forms.flatMap((form) => {
-        const result = searchFormItemSchema.safeParse(form);
-        return result.success
-          ? [
-              {
-                category: 'フォーム' as const,
-                title: result.data.title,
-                url: `/admin/forms/edit/${result.data.id}`,
-              },
-            ]
-          : [];
-      }),
-      data.answers.flatMap((answer) => {
-        const result = searchAnswerItemSchema.safeParse(answer);
-        return result.success
-          ? [
-              {
-                category: '回答' as const,
-                title: result.data.answer,
-                url: `/admin/answer/${result.data.answer_id}`,
-              },
-            ]
-          : [];
-      }),
-      data.users.flatMap((user) => {
-        const result = searchUserItemSchema.safeParse(user);
-        return result.success
-          ? [
-              {
-                category: 'ユーザー' as const,
-                title: result.data.name,
-                url: `/admin/users/`,
-              },
-            ]
-          : [];
-      }),
-      data.label_for_forms.flatMap((label) => {
-        const result = searchLabelItemSchema.safeParse(label);
-        return result.success
-          ? [
-              {
-                category: 'フォーム用ラベル' as const,
-                title: result.data.name,
-                url: `/admin/labels?tab=forms`,
-              },
-            ]
-          : [];
-      }),
-      data.label_for_answers.flatMap((label) => {
-        const result = searchLabelItemSchema.safeParse(label);
-        return result.success
-          ? [
-              {
-                category: '回答用ラベル' as const,
-                title: result.data.name,
-                url: `/admin/labels?tab=answers`,
-              },
-            ]
-          : [];
-      }),
-      data.comments.map((comment) => ({
-        category: 'コメント',
-        title: comment.content,
-        url: `/admin/answer/${comment.answer_id}`,
-      })),
-    ]
-      .flat()
-      .map((row, index) => ({ ...row, id: index }));
-  };
+  const rows = toSearchResultRows(data);
 
   const handleRowClick: GridEventListener<'rowClick'> = (
-    params: GridRowParams<Row>
+    params: GridRowParams<SearchResultRow>
   ) => {
     props.onClose();
     router.push(params.row.url);
@@ -156,7 +68,7 @@ const SearchResult = (props: {
         <Stack>
           <Typography>{props.searchContent} の検索結果</Typography>
           <DataGrid
-            rows={prepareRows()}
+            rows={rows}
             onRowClick={handleRowClick}
             columns={columns}
             initialState={{

--- a/src/app/(protected)/admin/_lib/searchResultRows.ts
+++ b/src/app/(protected)/admin/_lib/searchResultRows.ts
@@ -1,0 +1,95 @@
+import {
+  searchAnswerItemSchema,
+  searchFormItemSchema,
+  searchLabelItemSchema,
+  searchUserItemSchema,
+} from '@/lib/api-types';
+import type { SearchResponse } from '@/lib/api-types';
+
+export interface SearchResultRow {
+  id: number;
+  category:
+    | 'フォーム'
+    | '回答'
+    | 'ユーザー'
+    | 'フォーム用ラベル'
+    | '回答用ラベル'
+    | 'コメント';
+  title: string;
+  url: string;
+}
+
+type SearchResultRowWithoutId = Omit<SearchResultRow, 'id'>;
+
+export const toSearchResultRows = (data: SearchResponse): SearchResultRow[] =>
+  [
+    data.forms.flatMap((form): SearchResultRowWithoutId[] => {
+      const result = searchFormItemSchema.safeParse(form);
+      return result.success
+        ? [
+            {
+              category: 'フォーム',
+              title: result.data.title,
+              url: `/admin/forms/edit/${result.data.id}`,
+            },
+          ]
+        : [];
+    }),
+    data.answers.flatMap((answer): SearchResultRowWithoutId[] => {
+      const result = searchAnswerItemSchema.safeParse(answer);
+      return result.success
+        ? [
+            {
+              category: '回答',
+              title: result.data.answer,
+              url: `/admin/answer/${result.data.answer_id}`,
+            },
+          ]
+        : [];
+    }),
+    data.users.flatMap((user): SearchResultRowWithoutId[] => {
+      const result = searchUserItemSchema.safeParse(user);
+      return result.success
+        ? [
+            {
+              category: 'ユーザー',
+              title: result.data.name,
+              url: `/admin/users/`,
+            },
+          ]
+        : [];
+    }),
+    data.label_for_forms.flatMap((label): SearchResultRowWithoutId[] => {
+      const result = searchLabelItemSchema.safeParse(label);
+      return result.success
+        ? [
+            {
+              category: 'フォーム用ラベル',
+              title: result.data.name,
+              url: `/admin/labels?tab=forms`,
+            },
+          ]
+        : [];
+    }),
+    data.label_for_answers.flatMap((label): SearchResultRowWithoutId[] => {
+      const result = searchLabelItemSchema.safeParse(label);
+      return result.success
+        ? [
+            {
+              category: '回答用ラベル',
+              title: result.data.name,
+              url: `/admin/labels?tab=answers`,
+            },
+          ]
+        : [];
+    }),
+    data.comments.map(
+      (comment): SearchResultRowWithoutId => ({
+        category: 'コメント',
+        title: comment.content,
+        url: `/admin/answer/${comment.answer_id}`,
+      })
+    ),
+  ]
+    .flat()
+    .map((row, index) => ({ ...row, id: index }));

--- a/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/ChoiceEditor.tsx
@@ -16,7 +16,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Add, DragIndicator } from '@mui/icons-material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Button, IconButton, MenuItem, Stack, TextField } from '@mui/material';
-import { useController, useFieldArray } from 'react-hook-form';
+import { useController, useFieldArray, useWatch } from 'react-hook-form';
 import type { Control, UseFormRegister } from 'react-hook-form';
 
 import {
@@ -103,11 +103,115 @@ const ensureChoicesForQuestionType = (
   }
 };
 
-const ChoiceEditor = (props: {
+type ChoiceEditorProps = {
   control: Control<FormEditorValues>;
   register: UseFormRegister<FormEditorValues>;
   questionIndex: number;
+};
+
+const QuestionTypeField = (props: {
+  control: Control<FormEditorValues>;
+  questionIndex: number;
+  choiceCount: number;
+  appendChoice: () => void;
+  clearChoices: () => void;
 }) => {
+  const { field: questionTypeField } = useController({
+    control: props.control,
+    name: `questions.${props.questionIndex}.question_type`,
+  });
+
+  const handleQuestionTypeChange = (
+    nextQuestionType: FormEditorQuestion['question_type']
+  ) => {
+    questionTypeField.onChange(nextQuestionType);
+    ensureChoicesForQuestionType(
+      nextQuestionType,
+      props.choiceCount,
+      props.appendChoice,
+      props.clearChoices
+    );
+  };
+
+  return (
+    <TextField
+      {...questionTypeField}
+      value={questionTypeField.value}
+      label="質問の種類"
+      select
+      required
+      helperText="質問の種類を選択してください。"
+      onChange={(event) => {
+        const parsed = questionTypeSchema.safeParse(event.target.value);
+        if (parsed.success) {
+          handleQuestionTypeChange(parsed.data);
+        }
+      }}
+    >
+      <MenuItem value="Text">テキスト</MenuItem>
+      <MenuItem value="SingleChoice">単一選択</MenuItem>
+      <MenuItem value="MultipleChoice">複数選択</MenuItem>
+    </TextField>
+  );
+};
+
+const SortableChoiceList = (props: {
+  choiceFields: { id: string }[];
+  questionIndex: number;
+  register: UseFormRegister<FormEditorValues>;
+  moveChoice: (oldIndex: number, newIndex: number) => void;
+  removeChoice: (index: number) => void;
+  appendChoice: () => void;
+}) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = props.choiceFields.findIndex(
+      (field) => field.id === active.id
+    );
+    const newIndex = props.choiceFields.findIndex(
+      (field) => field.id === over.id
+    );
+    props.moveChoice(oldIndex, newIndex);
+  };
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <SortableContext
+        items={props.choiceFields.map((field) => field.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <Stack spacing={1}>
+          {props.choiceFields.map((field, index) => (
+            <SortableChoiceItem
+              key={field.id}
+              id={field.id}
+              index={index}
+              questionIndex={props.questionIndex}
+              register={props.register}
+              removeChoice={props.removeChoice}
+              canRemove={props.choiceFields.length > 1}
+              onAppendChoice={props.appendChoice}
+            />
+          ))}
+        </Stack>
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+const ChoiceEditor = (props: ChoiceEditorProps) => {
   const {
     fields: choiceFields,
     append,
@@ -118,18 +222,10 @@ const ChoiceEditor = (props: {
     name: `questions.${props.questionIndex}.choices`,
   });
 
-  const { field: questionTypeField } = useController({
+  const questionType = useWatch({
     control: props.control,
     name: `questions.${props.questionIndex}.question_type`,
   });
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 5,
-      },
-    })
-  );
 
   const appendChoice = () => {
     append({ id: null, choice: '' });
@@ -139,57 +235,21 @@ const ChoiceEditor = (props: {
     remove();
   };
 
-  const handleQuestionTypeChange = (
-    nextQuestionType: FormEditorQuestion['question_type']
-  ) => {
-    questionTypeField.onChange(nextQuestionType);
-    ensureChoicesForQuestionType(
-      nextQuestionType,
-      choiceFields.length,
-      appendChoice,
-      clearChoices
-    );
-  };
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) {
-      return;
-    }
-
-    const oldIndex = choiceFields.findIndex((field) => field.id === active.id);
-    const newIndex = choiceFields.findIndex((field) => field.id === over.id);
-    move(oldIndex, newIndex);
-  };
-
   const removeChoice = (choiceIndex: number) => {
     if (choiceFields.length > 1) {
       remove(choiceIndex);
     }
   };
 
-  const questionType = questionTypeField.value;
-
   return (
     <>
-      <TextField
-        {...questionTypeField}
-        value={questionType}
-        label="質問の種類"
-        select
-        required
-        helperText="質問の種類を選択してください。"
-        onChange={(event) => {
-          const parsed = questionTypeSchema.safeParse(event.target.value);
-          if (parsed.success) {
-            handleQuestionTypeChange(parsed.data);
-          }
-        }}
-      >
-        <MenuItem value="Text">テキスト</MenuItem>
-        <MenuItem value="SingleChoice">単一選択</MenuItem>
-        <MenuItem value="MultipleChoice">複数選択</MenuItem>
-      </TextField>
+      <QuestionTypeField
+        control={props.control}
+        questionIndex={props.questionIndex}
+        choiceCount={choiceFields.length}
+        appendChoice={appendChoice}
+        clearChoices={clearChoices}
+      />
       <Button
         variant="outlined"
         startIcon={<Add />}
@@ -198,27 +258,14 @@ const ChoiceEditor = (props: {
       >
         選択肢の追加
       </Button>
-      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-        <SortableContext
-          items={choiceFields.map((field) => field.id)}
-          strategy={verticalListSortingStrategy}
-        >
-          <Stack spacing={1}>
-            {choiceFields.map((field, index) => (
-              <SortableChoiceItem
-                key={field.id}
-                id={field.id}
-                index={index}
-                questionIndex={props.questionIndex}
-                register={props.register}
-                removeChoice={removeChoice}
-                canRemove={choiceFields.length > 1}
-                onAppendChoice={appendChoice}
-              />
-            ))}
-          </Stack>
-        </SortableContext>
-      </DndContext>
+      <SortableChoiceList
+        choiceFields={choiceFields}
+        questionIndex={props.questionIndex}
+        register={props.register}
+        moveChoice={move}
+        removeChoice={removeChoice}
+        appendChoice={appendChoice}
+      />
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormSettings.tsx
@@ -25,57 +25,52 @@ import type { FormEditorValues } from '../_schema/formEditorSchema';
 import FormGroupField from './FormGroupField';
 import FormLabelField from './FormLabelField';
 
-const FormSettings = (props: {
+type FormSettingsProps = {
   register: UseFormRegister<FormEditorValues>;
   control: Control<FormEditorValues>;
   setValue: UseFormSetValue<FormEditorValues>;
   labelOptions: GetFormLabelsResponse;
   groupOptions: GetUserGroupsResponse;
-}) => {
-  const { field: visibilityField } = useController({
-    control: props.control,
-    name: 'settings.visibility',
-  });
+};
 
-  const { field: answerVisibilityField } = useController({
-    control: props.control,
-    name: 'settings.answer_visibility',
-  });
+const BasicFormSettings = ({
+  register,
+  control,
+  labelOptions,
+}: Pick<FormSettingsProps, 'register' | 'control' | 'labelOptions'>) => (
+  <>
+    <TextField {...register('title')} label="フォームタイトル" required />
+    <TextField
+      {...register('description')}
+      label="フォームの説明"
+      required
+      multiline
+    />
+    <FormLabelField control={control} labelOptions={labelOptions} />
+  </>
+);
 
+const AcceptancePeriodSettings = ({
+  register,
+  control,
+  setValue,
+}: Pick<FormSettingsProps, 'register' | 'control' | 'setValue'>) => {
   const acceptancePeriod = useWatch({
-    control: props.control,
+    control,
     name: 'settings.acceptance_period',
   });
 
   const hasAcceptancePeriod = acceptancePeriod.kind === 'specified';
 
   const onAcceptancePeriodToggle = (checked: boolean) => {
-    props.setValue(
+    setValue(
       'settings.acceptance_period',
       checked ? { kind: 'specified', startAt: '', endAt: '' } : { kind: 'none' }
     );
   };
 
   return (
-    <Stack spacing={2}>
-      <Typography variant="h6" component="h2" sx={{ fontWeight: 'bold' }}>
-        フォーム設定
-      </Typography>
-      <TextField
-        {...props.register('title')}
-        label="フォームタイトル"
-        required
-      />
-      <TextField
-        {...props.register('description')}
-        label="フォームの説明"
-        required
-        multiline
-      />
-      <FormLabelField
-        control={props.control}
-        labelOptions={props.labelOptions}
-      />
+    <>
       <FormControlLabel
         label="回答開始日と回答終了日を設定する"
         control={
@@ -90,19 +85,34 @@ const FormSettings = (props: {
       {hasAcceptancePeriod && (
         <>
           <TextField
-            {...props.register('settings.acceptance_period.startAt')}
+            {...register('settings.acceptance_period.startAt')}
             label="回答開始日"
             type="datetime-local"
             helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
           />
           <TextField
-            {...props.register('settings.acceptance_period.endAt')}
+            {...register('settings.acceptance_period.endAt')}
             label="回答終了日"
             type="datetime-local"
             helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
           />
         </>
       )}
+    </>
+  );
+};
+
+const FormVisibilitySettings = ({
+  control,
+  groupOptions,
+}: Pick<FormSettingsProps, 'control' | 'groupOptions'>) => {
+  const { field: visibilityField } = useController({
+    control,
+    name: 'settings.visibility',
+  });
+
+  return (
+    <>
       <TextField
         {...visibilityField}
         value={visibilityField.value}
@@ -115,12 +125,28 @@ const FormSettings = (props: {
         <MenuItem value="PRIVATE">非公開</MenuItem>
       </TextField>
       <FormGroupField
-        control={props.control}
+        control={control}
         name="settings.allowed_group_ids"
         label="フォームを閲覧できるユーザーグループ"
         helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームを閲覧・回答できるようになります（公開設定が「公開」の場合に適用されます）。未指定の場合は全員が対象になります。"
-        groupOptions={props.groupOptions}
+        groupOptions={groupOptions}
       />
+    </>
+  );
+};
+
+const AnswerSettings = ({
+  register,
+  control,
+  groupOptions,
+}: Pick<FormSettingsProps, 'register' | 'control' | 'groupOptions'>) => {
+  const { field: answerVisibilityField } = useController({
+    control,
+    name: 'settings.answer_visibility',
+  });
+
+  return (
+    <>
       <TextField
         {...answerVisibilityField}
         value={answerVisibilityField.value}
@@ -133,27 +159,54 @@ const FormSettings = (props: {
         <MenuItem value="PRIVATE">非公開</MenuItem>
       </TextField>
       <FormGroupField
-        control={props.control}
+        control={control}
         name="settings.answer_group_ids"
         label="回答を投稿・閲覧できるユーザーグループ"
         helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームに回答したり、回答（公開設定が「公開」の場合）を閲覧したりできるようになります。未指定の場合は全員が対象になります。"
-        groupOptions={props.groupOptions}
+        groupOptions={groupOptions}
       />
       <FormControlLabel
         label="未ログインユーザーの回答を許可する"
-        control={
-          <Checkbox {...props.register('settings.allow_temporary_answers')} />
-        }
+        control={<Checkbox {...register('settings.allow_temporary_answers')} />}
       />
       <TextField
-        {...props.register('settings.discord_webhook_url')}
+        {...register('settings.discord_webhook_url')}
         label="Webhook URL"
         type="url"
       />
       <TextField
-        {...props.register('settings.default_answer_title')}
+        {...register('settings.default_answer_title')}
         label="デフォルトの回答タイトル"
         helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名をタイトルに埋め込むことができます。例: $username さんの回答"
+      />
+    </>
+  );
+};
+
+const FormSettings = (props: FormSettingsProps) => {
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6" component="h2" sx={{ fontWeight: 'bold' }}>
+        フォーム設定
+      </Typography>
+      <BasicFormSettings
+        register={props.register}
+        control={props.control}
+        labelOptions={props.labelOptions}
+      />
+      <AcceptancePeriodSettings
+        register={props.register}
+        control={props.control}
+        setValue={props.setValue}
+      />
+      <FormVisibilitySettings
+        control={props.control}
+        groupOptions={props.groupOptions}
+      />
+      <AnswerSettings
+        register={props.register}
+        control={props.control}
+        groupOptions={props.groupOptions}
       />
     </Stack>
   );

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -1,27 +1,13 @@
 'use client';
 
-import { Delete, Edit, Visibility } from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Box, Paper, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import NameEditDialog, {
+  type NameEditFormValues,
+} from '@/app/(protected)/_components/NameEditDialog';
+import NameManagementTable from '@/app/(protected)/_components/NameManagementTable';
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
@@ -29,11 +15,6 @@ import { useUserGroupCRUD } from '@/hooks/useUserGroupCRUD';
 import type { UserGroupSchema } from '@/lib/api-types';
 
 import GroupDetailDialog from './GroupDetailDialog';
-
-type EditGroupSchema = {
-  id: string;
-  name: string;
-};
 
 const Groups = (props: {
   groups: UserGroupSchema[];
@@ -48,7 +29,7 @@ const Groups = (props: {
   );
   const [detailGroup, setDetailGroup] = useState<UserGroupSchema | null>(null);
 
-  const { handleSubmit, register, reset } = useForm<EditGroupSchema>();
+  const { handleSubmit, register, reset } = useForm<NameEditFormValues>();
 
   const { deleteGroup, editGroup } = useUserGroupCRUD();
 
@@ -74,7 +55,7 @@ const Groups = (props: {
     setSelectedGroup(null);
   };
 
-  const onEdit = async (data: EditGroupSchema) => {
+  const onEdit = async (data: NameEditFormValues) => {
     const result = await editGroup(data.id, data.name);
     if (result.ok) {
       showSnackbar('グループを編集しました。', 'success');
@@ -115,82 +96,24 @@ const Groups = (props: {
 
   return (
     <Box>
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>グループ名</TableCell>
-              <TableCell align="right">アクション</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {groups.map((group) => (
-              <TableRow key={group.id}>
-                <TableCell component="th" scope="row">
-                  {group.name}
-                </TableCell>
-                <TableCell align="right">
-                  <IconButton
-                    color="default"
-                    onClick={() => {
-                      setDetailGroup(group);
-                    }}
-                    aria-label="詳細"
-                  >
-                    <Visibility />
-                  </IconButton>
-                  <IconButton
-                    color="primary"
-                    onClick={() => {
-                      handleOpenEdit(group);
-                    }}
-                    aria-label="編集"
-                  >
-                    <Edit />
-                  </IconButton>
-                  <IconButton
-                    color="error"
-                    onClick={() => {
-                      handleOpenDelete(group);
-                    }}
-                    aria-label="削除"
-                  >
-                    <Delete />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <NameManagementTable
+        items={groups}
+        nameHeader="グループ名"
+        onView={setDetailGroup}
+        onEdit={handleOpenEdit}
+        onDelete={handleOpenDelete}
+      />
 
-      <Dialog open={editDialogOpen} onClose={handleCloseEdit} fullWidth>
-        <DialogTitle>グループを編集</DialogTitle>
-        <Box
-          component="form"
-          onSubmit={(e) => {
-            void handleSubmit(onEdit)(e);
-          }}
-        >
-          <DialogContent>
-            <input {...register('id')} type="hidden" />
-            <TextField
-              {...register('name')}
-              autoFocus
-              margin="dense"
-              label="グループ名"
-              fullWidth
-              required
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseEdit}>キャンセル</Button>
-            <Button type="submit" variant="contained">
-              保存
-            </Button>
-          </DialogActions>
-        </Box>
-      </Dialog>
+      <NameEditDialog
+        open={editDialogOpen}
+        title="グループを編集"
+        nameLabel="グループ名"
+        register={register}
+        onClose={handleCloseEdit}
+        onSubmit={(e) => {
+          void handleSubmit(onEdit)(e);
+        }}
+      />
 
       <ConfirmDialog
         open={deleteDialogOpen}

--- a/src/app/(protected)/admin/users/_components/CreateRestrictionForm.tsx
+++ b/src/app/(protected)/admin/users/_components/CreateRestrictionForm.tsx
@@ -1,0 +1,113 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert, Button, Stack, TextField, Tooltip } from '@mui/material';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Controller, useForm } from 'react-hook-form';
+
+import { restrictionFormSchema } from './restrictionForm';
+import type {
+  RestrictionFormExpiration,
+  RestrictionFormInput,
+  RestrictionFormValues,
+} from './restrictionForm';
+
+const CreateRestrictionForm = ({
+  disabled,
+  submitError,
+  onSubmit,
+}: {
+  disabled: boolean;
+  submitError: string | null;
+  onSubmit: (values: RestrictionFormValues) => Promise<void>;
+}) => {
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<RestrictionFormInput, unknown, RestrictionFormValues>({
+    resolver: zodResolver(restrictionFormSchema),
+    defaultValues: { reason: '', expiration: { kind: 'indefinite' } },
+  });
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <form
+        onSubmit={(e) => {
+          void handleSubmit(onSubmit)(e);
+        }}
+      >
+        <Stack spacing={2}>
+          {submitError && <Alert severity="error">{submitError}</Alert>}
+          <Controller
+            name="reason"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="理由"
+                required
+                multiline
+                minRows={2}
+                fullWidth
+                size="small"
+                disabled={disabled}
+                error={Boolean(fieldState.error)}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="expiration"
+            control={control}
+            render={({ field, fieldState }) => (
+              <DateTimePicker
+                label="解除予定日時（任意・未指定で無期限）"
+                value={
+                  field.value.kind === 'expiresAt'
+                    ? field.value.expiresAt
+                    : null
+                }
+                onChange={(value) => {
+                  const expiration: RestrictionFormExpiration =
+                    value == null
+                      ? { kind: 'indefinite' }
+                      : { kind: 'expiresAt', expiresAt: value };
+                  field.onChange(expiration);
+                }}
+                disabled={disabled}
+                slotProps={{
+                  field: { clearable: true },
+                  textField: {
+                    fullWidth: true,
+                    size: 'small',
+                    error: Boolean(fieldState.error),
+                    helperText: fieldState.error?.message,
+                  },
+                }}
+              />
+            )}
+          />
+          <Tooltip
+            title={disabled ? '自分自身は制限できません' : ''}
+            placement="top"
+          >
+            <span>
+              <Button
+                type="submit"
+                color="error"
+                variant="outlined"
+                size="small"
+                disabled={disabled || isSubmitting}
+              >
+                制限する
+              </Button>
+            </span>
+          </Tooltip>
+        </Stack>
+      </form>
+    </LocalizationProvider>
+  );
+};
+
+export default CreateRestrictionForm;

--- a/src/app/(protected)/admin/users/_components/RestrictedAnswerSubmitterView.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictedAnswerSubmitterView.tsx
@@ -1,0 +1,59 @@
+import { Alert, Button, Stack, Tooltip, Typography } from '@mui/material';
+
+import { formatString } from '@/generic/DateFormatter';
+import type { GetAnswerSubmitterRestrictionResponse } from '@/lib/api-types';
+import {
+  formatRestrictionExpiration,
+  toRestrictionExpiration,
+} from '@/lib/restrictions/expiration';
+
+const RestrictedAnswerSubmitterView = ({
+  restriction,
+  disabled,
+  submitError,
+  onUnrestrict,
+}: {
+  restriction: NonNullable<GetAnswerSubmitterRestrictionResponse>;
+  disabled: boolean;
+  submitError: string | null;
+  onUnrestrict: () => Promise<void>;
+}) => {
+  const expiration = toRestrictionExpiration(restriction.expires_at);
+
+  return (
+    <Stack spacing={1.5}>
+      {submitError && <Alert severity="error">{submitError}</Alert>}
+      <Stack spacing={0.5}>
+        <Typography component="p">
+          <strong>理由:</strong> {restriction.reason}
+        </Typography>
+        <Typography component="p">
+          <strong>制限日時:</strong> {formatString(restriction.restricted_at)}
+        </Typography>
+        <Typography component="p">
+          <strong>解除予定:</strong> {formatRestrictionExpiration(expiration)}
+        </Typography>
+      </Stack>
+      <Tooltip
+        title={disabled ? '自分自身は制限できません' : ''}
+        placement="top"
+      >
+        <span>
+          <Button
+            color="error"
+            variant="outlined"
+            size="small"
+            disabled={disabled}
+            onClick={() => {
+              void onUnrestrict();
+            }}
+          >
+            制限を解除する
+          </Button>
+        </span>
+      </Tooltip>
+    </Stack>
+  );
+};
+
+export default RestrictedAnswerSubmitterView;

--- a/src/app/(protected)/admin/users/_components/RestrictionManagementSection.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionManagementSection.tsx
@@ -1,36 +1,15 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Stack,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@mui/material';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
-import { formatString } from '@/generic/DateFormatter';
 import { useAnswerSubmitterRestrictionActions } from '@/hooks/useAnswerSubmitterRestrictionActions';
-import {
-  formatRestrictionExpiration,
-  toRestrictionExpiration,
-} from '@/lib/restrictions/expiration';
 
-import { restrictionFormSchema, toRestrictionRequest } from './restrictionForm';
-import type {
-  RestrictionFormExpiration,
-  RestrictionFormInput,
-  RestrictionFormValues,
-} from './restrictionForm';
+import CreateRestrictionForm from './CreateRestrictionForm';
+import RestrictedAnswerSubmitterView from './RestrictedAnswerSubmitterView';
+import { toRestrictionRequest } from './restrictionForm';
+import type { RestrictionFormValues } from './restrictionForm';
+import RestrictionStatusFeedback from './RestrictionStatusFeedback';
 
 const RestrictionManagementSection = ({
   uuid,
@@ -49,79 +28,7 @@ const RestrictionManagementSection = ({
   const { restrictUser, unrestrictUser } =
     useAnswerSubmitterRestrictionActions();
 
-  const {
-    control,
-    handleSubmit,
-    formState: { isSubmitting },
-  } = useForm<RestrictionFormInput, unknown, RestrictionFormValues>({
-    resolver: zodResolver(restrictionFormSchema),
-    defaultValues: { reason: '', expiration: { kind: 'indefinite' } },
-  });
-
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
-        <CircularProgress size={24} />
-      </Box>
-    );
-  }
-
-  if (error) {
-    return <Alert severity="error">制限状態の取得に失敗しました。</Alert>;
-  }
-
-  // 既に制限中: 現在の内容を表示し、解除のみ行える。
-  if (data) {
-    const expiration = toRestrictionExpiration(data.expires_at);
-
-    const onUnrestrict = async () => {
-      setSubmitError(null);
-      const result = await unrestrictUser(uuid);
-      if (result.success) {
-        await mutate();
-      } else {
-        setSubmitError('制限の解除に失敗しました。');
-      }
-    };
-
-    return (
-      <Stack spacing={1.5}>
-        {submitError && <Alert severity="error">{submitError}</Alert>}
-        <Stack spacing={0.5}>
-          <Typography component="p">
-            <strong>理由:</strong> {data.reason}
-          </Typography>
-          <Typography component="p">
-            <strong>制限日時:</strong> {formatString(data.restricted_at)}
-          </Typography>
-          <Typography component="p">
-            <strong>解除予定:</strong> {formatRestrictionExpiration(expiration)}
-          </Typography>
-        </Stack>
-        <Tooltip
-          title={disabled ? '自分自身は制限できません' : ''}
-          placement="top"
-        >
-          <span>
-            <Button
-              color="error"
-              variant="outlined"
-              size="small"
-              disabled={disabled}
-              onClick={() => {
-                void onUnrestrict();
-              }}
-            >
-              制限を解除する
-            </Button>
-          </span>
-        </Tooltip>
-      </Stack>
-    );
-  }
-
-  // 未制限: 制限を付与するフォームを表示する。
-  const onRestrict = async (values: RestrictionFormValues) => {
+  const handleRestrict = async (values: RestrictionFormValues) => {
     setSubmitError(null);
     const result = await restrictUser(uuid, toRestrictionRequest(values));
     if (result.success) {
@@ -131,83 +38,37 @@ const RestrictionManagementSection = ({
     }
   };
 
+  const handleUnrestrict = async () => {
+    setSubmitError(null);
+    const result = await unrestrictUser(uuid);
+    if (result.success) {
+      await mutate();
+    } else {
+      setSubmitError('制限の解除に失敗しました。');
+    }
+  };
+
+  if (isLoading || error) {
+    return <RestrictionStatusFeedback error={error} isLoading={isLoading} />;
+  }
+
+  if (data) {
+    return (
+      <RestrictedAnswerSubmitterView
+        restriction={data}
+        disabled={disabled}
+        submitError={submitError}
+        onUnrestrict={handleUnrestrict}
+      />
+    );
+  }
+
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <form
-        onSubmit={(e) => {
-          void handleSubmit(onRestrict)(e);
-        }}
-      >
-        <Stack spacing={2}>
-          {submitError && <Alert severity="error">{submitError}</Alert>}
-          <Controller
-            name="reason"
-            control={control}
-            render={({ field, fieldState }) => (
-              <TextField
-                {...field}
-                label="理由"
-                required
-                multiline
-                minRows={2}
-                fullWidth
-                size="small"
-                disabled={disabled}
-                error={Boolean(fieldState.error)}
-                helperText={fieldState.error?.message}
-              />
-            )}
-          />
-          <Controller
-            name="expiration"
-            control={control}
-            render={({ field, fieldState }) => (
-              <DateTimePicker
-                label="解除予定日時（任意・未指定で無期限）"
-                value={
-                  field.value.kind === 'expiresAt'
-                    ? field.value.expiresAt
-                    : null
-                }
-                onChange={(value) => {
-                  const expiration: RestrictionFormExpiration =
-                    value == null
-                      ? { kind: 'indefinite' }
-                      : { kind: 'expiresAt', expiresAt: value };
-                  field.onChange(expiration);
-                }}
-                disabled={disabled}
-                slotProps={{
-                  field: { clearable: true },
-                  textField: {
-                    fullWidth: true,
-                    size: 'small',
-                    error: Boolean(fieldState.error),
-                    helperText: fieldState.error?.message,
-                  },
-                }}
-              />
-            )}
-          />
-          <Tooltip
-            title={disabled ? '自分自身は制限できません' : ''}
-            placement="top"
-          >
-            <span>
-              <Button
-                type="submit"
-                color="error"
-                variant="outlined"
-                size="small"
-                disabled={disabled || isSubmitting}
-              >
-                制限する
-              </Button>
-            </span>
-          </Tooltip>
-        </Stack>
-      </form>
-    </LocalizationProvider>
+    <CreateRestrictionForm
+      disabled={disabled}
+      submitError={submitError}
+      onSubmit={handleRestrict}
+    />
   );
 };
 

--- a/src/app/(protected)/admin/users/_components/RestrictionStatusFeedback.tsx
+++ b/src/app/(protected)/admin/users/_components/RestrictionStatusFeedback.tsx
@@ -1,0 +1,25 @@
+import { Alert, Box, CircularProgress } from '@mui/material';
+
+const RestrictionStatusFeedback = ({
+  error,
+  isLoading,
+}: {
+  error: unknown;
+  isLoading: boolean;
+}) => {
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">制限状態の取得に失敗しました。</Alert>;
+  }
+
+  return null;
+};
+
+export default RestrictionStatusFeedback;

--- a/tests/unit/searchResultRows.test.ts
+++ b/tests/unit/searchResultRows.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { toSearchResultRows } from '@/app/(protected)/admin/_lib/searchResultRows';
+import type { SearchResponse } from '@/lib/api-types';
+
+describe('toSearchResultRows', () => {
+  it('検索結果を管理画面の遷移先付き行へ変換する', () => {
+    const response = {
+      forms: [
+        { id: 'form-id', title: 'フォームタイトル' },
+        { id: 'ignored-form' },
+      ],
+      answers: [
+        { answer_id: 'answer-id', answer: '回答本文' },
+        { answer_id: 'ignored-answer' },
+      ],
+      users: [{ name: 'ユーザー名' }, { id: 'ignored-user' }],
+      label_for_forms: [{ name: 'フォームラベル' }, { id: 'ignored-label' }],
+      label_for_answers: [{ name: '回答ラベル' }, { id: 'ignored-label' }],
+      comments: [
+        {
+          id: 'comment-id',
+          answer_id: 'comment-answer-id',
+          commented_by: 'user-id',
+          content: 'コメント本文',
+        },
+      ],
+    } satisfies SearchResponse;
+
+    expect(toSearchResultRows(response)).toEqual([
+      {
+        id: 0,
+        category: 'フォーム',
+        title: 'フォームタイトル',
+        url: '/admin/forms/edit/form-id',
+      },
+      {
+        id: 1,
+        category: '回答',
+        title: '回答本文',
+        url: '/admin/answer/answer-id',
+      },
+      {
+        id: 2,
+        category: 'ユーザー',
+        title: 'ユーザー名',
+        url: '/admin/users/',
+      },
+      {
+        id: 3,
+        category: 'フォーム用ラベル',
+        title: 'フォームラベル',
+        url: '/admin/labels?tab=forms',
+      },
+      {
+        id: 4,
+        category: '回答用ラベル',
+        title: '回答ラベル',
+        url: '/admin/labels?tab=answers',
+      },
+      {
+        id: 5,
+        category: 'コメント',
+        title: 'コメント本文',
+        url: '/admin/answer/comment-answer-id',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要
- 巨大化していたラベル/グループ管理の一覧表示と編集ダイアログを共通表示コンポーネントへ切り出しました。
- 管理検索結果の行変換を純粋関数へ分離し、変換仕様を unit test で固定しました。
- 回答投稿制限管理とフォーム編集 UI を、状態取得・表示・フォーム入力・DnD 表示の責務ごとに分割しました。

## 確認事項
- pnpm vitest run --config vitest.unit.config.ts tests/unit/searchResultRows.test.ts: 検索結果の行変換が期待どおりであることを確認しました。
- pnpm vitest run --config vitest.component.config.ts tests/component/Groups.test.tsx tests/component/RestrictionManagementSection.test.tsx tests/component/ChoiceEditor.test.tsx: 分離対象の主要操作が維持されていることを確認しました。
- pnpm lint / pnpm fmt / pnpm type-check / pnpm build: 静的検査、整形、型検査、production build が通ることを確認しました。
- push 時の pre-push hook で pnpm test:unit が通ることを確認しました。

🤖 Generated with Codex