### PR TITLE
fix: 管理画面への権限のないアクセスをポップアップではなくSnackbar通知に変更

### DIFF
--- a/src/app/(protected)/(standard)/_components/MainMenu.tsx
+++ b/src/app/(protected)/(standard)/_components/MainMenu.tsx
@@ -14,7 +14,10 @@ import {
   useTheme,
 } from '@mui/material';
 import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useCurrentUser } from '@/app/_providers/currentUser';
 
 const menuItems = [
@@ -41,126 +44,143 @@ const menuItems = [
   },
 ];
 
-const MainMenu = () => {
+const MainMenu = ({ accessDenied }: { accessDenied?: string | undefined }) => {
   const theme = useTheme();
   const user = useCurrentUser();
   const userName = user.name;
+  const router = useRouter();
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    if (accessDenied != null) {
+      showSnackbar('このページを表示する権限がありません。', 'warning');
+      router.replace('/home', { scroll: false });
+    }
+  }, [accessDenied, router, showSnackbar]);
 
   return (
-    <Container maxWidth="md" sx={{ py: 5 }}>
-      <Box sx={{ mb: 5, textAlign: 'center' }}>
-        <Typography
-          variant="h5"
-          component="h1"
-          sx={{ fontWeight: 700 }}
-          gutterBottom
+    <>
+      <Container maxWidth="md" sx={{ py: 5 }}>
+        <Box sx={{ mb: 5, textAlign: 'center' }}>
+          <Typography
+            variant="h5"
+            component="h1"
+            sx={{ fontWeight: 700 }}
+            gutterBottom
+          >
+            {userName ? `ようこそ、${userName} さん` : 'ようこそ'}
+          </Typography>
+          <Typography variant="body1" color="textSecondary">
+            各機能にアクセスするには、下のカードをクリックしてください
+          </Typography>
+        </Box>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, 1fr)',
+              md: 'repeat(3, 1fr)',
+            },
+            gap: 3,
+            alignItems: 'stretch',
+          }}
         >
-          {userName ? `ようこそ、${userName} さん` : 'ようこそ'}
-        </Typography>
-        <Typography variant="body1" color="textSecondary">
-          各機能にアクセスするには、下のカードをクリックしてください
-        </Typography>
-      </Box>
-
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: {
-            xs: '1fr',
-            sm: 'repeat(2, 1fr)',
-            md: 'repeat(3, 1fr)',
-          },
-          gap: 3,
-          alignItems: 'stretch',
-        }}
-      >
-        {menuItems.map((item) => {
-          const Icon = item.icon;
-          return (
-            <Card
-              key={item.href}
-              elevation={2}
-              sx={{
-                height: '100%',
-                borderRadius: 3,
-                transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-                '&:hover': {
-                  transform: 'translateY(-4px)',
-                  boxShadow: theme.shadows[6],
-                },
-              }}
-            >
-              <CardActionArea
-                component={NextLink}
-                href={item.href}
-                sx={{ height: '100%' }}
+          {menuItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Card
+                key={item.href}
+                elevation={2}
+                sx={{
+                  height: '100%',
+                  borderRadius: 3,
+                  transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+                  '&:hover': {
+                    transform: 'translateY(-4px)',
+                    boxShadow: theme.shadows[6],
+                  },
+                }}
               >
-                <CardContent
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    textAlign: 'center',
-                    height: '100%',
-                    py: 4,
-                    px: 3,
-                    gap: 1.5,
-                  }}
+                <CardActionArea
+                  component={NextLink}
+                  href={item.href}
+                  sx={{ height: '100%' }}
                 >
-                  <Box
-                    sx={{
-                      width: 56,
-                      height: 56,
-                      borderRadius: '50%',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      backgroundColor: `${item.color}14`,
-                      color: item.color,
-                      mb: 1,
-                    }}
-                  >
-                    <Icon sx={{ fontSize: 28 }} />
-                  </Box>
-
-                  <Box sx={{ flexGrow: 1 }}>
-                    <Typography
-                      variant="h6"
-                      component="h2"
-                      sx={{ fontWeight: 700 }}
-                      gutterBottom
-                    >
-                      {item.title}
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      color="textSecondary"
-                      sx={{ lineHeight: 1.6 }}
-                    >
-                      {item.description}
-                    </Typography>
-                  </Box>
-
-                  <Box
+                  <CardContent
                     sx={{
                       display: 'flex',
+                      flexDirection: 'column',
                       alignItems: 'center',
-                      color: item.color,
-                      fontWeight: 600,
-                      fontSize: '0.875rem',
-                      gap: 0.5,
+                      textAlign: 'center',
+                      height: '100%',
+                      py: 4,
+                      px: 3,
+                      gap: 1.5,
                     }}
                   >
-                    詳細を見る
-                    <ArrowForwardIcon sx={{ fontSize: 18 }} />
-                  </Box>
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          );
-        })}
-      </Box>
-    </Container>
+                    <Box
+                      sx={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: '50%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        backgroundColor: `${item.color}14`,
+                        color: item.color,
+                        mb: 1,
+                      }}
+                    >
+                      <Icon sx={{ fontSize: 28 }} />
+                    </Box>
+
+                    <Box sx={{ flexGrow: 1 }}>
+                      <Typography
+                        variant="h6"
+                        component="h2"
+                        sx={{ fontWeight: 700 }}
+                        gutterBottom
+                      >
+                        {item.title}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        color="textSecondary"
+                        sx={{ lineHeight: 1.6 }}
+                      >
+                        {item.description}
+                      </Typography>
+                    </Box>
+
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        color: item.color,
+                        fontWeight: 600,
+                        fontSize: '0.875rem',
+                        gap: 0.5,
+                      }}
+                    >
+                      詳細を見る
+                      <ArrowForwardIcon sx={{ fontSize: 18 }} />
+                    </Box>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            );
+          })}
+        </Box>
+      </Container>
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </>
   );
 };
 

--- a/src/app/(protected)/(standard)/_components/MainMenu.tsx
+++ b/src/app/(protected)/(standard)/_components/MainMenu.tsx
@@ -52,7 +52,7 @@ const MainMenu = ({ accessDenied }: { accessDenied?: string | undefined }) => {
   const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
 
   useEffect(() => {
-    if (accessDenied != null) {
+    if (accessDenied) {
       showSnackbar('このページを表示する権限がありません。', 'warning');
       router.replace('/home', { scroll: false });
     }

--- a/src/app/(protected)/(standard)/home/page.tsx
+++ b/src/app/(protected)/(standard)/home/page.tsx
@@ -9,10 +9,16 @@ export const metadata: Metadata = {
 const Home = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ accessDenied?: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) => {
   const { accessDenied } = await searchParams;
-  return <MainMenu accessDenied={accessDenied} />;
+  return (
+    <MainMenu
+      accessDenied={
+        Array.isArray(accessDenied) ? accessDenied[0] : accessDenied
+      }
+    />
+  );
 };
 
 export default Home;

--- a/src/app/(protected)/(standard)/home/page.tsx
+++ b/src/app/(protected)/(standard)/home/page.tsx
@@ -6,6 +6,13 @@ export const metadata: Metadata = {
   title: 'ホーム | Seichi Portal',
 };
 
-const Home = () => <MainMenu />;
+const Home = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ accessDenied?: string }>;
+}) => {
+  const { accessDenied } = await searchParams;
+  return <MainMenu accessDenied={accessDenied} />;
+};
 
 export default Home;

--- a/src/app/(protected)/admin/layout.tsx
+++ b/src/app/(protected)/admin/layout.tsx
@@ -1,6 +1,6 @@
+import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
-import ErrorDialog from '@/app/_components/ErrorDialog';
 import NavBar from '@/app/_components/NavBar';
 import { getAdminAccess } from '@/lib/server/session';
 
@@ -13,7 +13,7 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
   const adminAccess = await getAdminAccess();
 
   if (adminAccess.state === 'forbidden') {
-    return <ErrorDialog status={403} showDiagnostics={false} />;
+    redirect('/home?accessDenied=admin');
   }
 
   return (


### PR DESCRIPTION
## 概要
- `/admin/*` へ認証済み・非管理者でアクセスした場合、「ホームへ戻る」ボタンしかないポップアップ(`ErrorDialog`)を表示していたのをやめ、`/home` へリダイレクトしてSnackbarで「このページを表示する権限がありません。」と通知する方式に変更 (#853)
- `src/app/(protected)/admin/layout.tsx` の forbidden 判定時の挙動を `<ErrorDialog />` 返却から `redirect('/home?accessDenied=admin')` に変更
- `src/app/(protected)/(standard)/home/page.tsx` で `accessDenied` クエリパラメータを受け取り `MainMenu` に渡し、`MainMenu` 側で Snackbar 表示後に `router.replace('/home')` でクエリパラメータを消去(既存の `FormsPageContent` の `createdFormId` 通知と同じパターンを踏襲)
- 未認証ユーザーの `/admin` アクセス時の挙動(ログイン誘導リダイレクト)は変更していない

close #853

## 確認事項
- モックバックエンドを立てた上で隔離した git worktree 上で実際に dev サーバーを起動し、非管理者ユーザーとして `/admin` にリクエストしたところ `307 Temporary Redirect` で `location: /home?accessDenied=admin` を確認、遷移先も `200 OK` で正常にレンダリングされることを確認した
- 未認証ユーザーの `/admin` アクセスが従来通り `/` へのログイン誘導リダイレクトのままであることも確認した
- この環境には Playwright 実行に必要な Chromium 用共有ライブラリが無く、ブラウザ上での Snackbar 表示自体は目視確認できていない。ロジックは既存の `FormsPageContent` で実績のあるパターンをそのまま踏襲している
- `pnpm lint` / `pnpm type-check` / `pnpm test:unit` はすべて通過(pre-commit / pre-push フックで実行済み)

🤖 Generated with Claude Code