### PR TITLE
fix: Markdownリンク偽装対策として遷移先確認ダイアログを追加

### DIFF
--- a/src/app/_components/ConfirmDialog.tsx
+++ b/src/app/_components/ConfirmDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogContentText,
   DialogTitle,
 } from '@mui/material';
+import type { ReactNode } from 'react';
 
 const ConfirmDialog = ({
   open,
@@ -20,7 +21,7 @@ const ConfirmDialog = ({
 }: {
   open: boolean;
   title: string;
-  description: string;
+  description: ReactNode;
   confirmLabel: string;
   pending: boolean;
   onConfirm: () => void;

--- a/src/app/_components/MarkdownText.tsx
+++ b/src/app/_components/MarkdownText.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { type MouseEvent, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+
+import ConfirmDialog from './ConfirmDialog';
 
 const defaultSx: SxProps<Theme> = {
   whiteSpace: 'pre-wrap',
@@ -23,8 +26,19 @@ type Props = {
  * Markdown 本文を描画する共通 component。
  * img 要素はトラッキングピクセル等の情報漏洩対策として一律描画せず、alt テキストのみ表示する。
  * a 要素は tabnabbing 対策として新しいタブで開く。
+ * また、リンク文言と実際の遷移先を偽装される(例: `[https://example.com](https://evil.example)`)
+ * リスクに備え、クリック時に実際の遷移先 URL を提示する確認ダイアログを挟んでから遷移する。
  */
 const MarkdownText = ({ children, sx }: Props) => {
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
+
+  const handleLinkClick =
+    (href: string | undefined) => (event: MouseEvent<HTMLAnchorElement>) => {
+      if (!href) return;
+      event.preventDefault();
+      setPendingHref(href);
+    };
+
   return (
     <Box sx={sx ? [defaultSx, sx].flat() : defaultSx}>
       <Markdown
@@ -32,7 +46,12 @@ const MarkdownText = ({ children, sx }: Props) => {
         components={{
           img: ({ alt }) => <>{alt ? `[image: ${alt}]` : '[image]'}</>,
           a: ({ href, children: linkChildren }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer">
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleLinkClick(href)}
+            >
               {linkChildren}
             </a>
           ),
@@ -40,6 +59,32 @@ const MarkdownText = ({ children, sx }: Props) => {
       >
         {children}
       </Markdown>
+      <ConfirmDialog
+        open={pendingHref !== null}
+        title="外部サイトに移動します"
+        description={
+          <>
+            表示されているリンク文言と実際の遷移先が異なる場合があります。以下の遷移先を確認のうえ移動してください。
+            <Typography
+              component="span"
+              sx={{ display: 'block', wordBreak: 'break-all', mt: 1 }}
+            >
+              {pendingHref}
+            </Typography>
+          </>
+        }
+        confirmLabel="移動する"
+        pending={false}
+        onConfirm={() => {
+          if (pendingHref) {
+            window.open(pendingHref, '_blank', 'noopener,noreferrer');
+          }
+          setPendingHref(null);
+        }}
+        onCancel={() => {
+          setPendingHref(null);
+        }}
+      />
     </Box>
   );
 };

--- a/src/app/_components/MarkdownText.tsx
+++ b/src/app/_components/MarkdownText.tsx
@@ -22,19 +22,23 @@ type Props = {
   sx?: SxProps<Theme>;
 };
 
+const isExternalHttpLink = (href: string | undefined): href is string =>
+  href !== undefined && /^https?:\/\//i.test(href);
+
 /**
  * Markdown 本文を描画する共通 component。
  * img 要素はトラッキングピクセル等の情報漏洩対策として一律描画せず、alt テキストのみ表示する。
  * a 要素は tabnabbing 対策として新しいタブで開く。
  * また、リンク文言と実際の遷移先を偽装される(例: `[https://example.com](https://evil.example)`)
- * リスクに備え、クリック時に実際の遷移先 URL を提示する確認ダイアログを挟んでから遷移する。
+ * リスクに備え、外部(http/https)リンクのクリック時のみ実際の遷移先 URL を提示する確認ダイアログを
+ * 挟んでから遷移する。相対パスやページ内アンカーなど同一オリジンへの内部リンクは対象外とする。
  */
 const MarkdownText = ({ children, sx }: Props) => {
   const [pendingHref, setPendingHref] = useState<string | null>(null);
 
   const handleLinkClick =
     (href: string | undefined) => (event: MouseEvent<HTMLAnchorElement>) => {
-      if (!href) return;
+      if (!isExternalHttpLink(href)) return;
       event.preventDefault();
       setPendingHref(href);
     };

--- a/tests/component/MarkdownText.test.tsx
+++ b/tests/component/MarkdownText.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import MarkdownText from '@/app/_components/MarkdownText';
 
-import { renderWithProviders, screen } from './render';
+import { renderWithProviders, screen, waitFor, within } from './render';
 
 describe('MarkdownText', () => {
   it('Markdown 記法(強調・箇条書き)を実際の HTML 要素として描画する', () => {
@@ -44,5 +45,76 @@ describe('MarkdownText', () => {
     const link = screen.getByRole('link', { name: 'リンク' });
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  describe('リンク偽装対策の確認ダイアログ', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('リンク文言と異なる遷移先を持つリンクをクリックすると、実際の遷移先を提示する確認ダイアログを表示し、既定では遷移しない', async () => {
+      const user = userEvent.setup();
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      renderWithProviders(
+        <MarkdownText>
+          {'[https://example.com](https://evil.example/phishing)'}
+        </MarkdownText>
+      );
+
+      await user.click(
+        screen.getByRole('link', { name: 'https://example.com' })
+      );
+
+      const dialog = await screen.findByRole('dialog');
+      expect(
+        within(dialog).getByText('https://evil.example/phishing')
+      ).toBeVisible();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('確認ダイアログで移動を選ぶと、実際の遷移先を新しいタブで開きダイアログを閉じる', async () => {
+      const user = userEvent.setup();
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      renderWithProviders(
+        <MarkdownText>{'[リンク](https://example.com/path)'}</MarkdownText>
+      );
+
+      await user.click(screen.getByRole('link', { name: 'リンク' }));
+      const dialog = await screen.findByRole('dialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: '移動する' })
+      );
+
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com/path',
+        '_blank',
+        'noopener,noreferrer'
+      );
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).toBeNull();
+      });
+    });
+
+    it('確認ダイアログでキャンセルを選ぶと、遷移せずダイアログを閉じる', async () => {
+      const user = userEvent.setup();
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      renderWithProviders(
+        <MarkdownText>{'[リンク](https://example.com/path)'}</MarkdownText>
+      );
+
+      await user.click(screen.getByRole('link', { name: 'リンク' }));
+      const dialog = await screen.findByRole('dialog');
+      await user.click(
+        within(dialog).getByRole('button', { name: 'キャンセル' })
+      );
+
+      expect(openSpy).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).toBeNull();
+      });
+    });
   });
 });

--- a/tests/component/MarkdownText.test.tsx
+++ b/tests/component/MarkdownText.test.tsx
@@ -116,5 +116,21 @@ describe('MarkdownText', () => {
         expect(screen.queryByRole('dialog')).toBeNull();
       });
     });
+
+    it.each([
+      ['相対パス', '/dashboard'],
+      ['ページ内アンカー', '#section-1'],
+    ])(
+      '同一オリジンへの内部リンク(%s)をクリックしても確認ダイアログは表示されない',
+      async (_label, href) => {
+        const user = userEvent.setup();
+
+        renderWithProviders(<MarkdownText>{`[リンク](${href})`}</MarkdownText>);
+
+        await user.click(screen.getByRole('link', { name: 'リンク' }));
+
+        expect(screen.queryByRole('dialog')).toBeNull();
+      }
+    );
   });
 });


### PR DESCRIPTION
## 概要
- Markdownのリンク記法は表示テキストと実際の遷移先URLを別々に指定できるため、表示文言を偽装して悪意あるサイトへ誘導する「リンク偽装」のリスクがある(#834)
- コメント・回答詳細・処罰理由など、Markdownを描画する全箇所で共通利用している `MarkdownText` のリンククリックをインターセプトし、実際の遷移先URLを提示する確認ダイアログを経由してから新しいタブで開くようにした
- 既存の tabnabbing 対策(`target="_blank"` + `rel="noopener noreferrer"`)はそのまま維持
- 汎用の `ConfirmDialog` の `description` prop を `string` から `ReactNode` に拡張し、遷移先URLを折り返し表示できるようにした(既存の利用箇所は文字列を渡すだけなので後方互換)

## 確認事項
- `MarkdownText.test.tsx` に、表示文言と遷移先が異なるリンクをクリックした際にダイアログへ実際のURLが表示されること・確定/キャンセルそれぞれの遷移挙動を検証するテストを追加し、通過を確認(component test 20 ファイル / 71 件パス)
- `pnpm eslint` / `pnpm tsc --noEmit` / `pnpm prettier --check` を対象ファイルに対して実行し、いずれも問題なし
- pre-commit・pre-push フック(lint / type-check / fmt / unit test)も通過

## 補足
- 今回はクリック時に毎回確認ダイアログを表示する方針とした。同一ドメインへの複数リンクなどでの体験改善(確認省略等)は今後の検討課題

🤖 Generated with Claude Code