### PR TITLE
fix: Markdownリンクのホイールクリックでも外部サイト警告ダイアログを表示する

### DIFF
--- a/src/app/_components/MarkdownText.tsx
+++ b/src/app/_components/MarkdownText.tsx
@@ -49,7 +49,9 @@ const MarkdownText = ({ children, sx }: Props) => {
     (href: string | undefined) => (event: MouseEvent<HTMLAnchorElement>) => {
       // ホイールクリック(中クリック)以外の auxclick(右クリック等)は対象外とする
       if (event.button !== 1) return;
-      handleLinkClick(href)(event);
+      if (!isExternalHttpLink(href)) return;
+      event.preventDefault();
+      setPendingHref(href);
     };
 
   return (

--- a/src/app/_components/MarkdownText.tsx
+++ b/src/app/_components/MarkdownText.tsx
@@ -32,6 +32,8 @@ const isExternalHttpLink = (href: string | undefined): href is string =>
  * また、リンク文言と実際の遷移先を偽装される(例: `[https://example.com](https://evil.example)`)
  * リスクに備え、外部(http/https)リンクのクリック時のみ実際の遷移先 URL を提示する確認ダイアログを
  * 挟んでから遷移する。相対パスやページ内アンカーなど同一オリジンへの内部リンクは対象外とする。
+ * ホイールクリック(中クリック)は click イベントではなく auxclick イベントとして発火するため、
+ * onAuxClick でも同様に確認ダイアログを挟む。
  */
 const MarkdownText = ({ children, sx }: Props) => {
   const [pendingHref, setPendingHref] = useState<string | null>(null);
@@ -41,6 +43,13 @@ const MarkdownText = ({ children, sx }: Props) => {
       if (!isExternalHttpLink(href)) return;
       event.preventDefault();
       setPendingHref(href);
+    };
+
+  const handleLinkAuxClick =
+    (href: string | undefined) => (event: MouseEvent<HTMLAnchorElement>) => {
+      // ホイールクリック(中クリック)以外の auxclick(右クリック等)は対象外とする
+      if (event.button !== 1) return;
+      handleLinkClick(href)(event);
     };
 
   return (
@@ -55,6 +64,7 @@ const MarkdownText = ({ children, sx }: Props) => {
               target="_blank"
               rel="noopener noreferrer"
               onClick={handleLinkClick(href)}
+              onAuxClick={handleLinkAuxClick(href)}
             >
               {linkChildren}
             </a>

--- a/tests/component/MarkdownText.test.tsx
+++ b/tests/component/MarkdownText.test.tsx
@@ -117,6 +117,24 @@ describe('MarkdownText', () => {
       });
     });
 
+    it('ホイールクリック(中クリック)でも確認ダイアログを表示し、既定では遷移しない', async () => {
+      const user = userEvent.setup();
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      renderWithProviders(
+        <MarkdownText>{'[リンク](https://example.com/path)'}</MarkdownText>
+      );
+
+      const link = screen.getByRole('link', { name: 'リンク' });
+      await user.pointer({ keys: '[MouseMiddle]', target: link });
+
+      const dialog = await screen.findByRole('dialog');
+      expect(
+        within(dialog).getByText('https://example.com/path')
+      ).toBeVisible();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
     it.each([
       ['相対パス', '/dashboard'],
       ['ページ内アンカー', '#section-1'],


### PR DESCRIPTION
## 概要
- `MarkdownText` の外部リンク警告ダイアログは `onClick` のみで実装されており、`click` イベントは主ボタン(左クリック)でのみ発火するため、ホイールクリック(中クリック)による新規タブオープンでは確認ダイアログをバイパスして直接遷移できてしまっていた
- `onAuxClick` を追加し、中クリック(`event.button === 1`)の場合も `onClick` と同じ処理(`preventDefault` してダイアログ表示)を通すよう修正
- 右クリック等の他の auxclick は対象外のまま(ボタン判定でガード)

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm fmt` (prettier --check) を通過
- `tests/component/MarkdownText.test.tsx` に中クリックのテストケースを追加(`user.pointer({ keys: '[MouseMiddle]', ... })` で `onAuxClick` の挙動を検証)
- ただし、このリポジトリの `tests/component/` 配下のテストは `@testing-library/user-event@14.6.1` と `jsdom@29.1.1` の組み合わせで `userEvent.setup()` が例外を投げる既存の環境不整合があり、変更前の状態でも同ファイルの既存テストが同じエラーで全滅することを確認済み(今回の変更が原因ではない)。そのため追加したテストケースを含め、component テストの実行による動作確認はできていない
- `pnpm test:unit`(vitest.unit.config.ts、component テストとは別スイート)は 68 件全て成功

## 補足
- `tests/component/` の `userEvent` 実行環境不整合は本 PR のスコープ外の既存問題として残置。別途対応が必要

🤖 Generated with Claude Code