### PR TITLE
回答タイトルが未設定のとき未設定であることがわかるように表示する

### DIFF
--- a/src/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetailsPageView.tsx
@@ -46,7 +46,8 @@ const AnswerDetailsPageView = ({
   >
     <Typography
       variant="h4"
-      sx={!data.answer.title ? { color: 'text.secondary' } : undefined}
+      component="h1"
+      sx={!data.answer.title?.trim() ? { color: 'text.secondary' } : undefined}
     >
       {resolveAnswerTitle(data.answer.title)}
     </Typography>

--- a/src/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/[answerId]/_components/AnswerDetailsPageView.tsx
@@ -8,6 +8,7 @@ import type {
   GetFormResponse,
   GetMessagesResponse,
 } from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 
 import AnswerDetails from './AnswerDetails';
 import AnswerMeta from './AnswerMeta';
@@ -43,7 +44,12 @@ const AnswerDetailsPageView = ({
       alignItems: 'stretch',
     }}
   >
-    <Typography variant="h4">{data.answer.title}</Typography>
+    <Typography
+      variant="h4"
+      sx={!data.answer.title ? { color: 'text.secondary' } : undefined}
+    >
+      {resolveAnswerTitle(data.answer.title)}
+    </Typography>
     <AnswerMeta
       answer={data.answer}
       messageAction={

--- a/src/app/(protected)/(standard)/forms/[formId]/answers/_lib/answerListRows.ts
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/_lib/answerListRows.ts
@@ -1,5 +1,6 @@
 import { formatString } from '@/generic/DateFormatter';
 import type { GetFormAnswersResponse } from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 
 export type AnswerListRow = {
   id: string;
@@ -12,6 +13,6 @@ export const toAnswerListRows = (
 ): AnswerListRow[] =>
   answers.map((answer) => ({
     id: answer.id,
-    title: answer.title ?? '',
+    title: resolveAnswerTitle(answer.title),
     date: formatString(answer.timestamp),
   }));

--- a/src/app/(protected)/admin/_components/Dashboard.tsx
+++ b/src/app/(protected)/admin/_components/Dashboard.tsx
@@ -16,6 +16,7 @@ import InfiniteScrollSentinel from '@/app/_components/InfiniteScrollSentinel';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
 import { formatString } from '@/generic/DateFormatter';
 import type { GetAnswersPageResponse, GetFormsResponse } from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 
 interface Row {
   id: string;
@@ -50,7 +51,7 @@ const DataTable = (props: {
       answers.map((answer) => ({
         id: answer.id,
         category: formTitleById.get(answer.form_id) ?? 'unknown form',
-        title: answer.title ?? '',
+        title: resolveAnswerTitle(answer.title),
         date: formatString(answer.timestamp),
       })),
     [answers, formTitleById]

--- a/src/app/(protected)/admin/answer/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(protected)/admin/answer/[answerId]/_components/AnswerDetails.tsx
@@ -17,6 +17,7 @@ import type {
   GetAnswerLabelsResponse,
   GetAnswerResponse,
 } from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 
 export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
   const { handleSubmit, register } = useForm<{ title: string }>();
@@ -53,8 +54,12 @@ export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
           sx={{ minWidth: 280, flexGrow: 1 }}
         />
       ) : (
-        <Typography variant="h4" component="h1">
-          {title}
+        <Typography
+          variant="h4"
+          component="h1"
+          sx={!title ? { color: 'text.secondary' } : undefined}
+        >
+          {resolveAnswerTitle(title)}
         </Typography>
       )}
       {isEditing ? (

--- a/src/app/(protected)/admin/answer/[answerId]/_components/AnswerDetails.tsx
+++ b/src/app/(protected)/admin/answer/[answerId]/_components/AnswerDetails.tsx
@@ -57,7 +57,7 @@ export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
         <Typography
           variant="h4"
           component="h1"
-          sx={!title ? { color: 'text.secondary' } : undefined}
+          sx={!title?.trim() ? { color: 'text.secondary' } : undefined}
         >
           {resolveAnswerTitle(title)}
         </Typography>

--- a/src/lib/forms/answerTitle.ts
+++ b/src/lib/forms/answerTitle.ts
@@ -1,0 +1,4 @@
+export const UNSET_ANSWER_TITLE = '(タイトル未設定)';
+
+export const resolveAnswerTitle = (title: string | null | undefined): string =>
+  title && title.trim() !== '' ? title : UNSET_ANSWER_TITLE;

--- a/tests/unit/answerListRows.test.ts
+++ b/tests/unit/answerListRows.test.ts
@@ -37,12 +37,15 @@ describe('toAnswerListRows', () => {
     ]);
   });
 
-  it('回答タイトルが null または未指定のときは空文字へ正規化する', () => {
+  it('回答タイトルが null または未指定のときは未設定を示す表示へ変換する', () => {
     const rows = toAnswerListRows([
       createAnswer({ id: 'null-title', title: null }),
       createAnswer({ id: 'missing-title' }),
     ]);
 
-    expect(rows.map((row) => row.title)).toEqual(['', '']);
+    expect(rows.map((row) => row.title)).toEqual([
+      '(タイトル未設定)',
+      '(タイトル未設定)',
+    ]);
   });
 });


### PR DESCRIPTION
## 概要
- #861 対応。回答タイトルが空文字/未設定のとき、単なる空白になりタイトル欄であることすら認識できなかった問題を修正
- 共通関数 `resolveAnswerTitle`（`src/lib/forms/answerTitle.ts`）を新設し、未設定時は「(タイトル未設定)」を表示するよう統一
- 対象は以下4箇所: 管理者向け回答詳細、一般ユーザー向け回答詳細、回答一覧(DataGrid)、管理ダッシュボードの回答一覧テーブル

## 確認事項
- `pnpm tsc --noEmit`、対象ファイルの `eslint`、`pnpm build` がすべて成功することを確認
- 既存のユニットテスト `tests/unit/answerListRows.test.ts` が旧仕様(空文字への正規化)を前提にしていたため、新仕様に合わせて期待値を更新し、テストが通ることを確認
- バックエンドAPIに依存するため、実ブラウザでの動作確認は未実施

## 補足
- 表示テキストは既存の未設定表示の慣習(`未設定`)に合わせつつ、タイトル欄であることを明確にするため「(タイトル未設定)」とした

🤖 Generated with Claude Code