### PR TITLE
refactor: ConversationCapabilities から adminLabel を削除し「運営チーム」表記に統一

### DIFF
--- a/src/app/(protected)/_components/Comments.tsx
+++ b/src/app/(protected)/_components/Comments.tsx
@@ -51,7 +51,6 @@ const Comments = (props: {
     composeLabel: 'コメントを入力...',
     composeHelperText: '',
     emptyMessage: 'コメントはまだありません',
-    adminLabel: '運営',
     deepLinkQueryParam: 'commentId',
     entryNoun: 'コメント',
   };

--- a/src/app/(protected)/_components/ConversationEntryHeader.tsx
+++ b/src/app/(protected)/_components/ConversationEntryHeader.tsx
@@ -90,7 +90,7 @@ const ConversationEntryHeader = ({
               avatar={
                 <Avatar src="/server-icon.png" sx={{ width: 18, height: 18 }} />
               }
-              label={capabilities.adminLabel}
+              label="運営チーム"
               color="success"
               size="small"
               sx={{ height: 20 }}

--- a/src/app/(protected)/_components/Messages.tsx
+++ b/src/app/(protected)/_components/Messages.tsx
@@ -55,7 +55,6 @@ const Messages = (props: {
     composeLabel: 'メッセージを入力してください',
     composeHelperText: 'Shift + Enter で改行、Enter で送信することができます。',
     emptyMessage: 'メッセージはまだありません',
-    adminLabel: '運営チーム',
     deepLinkQueryParam: 'messageId',
     entryNoun: 'メッセージ',
   };

--- a/src/app/(protected)/_components/conversationTypes.ts
+++ b/src/app/(protected)/_components/conversationTypes.ts
@@ -33,7 +33,6 @@ export type ConversationCapabilities = {
   composeLabel: string;
   composeHelperText: string;
   emptyMessage: string;
-  adminLabel: string;
   deepLinkQueryParam: ConversationDeepLinkQueryParam;
   /** エラーメッセージ等で使う、投稿を指す名詞(例: 'メッセージ' / 'コメント')。 */
   entryNoun: string;

--- a/tests/component/ConversationSurface.test.tsx
+++ b/tests/component/ConversationSurface.test.tsx
@@ -26,7 +26,6 @@ const capabilities: ConversationCapabilities = {
   composeLabel: '',
   composeHelperText: '',
   emptyMessage: '投稿はまだありません',
-  adminLabel: '運営',
   deepLinkQueryParam: 'commentId',
   entryNoun: 'コメント',
 };


### PR DESCRIPTION
## 概要
- コメント欄は「運営」、メッセージ欄は「運営チーム」と `ConversationCapabilities.adminLabel` 経由で表記が分かれていたが、呼び出し側ごとに文言を変える必要性がないため、`ConversationEntryHeader` 側で「運営チーム」に固定して不要な props を削除した
- `Comments.tsx` / `Messages.tsx` から `adminLabel` の指定を削除
- `conversationTypes.ts` の `ConversationCapabilities` から `adminLabel` フィールドを削除
- テスト側 (`ConversationSurface.test.tsx`) の型エラーに合わせて `adminLabel` の指定を削除

## 確認事項
- `pnpm tsc --noEmit` / `pnpm lint` が通ることを確認
- `adminLabel` の残存参照がないことを `grep` で確認
- pre-commit / pre-push フック（lint, type-check, fmt, unit-test）が通過
- `ConversationSurface.test.tsx` はコンポーネントテスト実行環境側の既存問題（`user-event` の `prepareDocument` エラー）で main ブランチでも同様に失敗することを確認済みで、今回の変更とは無関係

🤖 Generated with Claude Code