### PR TITLE
fix: コメント・メッセージ投稿後にSWRキャッシュを即座に再検証する

### DIFF
--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -27,7 +27,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
-      await mutate(commentsKey);
+      void mutate(commentsKey).catch(() => {});
       return { ok: true };
     }
 
@@ -51,7 +51,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
-      await mutate(commentsKey);
+      void mutate(commentsKey).catch(() => {});
       return { ok: true };
     }
 
@@ -77,7 +77,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
-      await mutate(commentsKey);
+      void mutate(commentsKey).catch(() => {});
       return { ok: true };
     }
 

--- a/src/hooks/useCommentActions.ts
+++ b/src/hooks/useCommentActions.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { useSWRConfig } from 'swr';
+
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
@@ -7,6 +9,12 @@ import { proxyClient } from '@/lib/proxyClient';
 type CommentActionResult = { ok: boolean; forbidden?: boolean };
 
 export const useCommentActions = (formId: string, answerId: string) => {
+  const { mutate } = useSWRConfig();
+  const commentsKey = [
+    '/api/v1/forms/{form_id}/answers/{answer_id}/comments',
+    { path: { form_id: formId, answer_id: answerId } },
+  ];
+
   const sendComment = async (content: string): Promise<CommentActionResult> => {
     const { data, error, response } = await proxyClient.POST(
       '/api/v1/forms/{form_id}/answers/{answer_id}/comments',
@@ -19,6 +27,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
+      await mutate(commentsKey);
       return { ok: true };
     }
 
@@ -42,6 +51,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
+      await mutate(commentsKey);
       return { ok: true };
     }
 
@@ -67,6 +77,7 @@ export const useCommentActions = (formId: string, answerId: string) => {
     );
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
+      await mutate(commentsKey);
       return { ok: true };
     }
 

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { useSWRConfig } from 'swr';
+
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
 import { proxyClient } from '@/lib/proxyClient';
@@ -7,6 +9,12 @@ import { proxyClient } from '@/lib/proxyClient';
 type SendMessageResult = { success: boolean; forbidden?: boolean };
 
 export const useSendMessage = (formId: string, answerId: string) => {
+  const { mutate } = useSWRConfig();
+  const messagesKey = [
+    '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
+    { path: { form_id: formId, answer_id: answerId } },
+  ];
+
   const sendMessage = async (body: string): Promise<SendMessageResult> => {
     const { data, error, response } = await proxyClient.POST(
       '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
@@ -18,6 +26,7 @@ export const useSendMessage = (formId: string, answerId: string) => {
 
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
+      await mutate(messagesKey);
       return { success: true };
     }
     return { success: false, ...(result.forbidden ? { forbidden: true } : {}) };

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -26,7 +26,7 @@ export const useSendMessage = (formId: string, answerId: string) => {
 
     const result = handleMutationResponse(response, data, error);
     if (result.success) {
-      await mutate(messagesKey);
+      void mutate(messagesKey).catch(() => {});
       return { success: true };
     }
     return { success: false, ...(result.forbidden ? { forbidden: true } : {}) };


### PR DESCRIPTION
## 概要
- Issue #858: コメント・メッセージを投稿してから画面に反映されるまでに時間がかかりすぎる問題を修正
- 原因: `useSendMessage`/`useCommentActions` はPOST/PATCH/DELETE成功後にSWRの再検証をトリガーしておらず、次のポーリング発火（`refreshInterval: 1000`、最大1秒後）まで画面に反映されなかった
- `useLabelCRUD`/`useUserGroupCRUD`で既に使われているパターン（成功時に`useSWRConfig().mutate(key)`で即時revalidateする）を踏襲し、メッセージ送信・コメント送信/更新/削除の各成功時に対象クエリを即座に再検証するようにした
- オプティミスティックUI（`optimisticData`）はリポジトリに前例がなく、ロールバックや一時IDの管理が新たに必要になるため見送り、既存の確立済みパターンで解決した

## 確認事項
- `tsc --noEmit`、ESLintともに変更ファイルでエラーなしを確認
- `pnpm test:unit`（68件）、`pnpm test:component`（73件）ともに全て通過し、既存機能への回帰がないことを確認
- E2E（`pnpm test:e2e`）はバックエンド・MSAL認証との連携が必要なため、この環境では未実施。レビュアーには実際のポーリング環境でコメント・メッセージ投稿時の反映速度を確認いただきたい

## 補足
特になし

🤖 Generated with Claude Code