### PR TITLE
API由来のnullableをmapper境界で正規化する

### DIFF
--- a/src/app/(protected)/(standard)/forms/[formId]/answers/_lib/answerListRows.ts
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/_lib/answerListRows.ts
@@ -3,7 +3,7 @@ import type { GetFormAnswersResponse } from '@/lib/api-types';
 
 export type AnswerListRow = {
   id: string;
-  title: string | null | undefined;
+  title: string;
   date: string;
 };
 
@@ -12,6 +12,6 @@ export const toAnswerListRows = (
 ): AnswerListRow[] =>
   answers.map((answer) => ({
     id: answer.id,
-    title: answer.title,
+    title: answer.title ?? '',
     date: formatString(answer.timestamp),
   }));

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -18,9 +18,13 @@ type CreateFormBody =
   ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
 type FormUpdateBody =
   ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
+type ApiAcceptancePeriod =
+  GetFormResponse['settings']['answer_settings']['acceptance_period'];
+type ApiVisibility = GetFormResponse['settings']['visibility'];
 
-const toVisibility = (value: string | null | undefined): FormVisibility =>
-  value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC';
+const toVisibility = (
+  value: ApiVisibility | null | undefined
+): FormVisibility => (value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC');
 
 const toNullableNonEmptyString = (value: string): string | null => {
   const trimmed = value.trim();
@@ -94,30 +98,32 @@ const toApiQuestion = (
 };
 
 const toAcceptancePeriodSetting = (
-  startAt: string | null | undefined,
-  endAt: string | null | undefined
-): AcceptancePeriodSetting =>
-  startAt && endAt
-    ? {
-        kind: 'specified',
-        startAt: fromStringToJSTDateTime(startAt),
-        endAt: fromStringToJSTDateTime(endAt),
-      }
-    : { kind: 'none' };
+  acceptancePeriod: ApiAcceptancePeriod
+): AcceptancePeriodSetting => {
+  const { start_at: startAt, end_at: endAt } = acceptancePeriod;
+
+  if (startAt === undefined || startAt === null) return { kind: 'none' };
+  if (endAt === undefined || endAt === null) return { kind: 'none' };
+
+  return {
+    kind: 'specified',
+    startAt: fromStringToJSTDateTime(startAt),
+    endAt: fromStringToJSTDateTime(endAt),
+  };
+};
 
 export const fromFormResponseToEditorValues = (
   form: GetFormResponse
 ): FormEditorValues => {
-  const startAt = form.settings.answer_settings.acceptance_period.start_at;
-  const endAt = form.settings.answer_settings.acceptance_period.end_at;
-
   return {
     title: form.title,
     description: form.description,
     questions: form.questions.map(toEditorQuestion),
     labels: form.labels,
     settings: {
-      acceptance_period: toAcceptancePeriodSetting(startAt, endAt),
+      acceptance_period: toAcceptancePeriodSetting(
+        form.settings.answer_settings.acceptance_period
+      ),
       discord_webhook_url: form.settings.discord_webhook_url ?? '',
       visibility: toVisibility(form.settings.visibility),
       default_answer_title:

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -99,12 +99,10 @@ const toAcceptancePeriodSetting = (
   acceptancePeriod: ApiAcceptancePeriod
 ): AcceptancePeriodSetting => {
   const { start_at: startAt, end_at: endAt } = acceptancePeriod;
-  const hasStartAt = startAt !== undefined && startAt !== null;
-  const hasEndAt = endAt !== undefined && endAt !== null;
 
-  if (!hasStartAt && !hasEndAt) return { kind: 'none' };
+  if (startAt == null && endAt == null) return { kind: 'none' };
 
-  if (!hasStartAt || !hasEndAt) {
+  if (startAt == null || endAt == null) {
     throw new Error(
       'Answer acceptance period must have both start_at and end_at'
     );

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -11,8 +11,8 @@ import type {
   FormEditorQuestion,
   FormEditorQuestionIdentity,
   FormEditorValues,
-  FormVisibility,
 } from '../_schema/formEditorSchema';
+import { visibilitySchema } from '../_schema/formEditorSchema';
 
 type CreateFormBody =
   ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
@@ -22,9 +22,7 @@ type ApiAcceptancePeriod =
   GetFormResponse['settings']['answer_settings']['acceptance_period'];
 type ApiVisibility = GetFormResponse['settings']['visibility'];
 
-const toVisibility = (
-  value: ApiVisibility | null | undefined
-): FormVisibility => (value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC');
+const toVisibility = (value: ApiVisibility) => visibilitySchema.parse(value);
 
 const toNullableNonEmptyString = (value: string): string | null => {
   const trimmed = value.trim();
@@ -101,9 +99,16 @@ const toAcceptancePeriodSetting = (
   acceptancePeriod: ApiAcceptancePeriod
 ): AcceptancePeriodSetting => {
   const { start_at: startAt, end_at: endAt } = acceptancePeriod;
+  const hasStartAt = startAt !== undefined && startAt !== null;
+  const hasEndAt = endAt !== undefined && endAt !== null;
 
-  if (startAt === undefined || startAt === null) return { kind: 'none' };
-  if (endAt === undefined || endAt === null) return { kind: 'none' };
+  if (!hasStartAt && !hasEndAt) return { kind: 'none' };
+
+  if (!hasStartAt || !hasEndAt) {
+    throw new Error(
+      'Answer acceptance period must have both start_at and end_at'
+    );
+  }
 
   return {
     kind: 'specified',

--- a/src/generic/DateFormatter.ts
+++ b/src/generic/DateFormatter.ts
@@ -18,10 +18,5 @@ export const fromStringToJSTDateTime = (date: string) => {
   return dayjs(new Date(date)).tz('Asia/Tokyo').format(formatString);
 };
 
-export const toApiDateTime = (
-  dateStr: string | null | undefined
-): string | null => {
-  if (!dateStr) return null;
-
-  return dayjs.tz(dateStr, 'Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ');
-};
+export const toApiDateTime = (dateStr: string): string =>
+  dayjs.tz(dateStr, 'Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ');

--- a/tests/unit/answerListRows.test.ts
+++ b/tests/unit/answerListRows.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { toAnswerListRows } from '@/app/(protected)/(standard)/forms/[formId]/answers/_lib/answerListRows';
+import type { GetFormAnswersResponse } from '@/lib/api-types';
+
+const createAnswer = (
+  overrides: Partial<GetFormAnswersResponse[number]>
+): GetFormAnswersResponse[number] => ({
+  id: 'answer-id',
+  form_id: 'form-id',
+  answers: [],
+  author: {
+    type: 'AUTHENTICATED_USER',
+    user: {
+      uuid: 'user-id',
+      name: 'ユーザー',
+      role: 'STANDARD_USER',
+    },
+  },
+  labels: [],
+  timestamp: '2026-06-01T10:00:00+09:00',
+  ...overrides,
+});
+
+describe('toAnswerListRows', () => {
+  it('回答一覧の行へ表示用の値を渡す', () => {
+    const rows = toAnswerListRows([
+      createAnswer({ id: 'with-title', title: '回答タイトル' }),
+    ]);
+
+    expect(rows).toEqual([
+      {
+        id: 'with-title',
+        title: '回答タイトル',
+        date: '2026年06月01日 10時00分',
+      },
+    ]);
+  });
+
+  it('回答タイトルが null または未指定のときは空文字へ正規化する', () => {
+    const rows = toAnswerListRows([
+      createAnswer({ id: 'null-title', title: null }),
+      createAnswer({ id: 'missing-title' }),
+    ]);
+
+    expect(rows.map((row) => row.title)).toEqual(['', '']);
+  });
+});

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -39,6 +39,47 @@ const baseValues: FormEditorValues = {
   },
 };
 
+const createFormResponse = (
+  overrides: Partial<GetFormResponse> = {}
+): GetFormResponse => ({
+  id: 'form-id',
+  title: 'Form title',
+  description: 'Form description',
+  labels: [],
+  metadata: {
+    created_at: '2026-06-01T00:00:00+09:00',
+    updated_at: '2026-06-01T00:00:00+09:00',
+  },
+  settings: {
+    visibility: 'PUBLIC',
+    allowed_group_ids: [],
+    allow_temporary_answers: false,
+    discord_webhook_url: null,
+    answer_settings: {
+      default_answer_title: null,
+      acceptance_period: {
+        start_at: null,
+        end_at: null,
+      },
+      visibility: 'PUBLIC',
+      answer_group_ids: [],
+    },
+  },
+  questions: [
+    {
+      id: 'question-id',
+      title: 'Question title',
+      description: null,
+      question_type: 'SingleChoice',
+      choices: [{ id: 1, label: 'First choice', position: 0 }],
+      is_required: false,
+      position: 0,
+      template_key: 'question_1',
+    },
+  ],
+  ...overrides,
+});
+
 describe('form request builders', () => {
   it('空のテンプレートキーと質問説明を API が受け付ける値へ正規化する', () => {
     const body = toCreateFormBody(baseValues);
@@ -107,45 +148,68 @@ describe('form request builders', () => {
   });
 
   it('フォーム取得レスポンスの選択肢 ID を画面内部表現へ保持する', () => {
-    const values = fromFormResponseToEditorValues({
-      id: 'form-id',
-      title: 'Form title',
-      description: 'Form description',
-      labels: [],
-      metadata: {
-        created_at: '2026-06-01T00:00:00+09:00',
-        updated_at: '2026-06-01T00:00:00+09:00',
-      },
-      settings: {
-        visibility: 'PUBLIC',
-        allowed_group_ids: [],
-        allow_temporary_answers: false,
-        discord_webhook_url: null,
-        answer_settings: {
-          default_answer_title: null,
-          acceptance_period: {
-            start_at: null,
-            end_at: null,
-          },
-          visibility: 'PUBLIC',
-          answer_group_ids: [],
-        },
-      },
-      questions: [
-        {
-          id: 'question-id',
-          title: 'Question title',
-          description: null,
-          question_type: 'SingleChoice',
-          choices: [{ id: 1, label: 'First choice', position: 0 }],
-          is_required: false,
-          position: 0,
-          template_key: 'question_1',
-        },
-      ],
-    } satisfies GetFormResponse);
+    const values = fromFormResponseToEditorValues(createFormResponse());
 
     expect(values.questions[0]?.choices[0]?.id).toBe(1);
+  });
+
+  it('回答期間が未設定のフォーム取得レスポンスを画面内部表現へ変換する', () => {
+    const values = fromFormResponseToEditorValues(createFormResponse());
+
+    expect(values.settings.acceptance_period).toEqual({ kind: 'none' });
+  });
+
+  it('回答期間が設定されたフォーム取得レスポンスを画面内部表現へ変換する', () => {
+    const values = fromFormResponseToEditorValues(
+      createFormResponse({
+        settings: {
+          ...createFormResponse().settings,
+          answer_settings: {
+            ...createFormResponse().settings.answer_settings,
+            acceptance_period: {
+              start_at: '2026-06-01T10:00:00+09:00',
+              end_at: '2026-06-30T23:59:00+09:00',
+            },
+          },
+        },
+      })
+    );
+
+    expect(values.settings.acceptance_period).toEqual({
+      kind: 'specified',
+      startAt: '2026-06-01T10:00',
+      endAt: '2026-06-30T23:59',
+    });
+  });
+
+  it('片方だけ欠けた回答期間は画面内部表現へ変換しない', () => {
+    const form = createFormResponse({
+      settings: {
+        ...createFormResponse().settings,
+        answer_settings: {
+          ...createFormResponse().settings.answer_settings,
+          acceptance_period: {
+            start_at: '2026-06-01T10:00:00+09:00',
+            end_at: null,
+          },
+        },
+      },
+    });
+
+    expect(() => fromFormResponseToEditorValues(form)).toThrow(
+      'Answer acceptance period must have both start_at and end_at'
+    );
+  });
+
+  it('未知の公開設定は画面内部表現へ変換しない', () => {
+    const form = createFormResponse({
+      settings: {
+        ...createFormResponse().settings,
+        visibility: 'UNKNOWN',
+      },
+    });
+
+    expect(() => fromFormResponseToEditorValues(form)).toThrow();
   });
 
   it('空の Webhook URL は null に正規化する', () => {


### PR DESCRIPTION
## 概要
- API DTO 由来の null/undefined を回答一覧 row とフォーム編集 mapper の境界で正規化し、内部の表示・編集モデルへ流さないようにしました。
- 汎用 date formatter の toApiDateTime は string のみを受ける責務に戻し、回答期間なしの判定はフォーム編集 mapper 側へ寄せました。
- 片方だけ欠けた回答期間や未知の公開設定は、黙って補正せず mapper 境界で検出するようにしました。

## 確認事項
- pnpm vitest run --config vitest.unit.config.ts tests/unit/formEditorMappers.test.ts tests/unit/answerListRows.test.ts で、追加した境界仕様のテスト 2 files / 15 tests が通ることを確認しました。
- pnpm test:unit で unit test 全体 12 files / 60 tests が通ることを確認しました。
- pnpm type-check で strict 型設定上の破綻がないことを確認しました。
- pnpm lint で ESLint ルールに通ることを確認しました。
- pre-commit hook で lint / type-check / fmt が通り、push 時の pre-push hook で unit test 全体が通ることを確認しました。

🤖 Generated with Codex