### PR TITLE
fix: 公開ルートでもサインイン済みならAppBarにユーザーメニューを表示する

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
 import NavBar from '@/app/_components/NavBar';
+import { AuthenticatedUserProvider } from '@/app/_providers/currentUser';
+import { getSession } from '@/lib/server/session';
 
 import styles from '../page.module.css';
 
@@ -13,11 +15,25 @@ export const metadata: Metadata = {
 };
 
 // ログイン任意の公開ルート。<html>/<body> と provider は共有 root layout が持つ。
-const PublicLayout = ({ children }: { children: ReactNode }) => (
-  <>
-    <NavBar />
-    <main className={styles['main']}>{children}</main>
-  </>
-);
+// サインイン済みの場合は NavBar がユーザーメニューを表示できるよう Context を注入する。
+const PublicLayout = async ({ children }: { children: ReactNode }) => {
+  const session = await getSession();
+  const content = (
+    <>
+      <NavBar />
+      <main className={styles['main']}>{children}</main>
+    </>
+  );
+
+  if (session.state !== 'authenticated') {
+    return content;
+  }
+
+  return (
+    <AuthenticatedUserProvider currentUser={session.user}>
+      {content}
+    </AuthenticatedUserProvider>
+  );
+};
 
 export default PublicLayout;


### PR DESCRIPTION
## Summary
- `(public)` レイアウトが `CurrentUserContext` を注入していなかったため、フォーム回答画面など公開ルートではサインイン済みでも AppBar が常にサインインボタンを表示していた
- `(public)/layout.tsx` でサーバー側の `getSession()` を確認し、認証済みなら `AuthenticatedUserProvider` で Context を注入するよう修正
- 未サインインの場合は従来通り Context を注入せず、`NavBar` はサインインボタンを表示する

## Test plan
- [x] `pnpm tsc --noEmit`
- [x] `pnpm exec eslint`
- [x] `pnpm build`
- [x] `pnpm test:unit` (pre-push hook, 60 tests passed)
- [ ] サインイン済み状態でフォーム回答画面 (`/forms/[formId]`) に遷移し、AppBar にユーザーメニューが表示されることを目視確認

Closes #828