### PR TITLE
fix: フォーム送信ボタンの連打による多重送信を防止する

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/DiscordNotificationSettings.tsx
@@ -26,7 +26,11 @@ const DiscordNotificationSettings = (props: {
   currentSettings: GetUserNotificationSettingsResponse;
   userId: string;
 }) => {
-  const { handleSubmit, control } = useForm<NotificationSettingsFormValues>({
+  const {
+    handleSubmit,
+    control,
+    formState: { isSubmitting },
+  } = useForm<NotificationSettingsFormValues>({
     defaultValues: fromNotificationSettingsResponseToFormValues(
       props.currentSettings
     ),
@@ -81,6 +85,7 @@ const DiscordNotificationSettings = (props: {
             endIcon={<SaveAltIcon />}
             type="submit"
             sx={{ alignSelf: 'flex-start' }}
+            disabled={isSubmitting}
           >
             保存
           </Button>

--- a/src/app/(protected)/_components/ConversationComposer.tsx
+++ b/src/app/(protected)/_components/ConversationComposer.tsx
@@ -77,6 +77,7 @@ const ConversationComposer = ({
           <TextField
             {...register('body')}
             helperText={helperText}
+            disabled={isSubmitting}
             sx={
               textFieldSx
                 ? [{ width: '100%' }, textFieldSx].flat()

--- a/src/app/(protected)/_components/ConversationComposer.tsx
+++ b/src/app/(protected)/_components/ConversationComposer.tsx
@@ -36,7 +36,12 @@ const ConversationComposer = ({
   onSend,
   textFieldSx,
 }: Props) => {
-  const { handleSubmit, register, reset } = useForm<ComposerForm>();
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<ComposerForm>();
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -84,6 +89,9 @@ const ConversationComposer = ({
                 !event.nativeEvent.isComposing
               ) {
                 event.preventDefault();
+                if (isSubmitting) {
+                  return;
+                }
                 void handleSubmit(onSubmit)();
               }
             }}
@@ -92,7 +100,11 @@ const ConversationComposer = ({
                 inputProps: { placeholder: label },
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton type="submit" aria-label="送信">
+                    <IconButton
+                      type="submit"
+                      aria-label="送信"
+                      disabled={isSubmitting}
+                    >
                       <SendIcon />
                     </IconButton>
                   </InputAdornment>

--- a/src/app/(protected)/_components/CreateLabelField.tsx
+++ b/src/app/(protected)/_components/CreateLabelField.tsx
@@ -59,7 +59,11 @@ const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
         新規作成
       </Button>
 
-      <Dialog open={dialogOpen} onClose={handleClose} fullWidth>
+      <Dialog
+        open={dialogOpen}
+        onClose={isSubmitting ? undefined : handleClose}
+        fullWidth
+      >
         <DialogTitle>新規ラベル作成</DialogTitle>
         <form
           onSubmit={(e) => {

--- a/src/app/(protected)/_components/CreateLabelField.tsx
+++ b/src/app/(protected)/_components/CreateLabelField.tsx
@@ -23,7 +23,12 @@ const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
 
-  const { handleSubmit, register, reset } = useForm<CreateLabelSchema>();
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<CreateLabelSchema>();
   const { createLabel } = useLabelCRUD(props.labelType);
 
   const handleOpen = () => {
@@ -72,8 +77,10 @@ const CreateLabelField = (props: { labelType: 'answers' | 'forms' }) => {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose}>キャンセル</Button>
-            <Button type="submit" variant="contained">
+            <Button onClick={handleClose} disabled={isSubmitting}>
+              キャンセル
+            </Button>
+            <Button type="submit" variant="contained" disabled={isSubmitting}>
               作成
             </Button>
           </DialogActions>

--- a/src/app/(protected)/_components/Labels.tsx
+++ b/src/app/(protected)/_components/Labels.tsx
@@ -22,7 +22,12 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedLabel, setSelectedLabel] = useState<Label | null>(null);
 
-  const { handleSubmit, register, reset } = useForm<NameEditFormValues>();
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<NameEditFormValues>();
 
   const { deleteLabel, editLabel: editLabelAction } = useLabelCRUD(
     props.labelType
@@ -103,6 +108,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
         title="ラベルを編集"
         nameLabel="ラベル名"
         register={register}
+        isSubmitting={isSubmitting}
         onClose={handleCloseEdit}
         onSubmit={(e) => {
           void handleSubmit(onEdit)(e);

--- a/src/app/(protected)/_components/NameEditDialog.tsx
+++ b/src/app/(protected)/_components/NameEditDialog.tsx
@@ -22,6 +22,7 @@ const NameEditDialog = (props: {
   title: ReactNode;
   nameLabel: string;
   register: UseFormRegister<NameEditFormValues>;
+  isSubmitting: boolean;
   onClose: () => void;
   onSubmit: NonNullable<ComponentPropsWithoutRef<'form'>['onSubmit']>;
 }) => (
@@ -40,8 +41,10 @@ const NameEditDialog = (props: {
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose}>キャンセル</Button>
-        <Button type="submit" variant="contained">
+        <Button onClick={props.onClose} disabled={props.isSubmitting}>
+          キャンセル
+        </Button>
+        <Button type="submit" variant="contained" disabled={props.isSubmitting}>
           保存
         </Button>
       </DialogActions>

--- a/src/app/(protected)/_components/NameEditDialog.tsx
+++ b/src/app/(protected)/_components/NameEditDialog.tsx
@@ -26,7 +26,11 @@ const NameEditDialog = (props: {
   onClose: () => void;
   onSubmit: NonNullable<ComponentPropsWithoutRef<'form'>['onSubmit']>;
 }) => (
-  <Dialog open={props.open} onClose={props.onClose} fullWidth>
+  <Dialog
+    open={props.open}
+    onClose={props.isSubmitting ? undefined : props.onClose}
+    fullWidth
+  >
     <DialogTitle>{props.title}</DialogTitle>
     <Box component="form" onSubmit={props.onSubmit}>
       <DialogContent>

--- a/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -39,7 +39,7 @@ const FormEditForm = (props: {
     register,
     setValue,
     setError,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm<FormEditorValues>({
     mode: 'onSubmit',
     reValidateMode: 'onBlur',
@@ -114,7 +114,12 @@ const FormEditForm = (props: {
           {isSubmitted && (
             <Alert severity="success">フォームの編集に成功しました。</Alert>
           )}
-          <Button type="submit" variant="contained" endIcon={<SendIcon />}>
+          <Button
+            type="submit"
+            variant="contained"
+            endIcon={<SendIcon />}
+            disabled={isSubmitting}
+          >
             設定内容を保存
           </Button>
         </Stack>

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -29,7 +29,12 @@ const Groups = (props: {
   );
   const [detailGroup, setDetailGroup] = useState<UserGroupSchema | null>(null);
 
-  const { handleSubmit, register, reset } = useForm<NameEditFormValues>();
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<NameEditFormValues>();
 
   const { deleteGroup, editGroup } = useUserGroupCRUD();
 
@@ -109,6 +114,7 @@ const Groups = (props: {
         title="グループを編集"
         nameLabel="グループ名"
         register={register}
+        isSubmitting={isSubmitting}
         onClose={handleCloseEdit}
         onSubmit={(e) => {
           void handleSubmit(onEdit)(e);

--- a/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -44,7 +44,7 @@ const AnswerSubmissionForm = ({
     register,
     handleSubmit,
     reset,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm<AnswerFormInput>();
 
   const handleAnswerSubmit = async (data: AnswerFormInput) => {
@@ -150,6 +150,7 @@ const AnswerSubmissionForm = ({
               variant="contained"
               size="large"
               endIcon={<SendIcon />}
+              disabled={isSubmitting}
             >
               送信
             </Button>


### PR DESCRIPTION
## 概要
- issue #846 の通り、回答送信ボタンなど各種フォームの送信ボタンが送信中も有効なままで、連打すると多重送信されてしまう問題を修正
- react-hook-form の `formState.isSubmitting` を各ボタンの `disabled` に反映させ、送信中はクリック不可にした
- issue コメントの「ほかにもあれば一緒に直してよい」に従い、同じパターンで連打防止が抜けていた箇所もまとめて修正した
  - 回答送信フォーム (`AnswerSubmissionForm`)
  - フォーム編集の保存ボタン (`FormEditForm`)
  - 会話・コメントの送信ボタン／Enter送信 (`ConversationComposer`)
  - ラベル・グループの名称編集ダイアログ (`NameEditDialog` / `Labels` / `Groups`)
  - Discord通知設定の保存ボタン (`DiscordNotificationSettings`)
  - ラベル新規作成ダイアログ (`CreateLabelField`)

## 確認事項
- `pnpm type-check` / `pnpm lint` が通ることを確認
- pre-commit / pre-push フックの lint・type-check・fmt・unit-test（60件）がすべて通過
- 既存の `FormCreateForm` / `CreateGroupField` で使われている `formState.isSubmitting` によるパターンに合わせて実装したため、実装方針としての一貫性がある

## 補足
- ブラウザでの実クリック確認は未実施（今回の変更は既存の `useForm` の `isSubmitting` を `disabled` に反映するのみで、副作用のあるロジック変更は含まれないため、型・lintと既存ユニットテストの通過をもって妥当と判断）

🤖 Generated with Claude Code