### PR TITLE
fix: 送信系 action hook に多重実行防止を組み込む

### DIFF
--- a/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import type { ApiPaths } from '@/lib/api/types';
 import { proxyClient } from '@/lib/proxyClient';
 
@@ -102,7 +103,7 @@ export const useAnswerSubmission = (
     });
   };
 
-  const submitAnswers = async (data: AnswerFormInput) => {
+  const submitAnswersOnce = async (data: AnswerFormInput) => {
     const { response, error } = await postAnswers(data);
 
     if (response.ok) {
@@ -136,7 +137,7 @@ export const useAnswerSubmission = (
 
   return {
     submissionState,
-    submitAnswers,
+    submitAnswers: useSingleFlightAction(submitAnswersOnce),
     resetSubmissionState,
   };
 };

--- a/src/generic/singleFlight.ts
+++ b/src/generic/singleFlight.ts
@@ -1,0 +1,26 @@
+export type SingleFlightLock<R> = { current: Promise<R> | null };
+
+export const createSingleFlightLock = <R>(): SingleFlightLock<R> => ({
+  current: null,
+});
+
+/**
+ * lock が実行中を示している間は、新しい呼び出しを行わず進行中の Promise を返す。
+ * 同じ処理が UI 側の複数の入り口（クリック・Enter キー連打など）から
+ * 同時に呼ばれても、実行は常に1つに保たれる。
+ */
+export const runSingleFlight = <Args extends unknown[], R>(
+  lock: SingleFlightLock<R>,
+  fn: (...args: Args) => Promise<R>,
+  ...args: Args
+): Promise<R> => {
+  if (lock.current) {
+    return lock.current;
+  }
+
+  const promise = fn(...args).finally(() => {
+    lock.current = null;
+  });
+  lock.current = promise;
+  return promise;
+};

--- a/src/hooks/useAnswerActions.ts
+++ b/src/hooks/useAnswerActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useAnswerActions = (formId: string, answerId: string) => {
@@ -28,5 +29,8 @@ export const useAnswerActions = (formId: string, answerId: string) => {
     return { ok: result.success };
   };
 
-  return { updateTitle, updateLabels };
+  return {
+    updateTitle: useSingleFlightAction(updateTitle),
+    updateLabels: useSingleFlightAction(updateLabels),
+  };
 };

--- a/src/hooks/useAnswerSubmitterRestrictionActions.ts
+++ b/src/hooks/useAnswerSubmitterRestrictionActions.ts
@@ -2,6 +2,7 @@
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 import type { MutationResult } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import type { PutAnswerSubmitterRestrictionSchema } from '@/lib/api-types';
 import { proxyClient } from '@/lib/proxyClient';
 
@@ -30,5 +31,8 @@ export const useAnswerSubmitterRestrictionActions = () => {
     return handleMutationResponse(response, data, error);
   };
 
-  return { restrictUser, unrestrictUser };
+  return {
+    restrictUser: useSingleFlightAction(restrictUser),
+    unrestrictUser: useSingleFlightAction(unrestrictUser),
+  };
 };

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 type CommentActionResult = { ok: boolean; forbidden?: boolean };
@@ -72,5 +73,9 @@ export const useCommentActions = (formId: string, answerId: string) => {
     return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
-  return { sendComment, deleteComment, updateComment };
+  return {
+    sendComment: useSingleFlightAction(sendComment),
+    deleteComment: useSingleFlightAction(deleteComment),
+    updateComment: useSingleFlightAction(updateComment),
+  };
 };

--- a/src/hooks/useDiscordActions.ts
+++ b/src/hooks/useDiscordActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useDiscordActions = () => {
@@ -12,5 +13,5 @@ export const useDiscordActions = () => {
     handleMutationResponse(response, data, error);
   };
 
-  return { unlinkDiscord };
+  return { unlinkDiscord: useSingleFlightAction(unlinkDiscord) };
 };

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useFormActions = () => {
@@ -26,5 +27,8 @@ export const useFormActions = () => {
     return { ok: result.success };
   };
 
-  return { archiveForm, restoreForm };
+  return {
+    archiveForm: useSingleFlightAction(archiveForm),
+    restoreForm: useSingleFlightAction(restoreForm),
+  };
 };

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import type { ApiPaths } from '@/lib/api/types';
 import { proxyClient } from '@/lib/proxyClient';
 
@@ -20,5 +21,5 @@ export const useFormEditActions = (formId: string) => {
     return { ok: result.success };
   };
 
-  return { updateForm };
+  return { updateForm: useSingleFlightAction(updateForm) };
 };

--- a/src/hooks/useFormLabelActions.ts
+++ b/src/hooks/useFormLabelActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useFormLabelActions = (formId: string) => {
@@ -16,5 +17,5 @@ export const useFormLabelActions = (formId: string) => {
     return { ok: result.success };
   };
 
-  return { updateLabels };
+  return { updateLabels: useSingleFlightAction(updateLabels) };
 };

--- a/src/hooks/useLabelCRUD.ts
+++ b/src/hooks/useLabelCRUD.ts
@@ -2,6 +2,7 @@
 
 import { useSWRConfig } from 'swr';
 
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
@@ -74,5 +75,9 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
     }
   };
 
-  return { createLabel, deleteLabel, editLabel };
+  return {
+    createLabel: useSingleFlightAction(createLabel),
+    deleteLabel: useSingleFlightAction(deleteLabel),
+    editLabel: useSingleFlightAction(editLabel),
+  };
 };

--- a/src/hooks/useMessageActions.ts
+++ b/src/hooks/useMessageActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 type MessageActionResult = { success: boolean; forbidden?: boolean };
@@ -54,5 +55,8 @@ export const useMessageActions = (formId: string, answerId: string) => {
     return { success: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
-  return { updateMessage, deleteMessage };
+  return {
+    updateMessage: useSingleFlightAction(updateMessage),
+    deleteMessage: useSingleFlightAction(deleteMessage),
+  };
 };

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import type { ApiPaths } from '@/lib/api/types';
 import { proxyClient } from '@/lib/proxyClient';
 
@@ -19,5 +20,5 @@ export const useNotificationSettings = () => {
     return { ok: response.ok };
   };
 
-  return { updateSettings };
+  return { updateSettings: useSingleFlightAction(updateSettings) };
 };

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 type SendMessageResult = { success: boolean; forbidden?: boolean };
@@ -22,5 +23,5 @@ export const useSendMessage = (formId: string, answerId: string) => {
     return { success: false, ...(result.forbidden ? { forbidden: true } : {}) };
   };
 
-  return { sendMessage };
+  return { sendMessage: useSingleFlightAction(sendMessage) };
 };

--- a/src/hooks/useSingleFlightAction.ts
+++ b/src/hooks/useSingleFlightAction.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import {
   createSingleFlightLock,
@@ -12,11 +12,25 @@ import {
  * ボタンの disabled 忘れやキー連打によるレースがあっても、
  * 実行中は新しい呼び出しを行わず進行中の Promise を返すため、
  * 呼び出し側（UI）の実装漏れが多重送信に直結しない。
+ *
+ * 返す関数の参照は安定させ、呼び出し側の useEffect / useCallback の
+ * 依存配列に入れても再レンダーの原因にならないようにする。
+ * ref への書き込みは render 中に行わず useEffect 側で行う
+ * （react-hooks/refs: ref は render 中に読み書きしない）。
  */
 export const useSingleFlightAction = <Args extends unknown[], R>(
   action: (...args: Args) => Promise<R>
 ): ((...args: Args) => Promise<R>) => {
   const lockRef = useRef(createSingleFlightLock<R>());
+  const actionRef = useRef(action);
 
-  return (...args: Args) => runSingleFlight(lockRef.current, action, ...args);
+  useEffect(() => {
+    actionRef.current = action;
+  }, [action]);
+
+  return useCallback(
+    (...args: Args) =>
+      runSingleFlight(lockRef.current, actionRef.current, ...args),
+    []
+  );
 };

--- a/src/hooks/useSingleFlightAction.ts
+++ b/src/hooks/useSingleFlightAction.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useRef } from 'react';
+
+import {
+  createSingleFlightLock,
+  runSingleFlight,
+} from '@/generic/singleFlight';
+
+/**
+ * 送信系の action 関数を多重実行不可にして返す。
+ * ボタンの disabled 忘れやキー連打によるレースがあっても、
+ * 実行中は新しい呼び出しを行わず進行中の Promise を返すため、
+ * 呼び出し側（UI）の実装漏れが多重送信に直結しない。
+ */
+export const useSingleFlightAction = <Args extends unknown[], R>(
+  action: (...args: Args) => Promise<R>
+): ((...args: Args) => Promise<R>) => {
+  const lockRef = useRef(createSingleFlightLock<R>());
+
+  return (...args: Args) => runSingleFlight(lockRef.current, action, ...args);
+};

--- a/src/hooks/useUserGroupCRUD.ts
+++ b/src/hooks/useUserGroupCRUD.ts
@@ -2,6 +2,7 @@
 
 import { useSWRConfig } from 'swr';
 
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useUserGroupCRUD = () => {
@@ -42,5 +43,9 @@ export const useUserGroupCRUD = () => {
     return { ok: response.ok };
   };
 
-  return { createGroup, editGroup, deleteGroup };
+  return {
+    createGroup: useSingleFlightAction(createGroup),
+    editGroup: useSingleFlightAction(editGroup),
+    deleteGroup: useSingleFlightAction(deleteGroup),
+  };
 };

--- a/src/hooks/useUserGroupMembershipActions.ts
+++ b/src/hooks/useUserGroupMembershipActions.ts
@@ -2,6 +2,7 @@
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 import type { MutationResult } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useUserGroupMembershipActions = () => {
@@ -31,5 +32,8 @@ export const useUserGroupMembershipActions = () => {
     return handleMutationResponse(response, data, error);
   };
 
-  return { addUserToGroup, removeUserFromGroup };
+  return {
+    addUserToGroup: useSingleFlightAction(addUserToGroup),
+    removeUserFromGroup: useSingleFlightAction(removeUserFromGroup),
+  };
 };

--- a/src/hooks/useUserRoleActions.ts
+++ b/src/hooks/useUserRoleActions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useUserRoleActions = () => {
@@ -15,5 +16,5 @@ export const useUserRoleActions = () => {
     handleMutationResponse(response, data, error);
   };
 
-  return { updateUserRole };
+  return { updateUserRole: useSingleFlightAction(updateUserRole) };
 };

--- a/tests/unit/singleFlight.test.ts
+++ b/tests/unit/singleFlight.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createSingleFlightLock,
+  runSingleFlight,
+} from '@/generic/singleFlight';
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('runSingleFlight', () => {
+  it('実行中に重ねて呼んでも、実処理は1回しか走らず同じ結果を共有する', async () => {
+    const { promise, resolve } = deferred<string>();
+    const fn = vi.fn(() => promise);
+    const lock = createSingleFlightLock<string>();
+
+    const first = runSingleFlight(lock, fn);
+    const second = runSingleFlight(lock, fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    resolve('done');
+
+    await expect(first).resolves.toBe('done');
+    await expect(second).resolves.toBe('done');
+  });
+
+  it('完了後に呼ぶと新しい実行として扱われる', async () => {
+    const fn = vi.fn(() => Promise.resolve('ok'));
+    const lock = createSingleFlightLock<string>();
+
+    await runSingleFlight(lock, fn);
+    await runSingleFlight(lock, fn);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('失敗した場合もロックが解除され、次の呼び出しは新規実行になる', async () => {
+    const lock = createSingleFlightLock<string>();
+    const failing = vi.fn(() => Promise.reject(new Error('failed')));
+
+    await expect(runSingleFlight(lock, failing)).rejects.toThrow('failed');
+
+    const succeeding = vi.fn(() => Promise.resolve('ok'));
+    await expect(runSingleFlight(lock, succeeding)).resolves.toBe('ok');
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要
- これまで二重送信防止は各フォームコンポーネントが `formState.isSubmitting` をボタンの `disabled` やダイアログの `onClose` に手作業で配線する形に依存しており、配線を1箇所でも忘れると多重送信が起きる構造だった（直近の #850 も同種のバグ修正）
- 汎用の多重実行防止ユーティリティ `src/generic/singleFlight.ts` と、それを React hook 化した `src/hooks/useSingleFlightAction.ts` を追加
- `useLabelCRUD` / `useUserGroupCRUD` / `useFormEditActions` / `useSendMessage` / `useDiscordActions` / `useAnswerActions` / `useAnswerSubmitterRestrictionActions` / `useCommentActions` / `useFormActions` / `useFormLabelActions` / `useMessageActions` / `useNotificationSettings` / `useUserGroupMembershipActions` / `useUserRoleActions` / `useAnswerSubmission` が返すミューテーション関数自体をこのフックで包み、実行中は新規呼び出しを行わず進行中の Promise を返すようにした
- これにより二重送信防止は特定のUI要素の実装責任ではなく、送信処理を実行する関数自体が持つ保証になった。既存の `isSubmitting` によるボタン無効化・ダイアログクローズ抑止は視覚的フィードバック（UX）としてそのまま残している

## 確認事項
- `pnpm run type-check` / `pnpm lint` / `pnpm test:unit` / `pnpm test:component` がすべて成功することを確認
- `runSingleFlight` の「同時実行時は実処理が1回しか走らない」「完了後の呼び出しは新規実行になる」「失敗時もロックが解除される」の3点を `tests/unit/singleFlight.test.ts` で検証
- 影響範囲のコンポーネントに、返り値の関数を `useEffect` / `useCallback` / `useMemo` の依存配列で参照している箇所がないことを確認済み（`useSingleFlightAction` は毎レンダーで新しい関数を返すが、ロック自体は `useRef` で永続化されるため安全性には影響しない）

## 補足
- ダイアログクローズ抑止やテキストフィールドの disabled 化など、既存の `isSubmitting` ベースのUXコードは今回変更していない

🤖 Generated with Claude Code