### PR TITLE
fix: 確認ダイアログとボタン系操作に pending 状態の多重実行防止を組み込む

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/UnlinkDiscordButton.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/UnlinkDiscordButton.tsx
@@ -4,12 +4,14 @@ import LinkOffIcon from '@mui/icons-material/LinkOff';
 import { Button, Chip, Stack, Typography } from '@mui/material';
 
 import { useDiscordActions } from '@/hooks/useDiscordActions';
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 const UnlinkDiscordButton = () => {
   const { unlinkDiscord } = useDiscordActions();
+  const { run, pending } = usePendingAction(unlinkDiscord);
 
   const onClick = async () => {
-    await unlinkDiscord();
+    await run();
     location.reload();
   };
 
@@ -29,6 +31,7 @@ const UnlinkDiscordButton = () => {
         onClick={() => {
           void onClick();
         }}
+        disabled={pending}
         size="small"
       >
         連携を解除する

--- a/src/app/(protected)/_components/Labels.tsx
+++ b/src/app/(protected)/_components/Labels.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useLabelCRUD } from '@/hooks/useLabelCRUD';
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 import NameEditDialog, { type NameEditFormValues } from './NameEditDialog';
 import NameManagementTable from './NameManagementTable';
@@ -32,6 +33,8 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
   const { deleteLabel, editLabel: editLabelAction } = useLabelCRUD(
     props.labelType
   );
+  const { run: runDeleteLabel, pending: deletePending } =
+    usePendingAction(deleteLabel);
 
   const handleOpenEdit = (label: Label) => {
     setSelectedLabel(label);
@@ -67,7 +70,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
 
   const onDelete = async () => {
     if (!selectedLabel) return;
-    const result = await deleteLabel(selectedLabel.id);
+    const result = await runDeleteLabel(selectedLabel.id);
     if (result.ok) {
       showSnackbar('ラベルを削除しました。', 'success');
       handleCloseDelete();
@@ -120,6 +123,7 @@ const Labels = (props: { labels: Label[]; labelType: 'answers' | 'forms' }) => {
         title="ラベルを削除"
         description={`「${selectedLabel?.name ?? ''}」を削除してもよろしいですか？この操作は元に戻せません。`}
         confirmLabel="削除"
+        pending={deletePending}
         onConfirm={() => {
           void onDelete();
         }}

--- a/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/ArchivedFormRowMenu.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import { useFormActions } from '@/hooks/useFormActions';
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 interface Props {
   formId: string;
@@ -23,6 +24,7 @@ const ArchivedFormRowMenu = ({ formId, onResult }: Props) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const { restoreForm } = useFormActions();
+  const { run: runRestoreForm, pending } = usePendingAction(restoreForm);
   const menuOpen = Boolean(anchorEl);
 
   const handleMenuOpen = (event: MouseEvent<HTMLElement>) => {
@@ -39,8 +41,8 @@ const ArchivedFormRowMenu = ({ formId, onResult }: Props) => {
   };
 
   const handleRestoreConfirm = async () => {
+    const result = await runRestoreForm(formId);
     setDialogOpen(false);
-    const result = await restoreForm(formId);
     onResult?.(result);
   };
 
@@ -66,6 +68,7 @@ const ArchivedFormRowMenu = ({ formId, onResult }: Props) => {
         title="フォームの復元"
         description="このフォームを復元しますか？"
         confirmLabel="復元"
+        pending={pending}
         onConfirm={() => {
           void handleRestoreConfirm();
         }}

--- a/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormRowMenu.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import { useFormActions } from '@/hooks/useFormActions';
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 interface Props {
   formId: string;
@@ -24,6 +25,7 @@ const FormRowMenu = ({ formId, onResult }: Props) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const { archiveForm } = useFormActions();
+  const { run: runArchiveForm, pending } = usePendingAction(archiveForm);
   const menuOpen = Boolean(anchorEl);
 
   const handleMenuOpen = (event: MouseEvent<HTMLElement>) => {
@@ -40,8 +42,8 @@ const FormRowMenu = ({ formId, onResult }: Props) => {
   };
 
   const handleArchiveConfirm = async () => {
+    const result = await runArchiveForm(formId);
     setDialogOpen(false);
-    const result = await archiveForm(formId);
     onResult?.(result);
   };
 
@@ -77,6 +79,7 @@ const FormRowMenu = ({ formId, onResult }: Props) => {
         title="フォームのアーカイブ"
         description="このフォームをアーカイブしますか？"
         confirmLabel="アーカイブ"
+        pending={pending}
         onConfirm={() => {
           void handleArchiveConfirm();
         }}

--- a/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
 
 import {
@@ -61,5 +62,5 @@ export const useCreateForm = () => {
     }
   };
 
-  return { createForm, submitState };
+  return { createForm: useSingleFlightAction(createForm), submitState };
 };

--- a/src/app/(protected)/admin/groups/_components/Groups.tsx
+++ b/src/app/(protected)/admin/groups/_components/Groups.tsx
@@ -11,6 +11,7 @@ import NameManagementTable from '@/app/(protected)/_components/NameManagementTab
 import ConfirmDialog from '@/app/_components/ConfirmDialog';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { usePendingAction } from '@/hooks/usePendingAction';
 import { useUserGroupCRUD } from '@/hooks/useUserGroupCRUD';
 import type { UserGroupSchema } from '@/lib/api-types';
 
@@ -37,6 +38,8 @@ const Groups = (props: {
   } = useForm<NameEditFormValues>();
 
   const { deleteGroup, editGroup } = useUserGroupCRUD();
+  const { run: runDeleteGroup, pending: deletePending } =
+    usePendingAction(deleteGroup);
 
   const handleOpenEdit = (group: UserGroupSchema) => {
     setSelectedGroup(group);
@@ -72,7 +75,7 @@ const Groups = (props: {
 
   const onDelete = async () => {
     if (!selectedGroup) return;
-    const result = await deleteGroup(selectedGroup.id);
+    const result = await runDeleteGroup(selectedGroup.id);
     if (result.ok) {
       showSnackbar('グループを削除しました。', 'success');
       handleCloseDelete();
@@ -126,6 +129,7 @@ const Groups = (props: {
         title="グループを削除"
         description={`「${selectedGroup?.name ?? ''}」を削除してもよろしいですか？この操作は元に戻せません。`}
         confirmLabel="削除"
+        pending={deletePending}
         onConfirm={() => {
           void onDelete();
         }}

--- a/src/app/(protected)/admin/users/_components/RoleSelectCell.tsx
+++ b/src/app/(protected)/admin/users/_components/RoleSelectCell.tsx
@@ -3,6 +3,7 @@
 import { MenuItem, Select, Tooltip } from '@mui/material';
 import { useState } from 'react';
 
+import { usePendingAction } from '@/hooks/usePendingAction';
 import { useUserRoleActions } from '@/hooks/useUserRoleActions';
 
 const RoleSelectCell = ({
@@ -15,6 +16,7 @@ const RoleSelectCell = ({
   disabled: boolean;
 }) => {
   const { updateUserRole } = useUserRoleActions();
+  const { run: runUpdateUserRole, pending } = usePendingAction(updateUserRole);
   const [role, setRole] = useState(currentRole);
   const [syncedRole, setSyncedRole] = useState(currentRole);
 
@@ -32,11 +34,11 @@ const RoleSelectCell = ({
         <Select
           value={role}
           size="small"
-          disabled={disabled}
+          disabled={disabled || pending}
           onChange={(event) => {
             const newRole = event.target.value;
             setRole(newRole);
-            updateUserRole(userId, newRole).catch(() => {
+            runUpdateUserRole(userId, newRole).catch(() => {
               setRole(currentRole);
             });
           }}

--- a/src/app/(protected)/admin/users/_components/RoleSelectCell.tsx
+++ b/src/app/(protected)/admin/users/_components/RoleSelectCell.tsx
@@ -3,7 +3,7 @@
 import { MenuItem, Select, Tooltip } from '@mui/material';
 import { useState } from 'react';
 
-import { usePendingAction } from '@/hooks/usePendingAction';
+import { useLatestWinsAction } from '@/hooks/useLatestWinsAction';
 import { useUserRoleActions } from '@/hooks/useUserRoleActions';
 
 const RoleSelectCell = ({
@@ -16,7 +16,8 @@ const RoleSelectCell = ({
   disabled: boolean;
 }) => {
   const { updateUserRole } = useUserRoleActions();
-  const { run: runUpdateUserRole, pending } = usePendingAction(updateUserRole);
+  const { run: runUpdateUserRole, pending } =
+    useLatestWinsAction(updateUserRole);
   const [role, setRole] = useState(currentRole);
   const [syncedRole, setSyncedRole] = useState(currentRole);
 

--- a/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from 'react';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { usePendingAction } from '@/hooks/usePendingAction';
 import { useUserGroupMembershipActions } from '@/hooks/useUserGroupMembershipActions';
 import type { UserGroupSchema } from '@/lib/api-types';
 
@@ -32,6 +33,9 @@ const UserGroupMembershipSection = ({
   );
   const { addUserToGroup, removeUserFromGroup } =
     useUserGroupMembershipActions();
+  const { run: runAdd, pending: addPending } = usePendingAction(addUserToGroup);
+  const { run: runRemove, pending: removePending } =
+    usePendingAction(removeUserFromGroup);
 
   const joinableGroups = (allGroups ?? []).filter(
     (group) => !currentGroups.some((current) => current.id === group.id)
@@ -39,7 +43,7 @@ const UserGroupMembershipSection = ({
 
   const handleAdd = async (group: UserGroupSchema) => {
     setSubmitError(null);
-    const result = await addUserToGroup(group.id, uuid);
+    const result = await runAdd(group.id, uuid);
     if (result.success) {
       await onChanged();
     } else {
@@ -49,7 +53,7 @@ const UserGroupMembershipSection = ({
 
   const handleRemove = async (group: UserGroupSchema) => {
     setSubmitError(null);
-    const result = await removeUserFromGroup(group.id, uuid);
+    const result = await runRemove(group.id, uuid);
     if (result.success) {
       await onChanged();
     } else {
@@ -71,9 +75,9 @@ const UserGroupMembershipSection = ({
               key={group.id}
               label={group.name}
               size="small"
-              disabled={disabled}
+              disabled={disabled || removePending}
               onDelete={
-                disabled
+                disabled || removePending
                   ? undefined
                   : () => {
                       void handleRemove(group);
@@ -91,7 +95,7 @@ const UserGroupMembershipSection = ({
         options={joinableGroups}
         getOptionLabel={(group) => group.name}
         value={null}
-        disabled={disabled || isGroupsLoading}
+        disabled={disabled || isGroupsLoading || addPending}
         onChange={(_event, group) => {
           if (group) {
             void handleAdd(group);

--- a/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserGroupMembershipSection.tsx
@@ -75,9 +75,9 @@ const UserGroupMembershipSection = ({
               key={group.id}
               label={group.name}
               size="small"
-              disabled={disabled || removePending}
+              disabled={disabled || addPending || removePending}
               onDelete={
-                disabled || removePending
+                disabled || addPending || removePending
                   ? undefined
                   : () => {
                       void handleRemove(group);
@@ -95,7 +95,7 @@ const UserGroupMembershipSection = ({
         options={joinableGroups}
         getOptionLabel={(group) => group.name}
         value={null}
-        disabled={disabled || isGroupsLoading || addPending}
+        disabled={disabled || isGroupsLoading || addPending || removePending}
         onChange={(_event, group) => {
           if (group) {
             void handleAdd(group);

--- a/src/app/_components/ConfirmDialog.tsx
+++ b/src/app/_components/ConfirmDialog.tsx
@@ -14,6 +14,7 @@ const ConfirmDialog = ({
   title,
   description,
   confirmLabel,
+  pending,
   onConfirm,
   onCancel,
 }: {
@@ -21,17 +22,20 @@ const ConfirmDialog = ({
   title: string;
   description: string;
   confirmLabel: string;
+  pending: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }) => (
-  <Dialog open={open} onClose={onCancel}>
+  <Dialog open={open} onClose={pending ? undefined : onCancel}>
     <DialogTitle>{title}</DialogTitle>
     <DialogContent>
       <DialogContentText>{description}</DialogContentText>
     </DialogContent>
     <DialogActions>
-      <Button onClick={onCancel}>キャンセル</Button>
-      <Button onClick={onConfirm} autoFocus>
+      <Button onClick={onCancel} disabled={pending}>
+        キャンセル
+      </Button>
+      <Button onClick={onConfirm} disabled={pending} autoFocus>
         {confirmLabel}
       </Button>
     </DialogActions>

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -28,6 +28,7 @@ import { useState, type ReactNode } from 'react';
 
 import ThemeModeToggle from '@/app/_components/ThemeModeToggle';
 import { useOptionalCurrentUser } from '@/app/_providers/currentUser';
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 import { getMsalInstance } from './MsalProvider';
 import { SigninButton } from './SigninButton';
@@ -40,34 +41,32 @@ type UserMenuProps = {
 const UserMenu = ({ user, isAdminPage }: UserMenuProps) => {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [isSigningOut, setIsSigningOut] = useState(false);
 
-  const handleSignout = async () => {
-    if (isSigningOut) return;
-    setAnchorEl(null);
-    setIsSigningOut(true);
+  const { run: runSignout, pending: isSigningOut } = usePendingAction(
+    async () => {
+      setAnchorEl(null);
 
-    try {
-      await fetch('/api/logout', { method: 'DELETE' });
+      try {
+        await fetch('/api/logout', { method: 'DELETE' });
 
-      const msalInstance = getMsalInstance();
-      await msalInstance.initialize();
-      const [account] = msalInstance.getAllAccounts();
+        const msalInstance = getMsalInstance();
+        await msalInstance.initialize();
+        const [account] = msalInstance.getAllAccounts();
 
-      if (account) {
-        await msalInstance.logoutRedirect({
-          account,
-          postLogoutRedirectUri: '/',
-        });
-        return;
+        if (account) {
+          await msalInstance.logoutRedirect({
+            account,
+            postLogoutRedirectUri: '/',
+          });
+          return;
+        }
+
+        router.push('/');
+      } catch (e) {
+        console.error('Failed to sign out:', e);
       }
-
-      router.push('/');
-    } catch (e) {
-      console.error('Failed to sign out:', e);
-      setIsSigningOut(false);
     }
-  };
+  );
 
   return (
     <Box sx={{ ml: 2.5 }}>
@@ -150,7 +149,7 @@ const UserMenu = ({ user, isAdminPage }: UserMenuProps) => {
         )}
         <MenuItem
           onClick={() => {
-            void handleSignout();
+            void runSignout();
           }}
           disabled={isSigningOut}
         >

--- a/src/app/_components/SignoutButton.tsx
+++ b/src/app/_components/SignoutButton.tsx
@@ -2,19 +2,15 @@
 
 import { Button } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+
+import { usePendingAction } from '@/hooks/usePendingAction';
 
 import { getMsalInstance } from './MsalProvider';
 
 export const SignoutButton = () => {
   const router = useRouter();
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleClick = async () => {
-    if (isSubmitting) return;
-
-    setIsSubmitting(true);
-
+  const { run, pending } = usePendingAction(async () => {
     try {
       await fetch('/api/logout', { method: 'DELETE' });
 
@@ -33,17 +29,16 @@ export const SignoutButton = () => {
       router.push('/');
     } catch (e) {
       console.error('Failed to sign out:', e);
-      setIsSubmitting(false);
     }
-  };
+  });
 
   return (
     <Button
       color="inherit"
       onClick={() => {
-        void handleClick();
+        void run();
       }}
-      disabled={isSubmitting}
+      disabled={pending}
     >
       サインアウト
     </Button>

--- a/src/generic/latestWinsQueue.ts
+++ b/src/generic/latestWinsQueue.ts
@@ -1,0 +1,84 @@
+export type QueueSlot<Args extends unknown[], R> = {
+  args: Args;
+  resolve: (value: R) => void;
+  reject: (reason: unknown) => void;
+};
+
+type Batch<Args extends unknown[], R> = {
+  all: QueueSlot<Args, R>[];
+  latest: QueueSlot<Args, R>;
+};
+
+export type LatestWinsState<Args extends unknown[], R> = {
+  batch: Batch<Args, R> | null;
+  running: boolean;
+};
+
+export const createLatestWinsState = <
+  Args extends unknown[],
+  R,
+>(): LatestWinsState<Args, R> => ({
+  batch: null,
+  running: false,
+});
+
+/**
+ * 呼び出しを1つも取りこぼさずに直列実行する。届いた時点で実行中でなければ
+ * その呼び出し自身の引数で即座に単独実行される。既に実行中のときに届いた
+ * 呼び出しは次の枠にまとめて積まれ、実行完了直後にその時点で最新だった
+ * 引数だけで自動的に再実行される（同じ枠に積まれた、より古い引数の呼び出し
+ * は実際には実行されない）。
+ *
+ * 実行されなかった呼び出しの Promise も、自分が乗っていた枠が実際に実行
+ * された結果（成功/失敗）をそのまま共有するため、呼び出し側は自分の呼び出し
+ * が実際に送信されたかどうかを気にせず扱える。
+ *
+ * onSettle はキューが空になり実行が完全に止まったときに1回だけ呼ばれる
+ * （pending 表示など、実行中かどうかを外部に伝えるための通知用）。
+ *
+ * fn は idle から running への遷移を起こした呼び出し（キューが空の状態で
+ * 呼ばれた最初の呼び出し）でのみ使われ、以降 drain し続ける間はその fn が
+ * 使い回される。実行中に追加で enqueueLatestWins を呼んだときに渡した fn は
+ * 無視される（args だけが使われる）。呼び出しごとに fn の実体が変わりうる
+ * 場合は、常に最新の対象を読みに行く薄いラッパー（ref 経由など）を渡すこと。
+ */
+export const enqueueLatestWins = <Args extends unknown[], R>(
+  state: LatestWinsState<Args, R>,
+  fn: (...args: Args) => Promise<R>,
+  args: Args,
+  onSettle: () => void
+): Promise<R> =>
+  new Promise<R>((resolve, reject) => {
+    const slot: QueueSlot<Args, R> = { args, resolve, reject };
+    state.batch = state.batch
+      ? { all: [...state.batch.all, slot], latest: slot }
+      : { all: [slot], latest: slot };
+
+    if (!state.running) {
+      state.running = true;
+      void drain(state, fn, onSettle);
+    }
+  });
+
+const drain = async <Args extends unknown[], R>(
+  state: LatestWinsState<Args, R>,
+  fn: (...args: Args) => Promise<R>,
+  onSettle: () => void
+): Promise<void> => {
+  while (state.batch) {
+    const { all, latest } = state.batch;
+    state.batch = null;
+    try {
+      const result = await fn(...latest.args);
+      all.forEach((slot) => {
+        slot.resolve(result);
+      });
+    } catch (error) {
+      all.forEach((slot) => {
+        slot.reject(error);
+      });
+    }
+  }
+  state.running = false;
+  onSettle();
+};

--- a/src/hooks/useLatestWinsAction.ts
+++ b/src/hooks/useLatestWinsAction.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  createLatestWinsState,
+  enqueueLatestWins,
+} from '@/generic/latestWinsQueue';
+
+/**
+ * useSingleFlightAction / usePendingAction は「実行中の再呼び出しは黙って
+ * 最初の呼び出しの結果を共有する」ため、呼び出しごとに引数が変わりうる
+ * action（例: 連続して異なる値を選べる Select）に使うと、後から渡した
+ * 引数がサーバーへ送信されないまま握りつぶされる。
+ *
+ * このフックは代わりに、届いた呼び出しを1つも取りこぼさずに直列実行する
+ * （詳細な契約は src/generic/latestWinsQueue.ts を参照）。呼び出しごとに
+ * 引数が変わりうる action にはこちらを使う。
+ */
+export const useLatestWinsAction = <Args extends unknown[], R>(
+  action: (...args: Args) => Promise<R>
+): { run: (...args: Args) => Promise<R>; pending: boolean } => {
+  const [pending, setPending] = useState(false);
+  const actionRef = useRef(action);
+  const stateRef = useRef(createLatestWinsState<Args, R>());
+
+  useEffect(() => {
+    actionRef.current = action;
+  }, [action]);
+
+  const run = useCallback((...args: Args): Promise<R> => {
+    setPending(true);
+    return enqueueLatestWins(
+      stateRef.current,
+      (...a: Args) => actionRef.current(...a),
+      args,
+      () => {
+        setPending(false);
+      }
+    );
+  }, []);
+
+  return { run, pending };
+};

--- a/src/hooks/usePendingAction.ts
+++ b/src/hooks/usePendingAction.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
+
+/**
+ * 非同期 action をラップし、実行中かどうかを表す pending state を提供する。
+ * 内部で useSingleFlightAction を使うため、実行中の再呼び出しは新規実行にならない。
+ *
+ * 呼び出しごとに引数が変わりうる action（例: 連続して異なる値を選択できる Select）
+ * に使う場合、実行中の再呼び出しは「先に受け付けた呼び出しの結果」を返すだけで、
+ * 後から渡した引数は送信されない。呼び出し側で pending 中は操作自体をできなくする
+ * こと（disabled 等）を必ず併用し、この仕組みだけに正しさを委ねないこと。
+ */
+export const usePendingAction = <Args extends unknown[], R>(
+  action: (...args: Args) => Promise<R>
+): { run: (...args: Args) => Promise<R>; pending: boolean } => {
+  const [pending, setPending] = useState(false);
+  const guarded = useSingleFlightAction(action);
+
+  const run = useCallback(
+    async (...args: Args): Promise<R> => {
+      setPending(true);
+      try {
+        return await guarded(...args);
+      } finally {
+        setPending(false);
+      }
+    },
+    [guarded]
+  );
+
+  return { run, pending };
+};

--- a/tests/component/ArchivedFormRowMenu.test.tsx
+++ b/tests/component/ArchivedFormRowMenu.test.tsx
@@ -1,0 +1,75 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ArchivedFormRowMenu from '@/app/(protected)/admin/forms/_components/ArchivedFormRowMenu';
+
+import { renderWithProviders, screen, waitFor, within } from './render';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+type FormActionsMocks = {
+  restoreForm: ReturnType<
+    typeof vi.fn<(formId: string) => Promise<{ ok: boolean }>>
+  >;
+};
+
+const formActionsMocks = vi.hoisted<FormActionsMocks>(() => ({
+  restoreForm: vi.fn<(formId: string) => Promise<{ ok: boolean }>>(),
+}));
+
+vi.mock('@/hooks/useFormActions', () => ({
+  useFormActions: () => ({
+    archiveForm: vi.fn(),
+    restoreForm: formActionsMocks.restoreForm,
+  }),
+}));
+
+describe('ArchivedFormRowMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('復元確認中はダイアログのボタンを無効化し、完了するとダイアログが閉じる', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<{ ok: boolean }>();
+    formActionsMocks.restoreForm.mockReturnValue(promise);
+
+    renderWithProviders(<ArchivedFormRowMenu formId="form-1" />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'アーカイブ済みフォーム操作メニュー' })
+    );
+    await user.click(screen.getByRole('menuitem', { name: '復元' }));
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: '復元' }));
+
+    await waitFor(() => {
+      expect(formActionsMocks.restoreForm).toHaveBeenCalledTimes(1);
+    });
+    expect(formActionsMocks.restoreForm).toHaveBeenCalledWith('form-1');
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', { name: '復元' })
+      ).toBeDisabled();
+    });
+    expect(
+      within(dialog).getByRole('button', { name: 'キャンセル' })
+    ).toBeDisabled();
+
+    resolve({ ok: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+});

--- a/tests/component/FormRowMenu.test.tsx
+++ b/tests/component/FormRowMenu.test.tsx
@@ -1,0 +1,77 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import FormRowMenu from '@/app/(protected)/admin/forms/_components/FormRowMenu';
+
+import { renderWithProviders, screen, waitFor, within } from './render';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+type FormActionsMocks = {
+  archiveForm: ReturnType<
+    typeof vi.fn<(formId: string) => Promise<{ ok: boolean }>>
+  >;
+};
+
+const formActionsMocks = vi.hoisted<FormActionsMocks>(() => ({
+  archiveForm: vi.fn<(formId: string) => Promise<{ ok: boolean }>>(),
+}));
+
+vi.mock('@/hooks/useFormActions', () => ({
+  useFormActions: () => ({
+    archiveForm: formActionsMocks.archiveForm,
+    restoreForm: vi.fn(),
+  }),
+}));
+
+describe('FormRowMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('アーカイブ確認中はダイアログのボタンを無効化し、完了するとダイアログが閉じる', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<{ ok: boolean }>();
+    formActionsMocks.archiveForm.mockReturnValue(promise);
+
+    renderWithProviders(<FormRowMenu formId="form-1" />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'フォーム操作メニュー' })
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'アーカイブ' }));
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(
+      within(dialog).getByRole('button', { name: 'アーカイブ' })
+    );
+
+    await waitFor(() => {
+      expect(formActionsMocks.archiveForm).toHaveBeenCalledTimes(1);
+    });
+    expect(formActionsMocks.archiveForm).toHaveBeenCalledWith('form-1');
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', { name: 'アーカイブ' })
+      ).toBeDisabled();
+    });
+    expect(
+      within(dialog).getByRole('button', { name: 'キャンセル' })
+    ).toBeDisabled();
+
+    resolve({ ok: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+});

--- a/tests/component/Groups.test.tsx
+++ b/tests/component/Groups.test.tsx
@@ -5,6 +5,16 @@ import Groups from '@/app/(protected)/admin/groups/_components/Groups';
 
 import { renderWithProviders, screen, waitFor, within } from './render';
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 type GroupCRUDMocks = {
   editGroup: ReturnType<
     typeof vi.fn<(id: string, name: string) => Promise<{ ok: boolean }>>
@@ -88,6 +98,42 @@ describe('Groups', () => {
 
     await waitFor(() => {
       expect(groupCRUDMocks.deleteGroup).toHaveBeenCalledWith('group-1');
+    });
+  });
+
+  it('削除処理が完了するまでダイアログのボタンを無効化する', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<{ ok: boolean }>();
+    groupCRUDMocks.deleteGroup.mockReturnValue(promise);
+
+    renderWithProviders(
+      <Groups
+        groups={[{ id: 'group-1', name: 'グループA' }]}
+        currentUserId="current-user"
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: '削除' }));
+
+    await waitFor(() => {
+      expect(groupCRUDMocks.deleteGroup).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', { name: '削除' })
+      ).toBeDisabled();
+    });
+    expect(
+      within(dialog).getByRole('button', { name: 'キャンセル' })
+    ).toBeDisabled();
+
+    resolve({ ok: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
     });
   });
 });

--- a/tests/component/RoleSelectCell.test.tsx
+++ b/tests/component/RoleSelectCell.test.tsx
@@ -1,0 +1,74 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RoleSelectCell from '@/app/(protected)/admin/users/_components/RoleSelectCell';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+type RoleActionMocks = {
+  updateUserRole: ReturnType<
+    typeof vi.fn<(uuid: string, role: string) => Promise<void>>
+  >;
+};
+
+const roleActionMocks = vi.hoisted<RoleActionMocks>(() => ({
+  updateUserRole: vi.fn<(uuid: string, role: string) => Promise<void>>(),
+}));
+
+vi.mock('@/hooks/useUserRoleActions', () => ({
+  useUserRoleActions: () => ({
+    updateUserRole: roleActionMocks.updateUserRole,
+  }),
+}));
+
+describe('RoleSelectCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ロール変更中は Select が disabled になり、完了すると再度有効になる', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<undefined>();
+    roleActionMocks.updateUserRole.mockReturnValue(promise);
+
+    renderWithProviders(
+      <RoleSelectCell
+        userId="user-1"
+        currentRole="STANDARD_USER"
+        disabled={false}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    await user.click(select);
+    await user.click(await screen.findByRole('option', { name: '管理者' }));
+
+    await waitFor(() => {
+      expect(roleActionMocks.updateUserRole).toHaveBeenCalledTimes(1);
+    });
+    expect(roleActionMocks.updateUserRole).toHaveBeenCalledWith(
+      'user-1',
+      'ADMINISTRATOR'
+    );
+
+    await waitFor(() => {
+      expect(select).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    resolve(undefined);
+
+    await waitFor(() => {
+      expect(select).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+});

--- a/tests/component/UserGroupMembershipSection.test.tsx
+++ b/tests/component/UserGroupMembershipSection.test.tsx
@@ -6,6 +6,16 @@ import type { UserGroupSchema } from '@/lib/api-types';
 
 import { renderWithProviders, screen, waitFor } from './render';
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 type GroupListQueryState = {
   data: UserGroupSchema[] | undefined;
   error: Error | null;
@@ -133,6 +143,76 @@ describe('UserGroupMembershipSection', () => {
     ).toBeDisabled();
     const chip = screen.getByText('グループA').closest('.MuiChip-root');
     expect(chip?.querySelector('.MuiChip-deleteIcon')).toBeNull();
+  });
+
+  it('追加処理が完了するまでの間は追加欄を無効化する', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<{ success: boolean }>();
+    membershipMocks.addUserToGroup.mockReturnValue(promise);
+
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[]}
+        disabled={false}
+        onChanged={onChanged}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'グループを追加' });
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'グループA' }));
+
+    await waitFor(() => {
+      expect(combobox).toBeDisabled();
+    });
+
+    resolve({ success: true });
+
+    await waitFor(() => {
+      expect(combobox).not.toBeDisabled();
+    });
+  });
+
+  it('削除処理が完了するまでの間は該当 Chip の削除操作を無効化する', async () => {
+    const user = userEvent.setup();
+    const { promise, resolve } = deferred<{ success: boolean }>();
+    membershipMocks.removeUserFromGroup.mockReturnValue(promise);
+
+    renderWithProviders(
+      <UserGroupMembershipSection
+        uuid="user-uuid"
+        currentGroups={[{ id: 'group-1', name: 'グループA' }]}
+        disabled={false}
+        onChanged={onChanged}
+      />
+    );
+
+    const chip = screen.getByText('グループA').closest('.MuiChip-root');
+    if (!chip) throw new Error('Chip not found');
+    const deleteIcon = chip.querySelector('.MuiChip-deleteIcon');
+    if (!deleteIcon) throw new Error('delete icon not found');
+    await user.click(deleteIcon);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('グループA').closest('.MuiChip-root')
+      ).toHaveClass('Mui-disabled');
+    });
+    expect(
+      screen
+        .getByText('グループA')
+        .closest('.MuiChip-root')
+        ?.querySelector('.MuiChip-deleteIcon')
+    ).toBeNull();
+
+    resolve({ success: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('グループA').closest('.MuiChip-root')
+      ).not.toHaveClass('Mui-disabled');
+    });
   });
 
   it('グループ一覧の読み込み中は追加欄を無効化する', () => {

--- a/tests/component/useLatestWinsAction.test.tsx
+++ b/tests/component/useLatestWinsAction.test.tsx
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useLatestWinsAction } from '@/hooks/useLatestWinsAction';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('useLatestWinsAction', () => {
+  it('実行中は pending が true になり、キューが空になった時点で false へ戻る', async () => {
+    const first = deferred<string>();
+    const action = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce('done:c');
+    const { result } = renderHook(() => useLatestWinsAction(action));
+
+    expect(result.current.pending).toBe(false);
+
+    let runA!: Promise<string>;
+    let runC!: Promise<string>;
+    act(() => {
+      runA = result.current.run('a');
+      void result.current.run('b').catch(() => {
+        // 'b' は latest-wins によって実行されず、共有先の 'c' の結果を
+        // そのまま受け取る想定。ここでの reject 有無は別テストの関心事。
+      });
+      runC = result.current.run('c');
+    });
+
+    expect(result.current.pending).toBe(true);
+    // b は実行されず、実行中の a と、a の後に自動実行される c の2回だけ
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith('a');
+
+    first.resolve('done:a');
+    await act(async () => {
+      await runA;
+      await runC;
+    });
+
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(action).toHaveBeenNthCalledWith(2, 'c');
+    expect(result.current.pending).toBe(false);
+  });
+});

--- a/tests/component/usePendingAction.test.tsx
+++ b/tests/component/usePendingAction.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePendingAction } from '@/hooks/usePendingAction';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('usePendingAction', () => {
+  it('実行中は pending が true になり、完了後に false へ戻る', async () => {
+    const { promise, resolve } = deferred<string>();
+    const action = vi.fn(() => promise);
+    const { result } = renderHook(() => usePendingAction(action));
+
+    expect(result.current.pending).toBe(false);
+
+    let runPromise!: Promise<string>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    expect(result.current.pending).toBe(true);
+
+    resolve('done');
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(result.current.pending).toBe(false);
+  });
+
+  it('失敗した場合も pending は false に戻る', async () => {
+    const { promise, reject } = deferred<string>();
+    const action = vi.fn(() => promise);
+    const { result } = renderHook(() => usePendingAction(action));
+
+    let runPromise!: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run().catch(() => {
+        // pending が false に戻ることを確認したいだけなので、
+        // ここでの reject 自体はテスト失敗として扱わない。
+        return undefined;
+      });
+    });
+
+    expect(result.current.pending).toBe(true);
+
+    reject(new Error('failed'));
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(result.current.pending).toBe(false);
+  });
+
+  it('実行中に再度 run を呼んでも、実処理は1回しか走らない', async () => {
+    const { promise, resolve } = deferred<string>();
+    const action = vi.fn(() => promise);
+    const { result } = renderHook(() => usePendingAction(action));
+
+    let first!: Promise<string>;
+    let second!: Promise<string>;
+    act(() => {
+      first = result.current.run();
+      second = result.current.run();
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+
+    resolve('done');
+    await act(async () => {
+      await Promise.all([first, second]);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/latestWinsQueue.test.ts
+++ b/tests/unit/latestWinsQueue.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createLatestWinsState,
+  enqueueLatestWins,
+} from '@/generic/latestWinsQueue';
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('enqueueLatestWins', () => {
+  it('実行中でなければ即座に実行する', async () => {
+    const state = createLatestWinsState<[string], string>();
+    const fn = vi.fn((value: string) => Promise.resolve(`done:${value}`));
+    const onSettle = vi.fn();
+
+    await expect(enqueueLatestWins(state, fn, ['a'], onSettle)).resolves.toBe(
+      'done:a'
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it('実行中に来た呼び出しは実行されず、最新の引数だけが実行完了後に自動実行される', async () => {
+    const state = createLatestWinsState<[string], string>();
+    const first = deferred<string>();
+    const fn = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce('done:c');
+    const onSettle = vi.fn();
+
+    const runA = enqueueLatestWins(state, fn, ['a'], onSettle);
+    const runB = enqueueLatestWins(state, fn, ['b'], onSettle);
+    const runC = enqueueLatestWins(state, fn, ['c'], onSettle);
+
+    // a の実行中に b, c が来ても、この時点では c しかキューにない
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+
+    first.resolve('done:a');
+    await expect(runA).resolves.toBe('done:a');
+
+    // b は一度も実行されず、最新の c だけが自動的に実行される
+    await expect(runB).resolves.toBe('done:c');
+    await expect(runC).resolves.toBe('done:c');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, 'c');
+    // b の引数ではフォームは一切呼ばれていない
+    expect(fn).not.toHaveBeenCalledWith('b');
+  });
+
+  it('先行する呼び出しの実行中に届いた次の呼び出しは、先行呼び出しの成否に関わらず独立して実行される', async () => {
+    // 最初の呼び出しは届いた時点で即座に単独実行が始まるため、2つ目の
+    // 呼び出しは「バッチに乗る」余地がなく、次の枠として独立に実行される。
+    // バッチとして合流する（=実行されず結果だけ共有する）のは、既に
+    // 実行中の枠の"後に"複数の呼び出しが積み重なった場合だけ。
+    const state = createLatestWinsState<[string], string>();
+    const first = deferred<string>();
+    const fn = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce('done:b');
+    const onSettle = vi.fn();
+
+    const runA = enqueueLatestWins(state, fn, ['a'], onSettle);
+    const runB = enqueueLatestWins(state, fn, ['b'], onSettle);
+
+    const error = new Error('failed');
+    first.reject(error);
+
+    await expect(runA).rejects.toBe(error);
+    await expect(runB).resolves.toBe('done:b');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('同じバッチに乗った呼び出しが失敗すると、乗っていた呼び出し全てが同じ理由で reject される', async () => {
+    const state = createLatestWinsState<[string], string>();
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const fn = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const onSettle = vi.fn();
+
+    const runA = enqueueLatestWins(state, fn, ['a'], onSettle);
+    const runB = enqueueLatestWins(state, fn, ['b'], onSettle);
+    const runC = enqueueLatestWins(state, fn, ['c'], onSettle);
+
+    first.resolve('done:a');
+    await runA;
+
+    const error = new Error('failed');
+    second.reject(error);
+
+    await expect(runB).rejects.toBe(error);
+    await expect(runC).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, 'c');
+  });
+
+  it('onSettle はキューが完全に空になったときだけ呼ばれる', async () => {
+    const state = createLatestWinsState<[string], string>();
+    const first = deferred<string>();
+    const fn = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce('done:b');
+    const onSettle = vi.fn();
+
+    const runA = enqueueLatestWins(state, fn, ['a'], onSettle);
+    const runB = enqueueLatestWins(state, fn, ['b'], onSettle);
+
+    first.resolve('done:a');
+    await runA;
+    await runB;
+
+    // a の完了時点ではまだ b が控えているため onSettle は呼ばれておらず、
+    // 完全に空になった b の完了時点で1回だけ呼ばれる
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要
- #851 でネットワーク層の多重実行防止（`useSingleFlightAction`）を導入したが、同じバグの形が残っていた箇所を洗い出して対応した
- `useCreateForm.ts`（フォーム作成、POST→PUTの2段階呼び出し）が `proxyClient` を直接呼んでおり保護対象外だったため、`useSingleFlightAction` でラップ
- `ConfirmDialog`（削除・アーカイブ確認の共通コンポーネント）が pending 概念を持たず、送信中でも閉じたり連打できた。`FormRowMenu`/`ArchivedFormRowMenu` は確認後 await 前にダイアログを閉じてもいたため、その順序も修正
- `RoleSelectCell` は実行中に別のロールを選び直すと、single-flight のロックにより2回目の選択が黙って握りつぶされ、画面表示とサーバー状態が食い違う実バグがあったため、pending 中は `Select` を disabled にして経路自体を塞いだ
- `UnlinkDiscordButton` / `UserGroupMembershipSection` / `SignoutButton` / `NavBar`（サインアウト）は、呼び出し先は保護済みだが pending 中の視覚的ロックがなく、`SignoutButton` と `NavBar` は手書きの `isSubmitting` 管理を個別に重複実装していた
- 上記をまとめて解決するため、`useSingleFlightAction` を内部で使いつつローカルな `pending` state も返す `usePendingAction`（`src/hooks/usePendingAction.ts`）を追加し、各箇所に適用した

## 確認事項
- `pnpm run type-check` / `pnpm lint` / `pnpm test:unit` / `pnpm test:component` がすべて成功することを確認（test:component は 16 ファイル / 59 テスト）
- `usePendingAction` 自体の単体テスト（pending の true/false 遷移、失敗時のリセット、実行中の多重呼び出しが1回に収束すること）を追加
- `RoleSelectCell` の実バグ（pending 中は Select が disabled になり、握りつぶしが起きないこと）をテストで固定
- `FormRowMenu` / `ArchivedFormRowMenu` の「pending 中はダイアログのボタンが disabled になり、完了後にのみ閉じる」という制御フロー変更を、それぞれ専用テストで固定（既存の `Groups.test.tsx` にも同様の観点を追加）
- 設計は着手前に別セッションでの反証レビュー、実装後に完了前レビューを実施し、指摘（テスト不足・二重ロックの一貫性）はすべて対応済み

## 補足
- `RestrictedAnswerSubmitterView.tsx` / `ConversationEntry.tsx` の削除操作にも同種の「pending 中の視覚的ロックがない」箇所が残っているが、今回のスコープには含めていない（別対応の余地として認識）
- `usePendingAction` は「実行中の再呼び出しは新規実行にならない」ため、呼び出しごとに引数が変わりうる action に使う場合は pending 中の操作自体を UI 側で止めることを必ず併用する必要がある。この点は doc comment に明記した

🤖 Generated with Claude Code