### PR TITLE
fix: 初回アクセス時のダークモードのライトフラッシュを解消する

### DIFF
--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -14,21 +14,18 @@ const SearchField = () => {
   return (
     <Paper
       component="form"
-      sx={{
+      sx={(theme) => ({
         p: '2px 4px',
         display: 'flex',
         alignItems: 'center',
         width: 400,
-        backgroundColor: (theme) =>
-          alpha(
-            theme.palette.common.white,
-            theme.palette.mode === 'dark' ? 0.15 : 0.85
-          ),
-        border: (theme) =>
-          theme.palette.mode === 'dark'
-            ? `1px solid ${alpha(theme.palette.common.white, 0.2)}`
-            : `1px solid ${alpha(theme.palette.text.primary, 0.2)}`,
-      }}
+        backgroundColor: alpha(theme.palette.common.white, 0.85),
+        border: `1px solid ${alpha(theme.palette.text.primary, 0.2)}`,
+        ...theme.applyStyles('dark', {
+          backgroundColor: alpha(theme.palette.common.white, 0.15),
+          border: `1px solid ${alpha(theme.palette.common.white, 0.2)}`,
+        }),
+      })}
     >
       <IconButton
         sx={{ p: '10px', color: 'text.primary' }}

--- a/src/app/_components/ThemeModeToggle.tsx
+++ b/src/app/_components/ThemeModeToggle.tsx
@@ -3,30 +3,48 @@
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import { IconButton, Tooltip } from '@mui/material';
+import { useColorScheme } from '@mui/material/styles';
+import { useSyncExternalStore } from 'react';
 
-import { useOptionalThemeMode } from '@/app/_providers/themeMode';
+const emptySubscribe = () => () => {};
+
+// サーバー描画とハイドレーション時は false、クライアント描画後に true を返す。
+// `useColorScheme` の mode/systemMode は effect 前（＝マウント前）で undefined のため、
+// マウント判定でアイコンのちらつきとハイドレーション不一致を防ぐ。
+const useMounted = () =>
+  useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
 
 const ThemeModeToggle = () => {
-  const themeMode = useOptionalThemeMode();
+  const { mode, systemMode, setMode } = useColorScheme();
+  const mounted = useMounted();
 
-  if (!themeMode) {
-    return null;
+  if (!mounted) {
+    return (
+      <IconButton color="inherit" aria-label="toggle theme" disabled>
+        <DarkModeIcon />
+      </IconButton>
+    );
   }
 
-  const { mode, toggleMode } = themeMode;
+  const resolvedMode = mode === 'system' ? systemMode : mode;
+  const isDark = resolvedMode === 'dark';
 
   return (
     <Tooltip
-      title={
-        mode === 'light' ? 'ダークテーマに切り替え' : 'ライトテーマに切り替え'
-      }
+      title={isDark ? 'ライトテーマに切り替え' : 'ダークテーマに切り替え'}
     >
       <IconButton
         color="inherit"
-        onClick={toggleMode}
+        onClick={() => {
+          setMode(isDark ? 'light' : 'dark');
+        }}
         aria-label="toggle theme"
       >
-        {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
+        {isDark ? <LightModeIcon /> : <DarkModeIcon />}
       </IconButton>
     </Tooltip>
   );

--- a/src/app/_providers/getAuthedTheme.ts
+++ b/src/app/_providers/getAuthedTheme.ts
@@ -2,8 +2,7 @@
 
 import { grey } from '@mui/material/colors';
 import { alpha, createTheme } from '@mui/material/styles';
-
-export type ThemeMode = 'light' | 'dark';
+import type { Theme } from '@mui/material/styles';
 
 const lightSurface = '#F4F7FB';
 const darkSurface = '#081522';
@@ -11,54 +10,75 @@ const darkPrimaryMain = '#90CAF9';
 const darkPrimaryHover = '#7EBFEF';
 const darkPrimaryText = '#102235';
 
-export const getAuthedTheme = (mode: ThemeMode) =>
+export const getAuthedTheme = () =>
   createTheme({
-    palette: {
-      mode,
-      primary: {
-        main: mode === 'dark' ? darkPrimaryMain : '#1976D2',
-        dark: mode === 'dark' ? darkPrimaryHover : undefined,
-        contrastText: mode === 'dark' ? darkPrimaryText : '#FFFFFF',
+    cssVariables: {
+      colorSchemeSelector: 'data-mui-color-scheme',
+    },
+    colorSchemes: {
+      light: {
+        palette: {
+          primary: {
+            main: '#1976D2',
+            contrastText: '#FFFFFF',
+          },
+          secondary: {
+            main: '#0F5D8C',
+            contrastText: '#FFFFFF',
+          },
+          background: {
+            default: lightSurface,
+            paper: '#FFFFFF',
+          },
+          text: {
+            primary: '#13202B',
+            secondary: 'rgba(19, 32, 43, 0.72)',
+          },
+          divider: 'rgba(19, 32, 43, 0.12)',
+        },
       },
-      secondary: {
-        main: '#0F5D8C',
-        contrastText: '#FFFFFF',
-      },
-      background: {
-        default: mode === 'dark' ? darkSurface : lightSurface,
-        paper: mode === 'dark' ? '#0B1825' : '#FFFFFF',
-      },
-      text: {
-        primary: mode === 'dark' ? '#FFFFFF' : '#13202B',
-        secondary:
-          mode === 'dark'
-            ? 'rgba(255, 255, 255, 0.72)'
-            : 'rgba(19, 32, 43, 0.72)',
-      },
-      divider:
-        mode === 'dark'
-          ? 'rgba(255, 255, 255, 0.08)'
-          : 'rgba(19, 32, 43, 0.12)',
-      grey: {
-        ...grey,
-        ...(mode === 'dark'
-          ? {
-              50: '#122131',
-            }
-          : {}),
+      dark: {
+        palette: {
+          primary: {
+            main: darkPrimaryMain,
+            dark: darkPrimaryHover,
+            contrastText: darkPrimaryText,
+          },
+          secondary: {
+            main: '#0F5D8C',
+            contrastText: '#FFFFFF',
+          },
+          background: {
+            default: darkSurface,
+            paper: '#0B1825',
+          },
+          text: {
+            primary: '#FFFFFF',
+            secondary: 'rgba(255, 255, 255, 0.72)',
+          },
+          divider: 'rgba(255, 255, 255, 0.08)',
+          grey: {
+            ...grey,
+            50: '#122131',
+          },
+        },
       },
     },
     components: {
       MuiCssBaseline: {
         styleOverrides: {
-          body: {
-            backgroundColor: mode === 'dark' ? darkSurface : lightSurface,
+          body: ({ theme }: { theme: Theme }) => ({
+            backgroundColor: lightSurface,
             backgroundImage:
-              mode === 'dark'
-                ? 'linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, rgba(255, 255, 255, 0) 28%)'
-                : 'linear-gradient(180deg, rgba(15, 93, 140, 0.08) 0%, rgba(15, 93, 140, 0) 24%)',
-            color: mode === 'dark' ? '#FFFFFF' : '#13202B',
-          },
+              'linear-gradient(180deg, rgba(15, 93, 140, 0.08) 0%, rgba(15, 93, 140, 0) 24%)',
+            color: '#13202B',
+            ...theme.applyStyles('dark', {
+              backgroundColor: darkSurface,
+              backgroundImage:
+                'linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, rgba(255, 255, 255, 0) 28%)',
+              color: '#FFFFFF',
+            }),
+          }),
         },
       },
       MuiInputLabel: {
@@ -71,16 +91,19 @@ export const getAuthedTheme = (mode: ThemeMode) =>
             fontSize: '1.1rem',
             marginBottom: '4px',
             color: theme.palette.text.primary,
+            ...theme.applyStyles('dark', {
+              color: '#FFFFFF',
+            }),
           }),
         },
       },
       MuiOutlinedInput: {
         styleOverrides: {
           root: ({ theme }) => ({
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? alpha(theme.palette.common.white, 0.12)
-                : alpha(theme.palette.common.white, 0.92),
+            backgroundColor: alpha(theme.palette.common.white, 0.92),
+            ...theme.applyStyles('dark', {
+              backgroundColor: alpha(theme.palette.common.white, 0.12),
+            }),
           }),
           input: {
             height: 'auto',
@@ -89,13 +112,13 @@ export const getAuthedTheme = (mode: ThemeMode) =>
           },
           notchedOutline: ({ theme }) => ({
             top: 0,
-            borderColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, 0.18)'
-                : alpha(theme.palette.text.primary, 0.2),
+            borderColor: alpha(theme.palette.text.primary, 0.2),
             legend: {
               display: 'none',
             },
+            ...theme.applyStyles('dark', {
+              borderColor: 'rgba(255, 255, 255, 0.18)',
+            }),
           }),
         },
       },
@@ -108,22 +131,20 @@ export const getAuthedTheme = (mode: ThemeMode) =>
       },
       MuiCard: {
         styleOverrides: {
-          root: {
+          root: ({ theme }) => ({
             display: 'flex',
             flexDirection: 'column',
-            backgroundColor:
-              mode === 'dark' ? 'rgba(11, 24, 37, 0.92)' : '#FFFFFF',
+            backgroundColor: '#FFFFFF',
             backgroundImage: 'none',
-            border: `1px solid ${
-              mode === 'dark'
-                ? 'rgba(255, 255, 255, 0.06)'
-                : 'rgba(19, 32, 43, 0.08)'
-            }`,
-            boxShadow:
-              mode === 'dark'
-                ? '0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px rgba(0, 0, 0, 0.14), 0px 1px 3px rgba(0, 0, 0, 0.12)'
-                : '0px 6px 18px rgba(19, 32, 43, 0.08)',
-          },
+            border: '1px solid rgba(19, 32, 43, 0.08)',
+            boxShadow: '0px 6px 18px rgba(19, 32, 43, 0.08)',
+            ...theme.applyStyles('dark', {
+              backgroundColor: 'rgba(11, 24, 37, 0.92)',
+              border: '1px solid rgba(255, 255, 255, 0.06)',
+              boxShadow:
+                '0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px rgba(0, 0, 0, 0.14), 0px 1px 3px rgba(0, 0, 0, 0.12)',
+            }),
+          }),
         },
       },
       MuiChip: {
@@ -134,15 +155,13 @@ export const getAuthedTheme = (mode: ThemeMode) =>
             }
 
             return {
-              backgroundColor:
-                theme.palette.mode === 'dark'
-                  ? alpha(theme.palette.common.white, 0.16)
-                  : alpha(theme.palette.primary.main, 0.14),
-              color:
-                theme.palette.mode === 'dark'
-                  ? theme.palette.text.primary
-                  : theme.palette.primary.dark,
+              backgroundColor: alpha(theme.palette.primary.main, 0.14),
+              color: theme.palette.primary.dark,
               fontWeight: 600,
+              ...theme.applyStyles('dark', {
+                backgroundColor: alpha(theme.palette.common.white, 0.16),
+                color: '#FFFFFF',
+              }),
             };
           },
         },
@@ -150,15 +169,16 @@ export const getAuthedTheme = (mode: ThemeMode) =>
       MuiDrawer: {
         styleOverrides: {
           paper: ({ theme }) => ({
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? '#102235'
-                : alpha(theme.palette.background.paper, 0.98),
+            backgroundColor: alpha(theme.palette.background.paper, 0.98),
             backgroundImage:
-              theme.palette.mode === 'dark'
-                ? 'linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0) 22%)'
-                : 'linear-gradient(180deg, rgba(15, 93, 140, 0.08) 0%, rgba(15, 93, 140, 0) 22%)',
+              'linear-gradient(180deg, rgba(15, 93, 140, 0.08) 0%, rgba(15, 93, 140, 0) 22%)',
             borderRight: `1px solid ${theme.palette.divider}`,
+            ...theme.applyStyles('dark', {
+              backgroundColor: '#102235',
+              backgroundImage:
+                'linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0) 22%)',
+              borderRight: '1px solid rgba(255, 255, 255, 0.08)',
+            }),
           }),
         },
       },

--- a/src/app/_providers/themeMode.tsx
+++ b/src/app/_providers/themeMode.tsx
@@ -1,56 +1,17 @@
 'use client';
 
-import { CssBaseline, ThemeProvider } from '@mui/material';
+import { CssBaseline } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
-import {
-  createContext,
-  useContext,
-  useMemo,
-  useSyncExternalStore,
-} from 'react';
 import type { ReactNode } from 'react';
 import { SWRConfig } from 'swr';
 
 import { MsalProvider } from '@/app/_components/MsalProvider';
 import { fetcher } from '@/app/_swr/fetcher';
 
-import { getAuthedTheme, type ThemeMode } from './getAuthedTheme';
+import { getAuthedTheme } from './getAuthedTheme';
 
-const STORAGE_KEY = 'seichi-portal-theme-mode';
-const THEME_MODE_EVENT = 'seichi-portal-theme-mode-change';
-
-type ThemeModeContextValue = {
-  mode: ThemeMode;
-  setMode: (mode: ThemeMode) => void;
-  toggleMode: () => void;
-};
-
-const ThemeModeContext = createContext<ThemeModeContextValue | null>(null);
-
-const subscribeThemeMode = (callback: () => void) => {
-  const handleStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEY) {
-      callback();
-    }
-  };
-
-  const handleThemeModeChange = () => {
-    callback();
-  };
-
-  window.addEventListener('storage', handleStorage);
-  window.addEventListener(THEME_MODE_EVENT, handleThemeModeChange);
-
-  return () => {
-    window.removeEventListener('storage', handleStorage);
-    window.removeEventListener(THEME_MODE_EVENT, handleThemeModeChange);
-  };
-};
-
-const getThemeModeSnapshot = (): ThemeMode =>
-  window.localStorage.getItem(STORAGE_KEY) === 'dark' ? 'dark' : 'light';
-
-const getThemeModeServerSnapshot = (): ThemeMode => 'light';
+const theme = getAuthedTheme();
 
 export const AppProviders = ({
   children,
@@ -60,59 +21,19 @@ export const AppProviders = ({
   children: ReactNode;
   msalClientId: string;
   msalRedirectUri: string;
-}) => {
-  const mode = useSyncExternalStore(
-    subscribeThemeMode,
-    getThemeModeSnapshot,
-    getThemeModeServerSnapshot
-  );
-
-  const setMode = (nextMode: ThemeMode) => {
-    window.localStorage.setItem(STORAGE_KEY, nextMode);
-    window.dispatchEvent(new Event(THEME_MODE_EVENT));
-  };
-
-  const theme = useMemo(() => getAuthedTheme(mode), [mode]);
-
-  const value = useMemo<ThemeModeContextValue>(
-    () => ({
-      mode,
-      setMode,
-      toggleMode: () => {
-        setMode(mode === 'light' ? 'dark' : 'light');
-      },
-    }),
-    [mode]
-  );
-
-  return (
-    <AppRouterCacheProvider>
-      <ThemeModeContext.Provider value={value}>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <SWRConfig
-            value={{
-              fetcher,
-            }}
-          >
-            <MsalProvider clientId={msalClientId} redirectUri={msalRedirectUri}>
-              {children}
-            </MsalProvider>
-          </SWRConfig>
-        </ThemeProvider>
-      </ThemeModeContext.Provider>
-    </AppRouterCacheProvider>
-  );
-};
-
-export const useThemeMode = () => {
-  const context = useContext(ThemeModeContext);
-
-  if (!context) {
-    throw new Error('useThemeMode must be used within AppProviders');
-  }
-
-  return context;
-};
-
-export const useOptionalThemeMode = () => useContext(ThemeModeContext);
+}) => (
+  <AppRouterCacheProvider>
+    <ThemeProvider theme={theme} defaultMode="system">
+      <CssBaseline />
+      <SWRConfig
+        value={{
+          fetcher,
+        }}
+      >
+        <MsalProvider clientId={msalClientId} redirectUri={msalRedirectUri}>
+          {children}
+        </MsalProvider>
+      </SWRConfig>
+    </ThemeProvider>
+  </AppRouterCacheProvider>
+);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,6 @@
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 
-  --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
 
@@ -56,13 +55,6 @@ body {
 body {
   font-family:
     'Segoe UI', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
 }
 
 code {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 import type { ReactNode } from 'react';
 
 import { getMsalConfig } from '@/env.server';
@@ -9,8 +10,9 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
   const msalConfig = getMsalConfig();
 
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <body>
+        <InitColorSchemeScript defaultMode="system" />
         <AppProviders
           msalClientId={msalConfig.clientId}
           msalRedirectUri={msalConfig.redirectUri}

--- a/tests/component/render.tsx
+++ b/tests/component/render.tsx
@@ -7,7 +7,7 @@ import { SWRConfig } from 'swr';
 import { getAuthedTheme } from '@/app/_providers/getAuthedTheme';
 
 const ComponentTestProviders = ({ children }: { children: ReactNode }) => (
-  <ThemeProvider theme={getAuthedTheme('light')}>
+  <ThemeProvider theme={getAuthedTheme()}>
     <CssBaseline />
     <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
   </ThemeProvider>

--- a/tests/e2e/theme-color-scheme.spec.ts
+++ b/tests/e2e/theme-color-scheme.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+// Issue 817: システム設定がダークモードのユーザーが初回アクセスしたとき、
+// ライトの一瞬表示なく初回ペイントからダークで表示されることを保証する。
+// InitColorSchemeScript がペイント前に data-mui-color-scheme を確定させ、
+// CSS 変数テーマがその属性で配色を切り替えることを、解決後の最終状態で検証する。
+
+const darkSurface = 'rgb(8, 21, 34)'; // #081522
+const lightSurface = 'rgb(244, 247, 251)'; // #F4F7FB
+
+test('システム設定がダークのとき、ランディングページが初回からダーク配色になる', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ colorScheme: 'dark' });
+  const page = await context.newPage();
+  await page.goto('/');
+
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-mui-color-scheme',
+    'dark'
+  );
+  const backgroundColor = await page.evaluate(
+    () => getComputedStyle(document.body).backgroundColor
+  );
+  expect(backgroundColor).toBe(darkSurface);
+
+  await context.close();
+});
+
+test('システム設定がライトのとき、ランディングページがライト配色になる', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ colorScheme: 'light' });
+  const page = await context.newPage();
+  await page.goto('/');
+
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-mui-color-scheme',
+    'light'
+  );
+  const backgroundColor = await page.evaluate(
+    () => getComputedStyle(document.body).backgroundColor
+  );
+  expect(backgroundColor).toBe(lightSurface);
+
+  await context.close();
+});


### PR DESCRIPTION
## 概要
- close #817。システム設定がダークのユーザーが初回に開くと、SSR が常にライトで描画し hydration 後にモードへ再レンダリングするためライトが一瞬表示されていた（かつ `prefers-color-scheme` を見ておらず未設定初回はライト固定だった）問題を解消する。
- MUI の CSS 変数モード（`colorSchemes` + `cssVariables`）へ移行し、`InitColorSchemeScript` でペイント前に配色を確定。OS 設定に追従しつつ初回ペイントからダークで表示され、手動トグルの選択は MUI 標準ストレージへ保存して以後優先する。
- 独自の `useSyncExternalStore` テーマストア・カスタムイベント・ライト固定の body 背景（もう一つのフラッシュ源）を撤去。各コンポーネント override の `palette.mode` 分岐は `theme.applyStyles('dark', …)` へ移行し、配色の値は移行前後で一致。

## 確認事項
- `pnpm type-check` / `lint` / `fmt` / `build` / `test:component`(23件) がすべて通過。
- dev サーバの SSR HTML を確認し、`InitColorSchemeScript` が `matchMedia(prefers-color-scheme)` と localStorage を読むインラインスクリプトとしてペイント前に展開され、`[data-mui-color-scheme="dark"]` / `"light"` 両方の CSS 変数ブロックが出力される（＝再レンダリング無しで配色確定）ことを実証。
- 回帰ガードとして e2e (`tests/e2e/theme-color-scheme.spec.ts`) を追加。`colorScheme` dark/light で `/` を開き `html[data-mui-color-scheme]` と body 背景色を検証する。ローカルは Chromium のシステムライブラリ欠如で未実行のため、CI (`e2e.yaml`, `playwright install --with-deps`) での実行を確認したい。
- レビュー観点: `applyStyles` への置換に mode 分岐の焼き付き残りがないか、`ThemeModeToggle` の mounted ガード（`useSyncExternalStore`）でハイドレーション不一致が防げているか。

## 補足
- 既にダークのユーザーはトグルアイコンが初回に月→太陽へ1フレーム入れ替わる（背景フラッシュでもハイドレーション不一致でもない）。Issue の主訴である背景のちらつきは解消済み。
- 旧 localStorage キー（`seichi-portal-theme-mode`）は移行しないため、デプロイ後に既存ユーザーの選択は一度リセットされ system 追従に戻る。

🤖 Generated with Claude Code