### PR TITLE
fix: フォーム回答画面のUIを画面中央に寄せる

### DIFF
--- a/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
@@ -60,7 +60,7 @@ const AnswerForm = ({
   }
 
   return (
-    <Stack spacing={0}>
+    <Stack spacing={0} sx={{ width: '100%' }}>
       <SubmissionErrorAlert submissionState={submissionState} />
       <AnswerSubmissionForm
         questions={questions}


### PR DESCRIPTION
## 概要
- Issue #818: フォーム回答画面 (`/forms/[formId]`) の回答入力 UI が画面左に寄って表示されており、中央寄せに直してほしいという要望への対応
- 原因: 親レイアウトの `.main`（`display:flex; flex-direction:row;`、`justify-content` 未指定）の直接の子である `AnswerForm.tsx` の `Stack`（回答入力中の主経路）が幅指定を持たず、内容幅に縮んで左端に張り付いていた
- `Stack` に `width: '100%'` を追加し、同ファイル内の他の分岐（未ログイン時・送信エラー時）や `AnswerSubmissionForm.tsx` と同じ `width:100% + maxWidth:800 + mx:auto` パターンに揃えて、中央寄せが機能するようにした

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm build`: いずれも成功
- `pnpm test:unit`: 60件全て成功
- ブラウザでの目視確認は、バックエンド API に到達できない環境のため未実施。CSS の挙動（flex item が `width:100%` を持つことで子要素の `max-width + margin:auto` による中央寄せが有効になる）はコードレビューで検証済み
- 他の分岐（未ログイン時のメッセージ、送信エラー時の Alert、送信完了後の画面）は元々同じパターンで中央寄せ済みであることを確認し、中央寄せ漏れが残っていないことを確認した
- レビュアーには、実際にフォーム回答画面をブラウザで開いて中央寄せになっていることの目視確認をお願いしたい

## 補足
- 変更は `src/app/(public)/forms/[formId]/_components/AnswerForm.tsx` の1行のみ

🤖 Generated with Claude Code