### PR TITLE
feat: コメントを編集できるようにする

### DIFF
--- a/src/app/(protected)/_components/Comments.tsx
+++ b/src/app/(protected)/_components/Comments.tsx
@@ -40,7 +40,9 @@ const Comments = (props: {
         (props.showDeleteButton ?? false) ||
         (props.currentUserId !== undefined &&
           comment.commented_by.uuid === props.currentUserId),
-      canEdit: comment.commented_by.uuid === props.currentUserId,
+      canEdit:
+        props.currentUserId !== undefined &&
+        comment.commented_by.uuid === props.currentUserId,
     })
   );
 

--- a/src/app/(protected)/_components/Comments.tsx
+++ b/src/app/(protected)/_components/Comments.tsx
@@ -40,7 +40,7 @@ const Comments = (props: {
         (props.showDeleteButton ?? false) ||
         (props.currentUserId !== undefined &&
           comment.commented_by.uuid === props.currentUserId),
-      canEdit: false,
+      canEdit: comment.commented_by.uuid === props.currentUserId,
     })
   );
 
@@ -51,6 +51,7 @@ const Comments = (props: {
     emptyMessage: 'コメントはまだありません',
     adminLabel: '運営',
     deepLinkQueryParam: 'commentId',
+    entryNoun: 'コメント',
   };
 
   const deepLinkState = useConversationEntryDeepLink(
@@ -93,6 +94,7 @@ const Comments = (props: {
             </Box>
           ) : null
         }
+        onUpdate={actions.update}
         onDelete={actions.deleteEntry}
       />
     </Box>

--- a/src/app/(protected)/_components/ConversationEntry.tsx
+++ b/src/app/(protected)/_components/ConversationEntry.tsx
@@ -113,7 +113,7 @@ const ConversationEntry = ({
 
     const result = await onDelete(entry.id);
     if (result.forbidden) {
-      showError('このメッセージを削除する権限がありません。');
+      showError(`この${capabilities.entryNoun}を削除する権限がありません。`);
     } else if (!result.success) {
       showError('不明なエラーが発生しました。もう一度お試しください。');
     }
@@ -127,7 +127,7 @@ const ConversationEntry = ({
 
     const result = await onUpdate(entry.id, draftBody);
     if (result.forbidden) {
-      showError('このメッセージを編集する権限がありません。');
+      showError(`この${capabilities.entryNoun}を編集する権限がありません。`);
       return;
     }
 

--- a/src/app/(protected)/_components/Messages.tsx
+++ b/src/app/(protected)/_components/Messages.tsx
@@ -57,6 +57,7 @@ const Messages = (props: {
     emptyMessage: 'メッセージはまだありません',
     adminLabel: '運営チーム',
     deepLinkQueryParam: 'messageId',
+    entryNoun: 'メッセージ',
   };
 
   const deepLinkState = useConversationEntryDeepLink(

--- a/src/app/(protected)/_components/conversationTypes.ts
+++ b/src/app/(protected)/_components/conversationTypes.ts
@@ -35,4 +35,6 @@ export type ConversationCapabilities = {
   emptyMessage: string;
   adminLabel: string;
   deepLinkQueryParam: ConversationDeepLinkQueryParam;
+  /** エラーメッセージ等で使う、投稿を指す名詞(例: 'メッセージ' / 'コメント')。 */
+  entryNoun: string;
 };

--- a/src/app/(protected)/_components/useConversationActions.ts
+++ b/src/app/(protected)/_components/useConversationActions.ts
@@ -13,11 +13,24 @@ export const useCommentConversationActions = (
   formId: string,
   answerId: string
 ) => {
-  const { sendComment, deleteComment } = useCommentActions(formId, answerId);
+  const { sendComment, deleteComment, updateComment } = useCommentActions(
+    formId,
+    answerId
+  );
 
   return {
     send: async (body: string): Promise<ConversationActionResult> => {
       const result = await sendComment(body);
+      return {
+        success: result.ok,
+        ...(result.forbidden ? { forbidden: true } : {}),
+      };
+    },
+    update: async (
+      entryId: string,
+      body: string
+    ): Promise<ConversationActionResult> => {
+      const result = await updateComment(entryId, body);
       return {
         success: result.ok,
         ...(result.forbidden ? { forbidden: true } : {}),

--- a/src/app/(protected)/admin/answer/[answerId]/_components/AdminAnswerPageView.tsx
+++ b/src/app/(protected)/admin/answer/[answerId]/_components/AdminAnswerPageView.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import { Stack } from '@mui/material';
 
 import StandardAnswerDetails from '@/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetails';
 import StandardAnswerMeta from '@/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerMeta';
 import Messages from '@/app/(protected)/_components/Messages';
 import type { ConversationDeepLinkProps } from '@/app/(protected)/_components/useConversationEntryDeepLink';
+import { useOptionalCurrentUser } from '@/app/_providers/currentUser';
 import type {
   AnswerComment,
   GetAnswerLabelsResponse,
@@ -39,47 +42,51 @@ const AdminAnswerPageView = ({
   data: AdminAnswerPageData;
   messageDeepLink: ConversationDeepLinkProps;
   commentDeepLink: ConversationDeepLinkProps;
-}) => (
-  <Stack
-    direction="column"
-    spacing={4}
-    sx={{
-      width: '100%',
-      justifyContent: 'flex-start',
-      alignItems: 'stretch',
-    }}
-  >
-    <AdminAnswerTitle answer={data.answer} />
-    <StandardAnswerMeta
-      answer={data.answer}
-      labelsSlot={
-        <AdminAnswerLabels labelOptions={data.labels} answer={data.answer} />
-      }
-      extraActions={<AdminAnswerLabelManagementButton />}
-      messageAction={
-        <Messages
-          messages={data.messages}
-          formId={data.answer.form_id}
-          answerId={answerId}
-          title="メッセージ"
-          triggerLabel={`回答者にメッセージを送信 (${data.messages.length})`}
-          deepLink={messageDeepLink}
-        />
-      }
-    />
-    <StandardAnswerDetails
-      answer={data.answer}
-      questions={data.form.questions}
-    />
-    <Comments
-      comments={data.comments}
-      formId={data.answer.form_id}
-      answerId={answerId}
-      currentUserId={undefined}
-      showDeleteButton
-      deepLink={commentDeepLink}
-    />
-  </Stack>
-);
+}) => {
+  const currentUser = useOptionalCurrentUser();
+
+  return (
+    <Stack
+      direction="column"
+      spacing={4}
+      sx={{
+        width: '100%',
+        justifyContent: 'flex-start',
+        alignItems: 'stretch',
+      }}
+    >
+      <AdminAnswerTitle answer={data.answer} />
+      <StandardAnswerMeta
+        answer={data.answer}
+        labelsSlot={
+          <AdminAnswerLabels labelOptions={data.labels} answer={data.answer} />
+        }
+        extraActions={<AdminAnswerLabelManagementButton />}
+        messageAction={
+          <Messages
+            messages={data.messages}
+            formId={data.answer.form_id}
+            answerId={answerId}
+            title="メッセージ"
+            triggerLabel={`回答者にメッセージを送信 (${data.messages.length})`}
+            deepLink={messageDeepLink}
+          />
+        }
+      />
+      <StandardAnswerDetails
+        answer={data.answer}
+        questions={data.form.questions}
+      />
+      <Comments
+        comments={data.comments}
+        formId={data.answer.form_id}
+        answerId={answerId}
+        currentUserId={currentUser?.id}
+        showDeleteButton
+        deepLink={commentDeepLink}
+      />
+    </Stack>
+  );
+};
 
 export default AdminAnswerPageView;

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -47,5 +47,30 @@ export const useCommentActions = (formId: string, answerId: string) => {
     return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
-  return { sendComment, deleteComment };
+  const updateComment = async (
+    commentId: string,
+    content: string
+  ): Promise<CommentActionResult> => {
+    const { data, error, response } = await proxyClient.PATCH(
+      '/api/v1/forms/{form_id}/answers/{answer_id}/comments/{comment_id}',
+      {
+        params: {
+          path: {
+            form_id: formId,
+            answer_id: answerId,
+            comment_id: commentId,
+          },
+        },
+        body: { content },
+      }
+    );
+    const result = handleMutationResponse(response, data, error);
+    if (result.success) {
+      return { ok: true };
+    }
+
+    return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
+  };
+
+  return { sendComment, deleteComment, updateComment };
 };

--- a/tests/component/Comments.test.tsx
+++ b/tests/component/Comments.test.tsx
@@ -1,20 +1,26 @@
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Comments from '@/app/(protected)/_components/Comments';
 import type { AnswerComment } from '@/lib/api-types';
 
-import { renderWithProviders, screen } from './render';
+import { renderWithProviders, screen, waitFor, within } from './render';
 
 const sendCommentMock = vi.hoisted(() => vi.fn());
 const deleteCommentMock = vi.hoisted(() => vi.fn());
+const updateCommentMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/app/(protected)/_components/useConversationActions', () => ({
   useCommentConversationActions: () => ({
     send: sendCommentMock,
+    update: updateCommentMock,
     deleteEntry: deleteCommentMock,
   }),
 }));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 const comments: AnswerComment[] = [
   {
@@ -139,5 +145,257 @@ describe('Comments', () => {
     expect(
       screen.queryByRole('button', { name: 'リンクをコピー' })
     ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * canEdit は「投稿者本人かどうか」だけで決まり、showDeleteButton (管理者向けの
+ * 一律削除許可) には連動しない設計(#838)。この非対称性を、一般ユーザー画面・
+ * 管理者画面の両方に相当する props の組み合わせで確認する。
+ */
+describe('Comments のコメント編集メニュー表示条件 (canEdit)', () => {
+  const openMenuFor = async (
+    user: ReturnType<typeof userEvent.setup>,
+    index: number
+  ) => {
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(`コメント \\(${comments.length}\\)`),
+      })
+    );
+    const menuTriggers = await screen.findAllByRole('button', {
+      name: 'その他の操作',
+    });
+    const trigger = menuTriggers[index];
+    if (trigger === undefined) {
+      throw new Error(
+        `${index} 件目のコメントの操作メニュー button が見つかりません`
+      );
+    }
+    await user.click(trigger);
+  };
+
+  it('一般ユーザー画面相当: 自分が投稿したコメントには編集メニューが表示される', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="user-1"
+        showDeleteButton={undefined}
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await openMenuFor(user, 0);
+    expect(await screen.findByRole('menuitem', { name: '編集' })).toBeVisible();
+  });
+
+  it('一般ユーザー画面相当: 他人が投稿したコメントには編集メニューが表示されない', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="user-1"
+        showDeleteButton={undefined}
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await openMenuFor(user, 1);
+    await screen.findByRole('menuitem', { name: 'リンクをコピー' });
+    expect(
+      screen.queryByRole('menuitem', { name: '編集' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('管理者画面相当: 管理者自身が投稿したコメントには編集メニューが表示される', async () => {
+    const user = userEvent.setup();
+    const adminComments: AnswerComment[] = [
+      {
+        id: 'comment-uuid-admin',
+        content: '対応します',
+        commented_by: {
+          name: 'Admin',
+          role: 'ADMINISTRATOR',
+          uuid: 'admin-1',
+        },
+        timestamp: '2024-01-03T00:00:00Z',
+      },
+    ];
+
+    renderWithProviders(
+      <Comments
+        comments={adminComments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="admin-1"
+        showDeleteButton
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /コメント \(1\)/ }));
+    await user.click(
+      await screen.findByRole('button', { name: 'その他の操作' })
+    );
+    expect(await screen.findByRole('menuitem', { name: '編集' })).toBeVisible();
+  });
+
+  it('管理者画面相当: showDeleteButton により削除メニューは表示されるが、自分以外が投稿したコメントには編集メニューは表示されない(削除許可と編集許可は連動しない)', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="admin-1"
+        showDeleteButton
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await openMenuFor(user, 0);
+    expect(await screen.findByRole('menuitem', { name: '削除' })).toBeVisible();
+    expect(
+      screen.queryByRole('menuitem', { name: '編集' })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('Comments のコメント編集・削除の結果表示', () => {
+  it('自分のコメントを編集して保存すると、update が (commentId, 新しい内容) で呼ばれ、編集フォームが閉じる', async () => {
+    const user = userEvent.setup();
+    updateCommentMock.mockResolvedValue({ success: true });
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="user-1"
+        showDeleteButton={undefined}
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(`コメント \\(${comments.length}\\)`),
+      })
+    );
+    const menuTriggers = await screen.findAllByRole('button', {
+      name: 'その他の操作',
+    });
+    const firstTrigger = menuTriggers[0];
+    if (firstTrigger === undefined) {
+      throw new Error('1 件目のコメントの操作メニュー button が見つかりません');
+    }
+    await user.click(firstTrigger);
+    await user.click(await screen.findByRole('menuitem', { name: '編集' }));
+
+    // 編集用 TextField と drawer 下部の投稿用 TextField の 2 つが同時に
+    // role="textbox" として存在するため、編集対象の初期値で絞り込む。
+    const textbox = await screen.findByDisplayValue('はじめまして');
+    await user.clear(textbox);
+    await user.type(textbox, '内容を更新しました{Enter}');
+
+    expect(updateCommentMock).toHaveBeenCalledWith(
+      'comment-uuid-1',
+      '内容を更新しました'
+    );
+
+    // 保存成功時は編集フォームを閉じる(この component は再取得データを
+    // props で受け取る側であり、表示内容自体の反映は SWR の再検証に委ねる)。
+    const entryContainer = document.getElementById(
+      'conversation-entry-comment-uuid-1'
+    );
+    if (entryContainer === null) {
+      throw new Error('編集対象コメントの container が見つかりません');
+    }
+    await waitFor(() => {
+      expect(
+        within(entryContainer).queryByRole('textbox')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('編集が forbidden で拒否された場合、"コメント" という語で権限エラーを表示する(メッセージ側の固定文言バグの再発防止)', async () => {
+    const user = userEvent.setup();
+    updateCommentMock.mockResolvedValue({ success: false, forbidden: true });
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId="user-1"
+        showDeleteButton={undefined}
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(`コメント \\(${comments.length}\\)`),
+      })
+    );
+    const menuTriggers = await screen.findAllByRole('button', {
+      name: 'その他の操作',
+    });
+    const firstTrigger = menuTriggers[0];
+    if (firstTrigger === undefined) {
+      throw new Error('1 件目のコメントの操作メニュー button が見つかりません');
+    }
+    await user.click(firstTrigger);
+    await user.click(await screen.findByRole('menuitem', { name: '編集' }));
+
+    const textbox = await screen.findByDisplayValue('はじめまして');
+    await user.type(textbox, '更新{Enter}');
+
+    expect(
+      await screen.findByText('このコメントを編集する権限がありません。')
+    ).toBeVisible();
+  });
+
+  it('削除が forbidden で拒否された場合、"コメント" という語で権限エラーを表示する(既存の固定文言バグの再発防止)', async () => {
+    const user = userEvent.setup();
+    deleteCommentMock.mockResolvedValue({ success: false, forbidden: true });
+
+    renderWithProviders(
+      <Comments
+        comments={comments}
+        formId="form-1"
+        answerId="answer-1"
+        currentUserId={undefined}
+        showDeleteButton
+        deepLink={{ entryId: undefined, onClose: vi.fn() }}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(`コメント \\(${comments.length}\\)`),
+      })
+    );
+    const menuTriggers = await screen.findAllByRole('button', {
+      name: 'その他の操作',
+    });
+    const firstTrigger = menuTriggers[0];
+    if (firstTrigger === undefined) {
+      throw new Error('1 件目のコメントの操作メニュー button が見つかりません');
+    }
+    await user.click(firstTrigger);
+    await user.click(await screen.findByRole('menuitem', { name: '削除' }));
+
+    expect(
+      await screen.findByText('このコメントを削除する権限がありません。')
+    ).toBeVisible();
   });
 });

--- a/tests/component/ConversationSurface.test.tsx
+++ b/tests/component/ConversationSurface.test.tsx
@@ -28,6 +28,7 @@ const capabilities: ConversationCapabilities = {
   emptyMessage: '投稿はまだありません',
   adminLabel: '運営',
   deepLinkQueryParam: 'commentId',
+  entryNoun: 'コメント',
 };
 
 describe('ConversationSurface の直リンク自動オープン', () => {


### PR DESCRIPTION
## 概要
- Issue #838 の対応。コメントは新規作成・削除は既に実装済みだったが、編集だけが未実装だった。バックエンドの PATCH エンドポイント(`.../comments/{comment_id}`)は既に生成済み・未使用の状態だったため、フロント側の配線を追加した。
- `canEdit`(編集ボタンの表示条件)は「投稿者本人のみ」に限定した。削除は運営に一律許可する `canDelete` とは意図的に非対称な設計にしている(管理者であっても他人のコメント本文を書き換えられるべきではないと判断)。
- 管理者画面 (`AdminAnswerPageView.tsx`) では従来 `currentUserId` を渡していなかったため、自分の投稿を編集できるよう `useOptionalCurrentUser()` で現在ユーザーIDを取得する変更も含む。
- 副次的に、削除・編集の権限エラー(403)メッセージが常に「メッセージ」固定文言だったバグを修正し、コメント/メッセージで正しく文言を出し分けるようにした(`ConversationCapabilities.entryNoun` を追加)。
- 影響範囲: `Comments.tsx`, `Messages.tsx`, `ConversationEntry.tsx`, `conversationTypes.ts`, `useConversationActions.ts`, `useCommentActions.ts`, `AdminAnswerPageView.tsx`。共通コンポーネント (`ConversationEntryEditor.tsx` 等) 自体の編集フォームロジックは変更していない。

## 確認事項
- `pnpm lint` / `pnpm type-check` / `pnpm test:unit`(60 tests) / `pnpm test:component`(50 tests) がすべて通ることを確認。
- `tests/component/Comments.test.tsx` に、canEdit の4分岐(一般ユーザー×自分/他人、管理者×自分/他人)、編集保存の成功パス、編集・削除それぞれの forbidden 時のエラー文言(「コメント」表記)を検証するテストを追加。
- レビューで、`useOptionalCurrentUser()` から取得する ID がバックエンドの `comment.commented_by.uuid` と同じ識別子空間であること、`currentUserId` が `undefined` の場合は安全側(編集不可)に倒れることを確認済み。

## 補足
- メッセージ側 (`Messages.tsx`) の forbidden 文言を検証する自動テストは既存に存在しない(`Messages.test.tsx` 自体が無い)。今回の変更でも従来通り「メッセージ」表記になることは確認済みだが、テストとしては未整備。今回のスコープでは新規テストファイルの追加は見送った。

🤖 Generated with Claude Code