### PR TITLE
回答タイトルの埋め込み記法を $form_name に対応させる

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -178,7 +178,7 @@ const AnswerSettings = ({
       <TextField
         {...register('settings.default_answer_title')}
         label="デフォルトの回答タイトル"
-        helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名をタイトルに埋め込むことができます。例: $username さんの回答"
+        helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名を、$form_name でフォームタイトルをタイトルに埋め込むことができます。例: [$form_name] $username さんの回答"
       />
     </>
   );

--- a/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
@@ -49,7 +49,7 @@ const QuestionEditor = (props: {
       <TextField
         {...props.register(`questions.${props.questionIndex}.template_key`)}
         label="テンプレートキー"
-        helperText="テンプレートで識別するためのキーです。空欄のままでも構いません。"
+        helperText="回答タイトルへの埋め込みに使う識別キーです。半角英数字・_・- のみ使用できます（1〜255文字）。username と form_name は予約語のため使用できません。空欄のままでも構いません。"
       />
       <FormControlLabel
         label="この質問への回答を必須にする"

--- a/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
@@ -22,7 +22,7 @@ export const createEmptyFormEditorValues = (): FormEditorValues => ({
   settings: {
     acceptance_period: { kind: 'none' },
     discord_webhook_url: '',
-    default_answer_title: '',
+    default_answer_title: '[$form_name] $username さんの回答',
     visibility: 'PRIVATE',
     allowed_group_ids: [],
     answer_visibility: 'PRIVATE',

--- a/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
@@ -7,14 +7,12 @@ const reservedTemplateKeys = new Set(['username', 'form_name']);
 
 const templateKeySchema = z
   .string()
-  .refine(
-    (value) => value.trim() === '' || templateKeyPattern.test(value.trim()),
-    {
-      message:
-        'テンプレートキーは半角英数字・_・- のみ使用できます（1〜255文字）。',
-    }
-  )
-  .refine((value) => !reservedTemplateKeys.has(value.trim()), {
+  .trim()
+  .refine((value) => value === '' || templateKeyPattern.test(value), {
+    message:
+      'テンプレートキーは半角英数字・_・- のみ使用できます（1〜255文字）。',
+  })
+  .refine((value) => !reservedTemplateKeys.has(value), {
     message: 'username と form_name は予約語のため使用できません。',
   });
 

--- a/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
@@ -2,6 +2,22 @@ import { z } from 'zod';
 
 const requiredStringSchema = z.string().trim().min(1, '入力してください。');
 
+const templateKeyPattern = /^[A-Za-z0-9_-]{1,255}$/;
+const reservedTemplateKeys = new Set(['username', 'form_name']);
+
+const templateKeySchema = z
+  .string()
+  .refine(
+    (value) => value.trim() === '' || templateKeyPattern.test(value.trim()),
+    {
+      message:
+        'テンプレートキーは半角英数字・_・- のみ使用できます（1〜255文字）。',
+    }
+  )
+  .refine((value) => !reservedTemplateKeys.has(value.trim()), {
+    message: 'username と form_name は予約語のため使用できません。',
+  });
+
 export const questionTypeSchema = z.enum([
   'Text',
   'SingleChoice',
@@ -34,7 +50,7 @@ export const formEditorQuestionSchema = z
     choices: choiceSchema.array(),
     is_required: z.boolean(),
     position: z.number().int().gte(0),
-    template_key: z.string(),
+    template_key: templateKeySchema,
   })
   .superRefine((question, context) => {
     if (question.question_type !== 'Text' && question.choices.length === 0) {

--- a/tests/unit/formEditorSchema.test.ts
+++ b/tests/unit/formEditorSchema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { formEditorQuestionSchema } from '@/app/(protected)/admin/forms/_schema/formEditorSchema';
+import type { FormEditorQuestion } from '@/app/(protected)/admin/forms/_schema/formEditorSchema';
+
+const baseQuestion: FormEditorQuestion = {
+  identity: { kind: 'new' },
+  title: 'Question title',
+  description: '',
+  question_type: 'Text',
+  choices: [],
+  is_required: false,
+  position: 0,
+  template_key: '',
+};
+
+const parseTemplateKey = (templateKey: string) =>
+  formEditorQuestionSchema.safeParse({
+    ...baseQuestion,
+    template_key: templateKey,
+  });
+
+describe('formEditorQuestionSchema template_key', () => {
+  it('allows an empty template_key', () => {
+    expect(parseTemplateKey('').success).toBe(true);
+  });
+
+  it('allows ASCII alphanumeric, underscore and hyphen', () => {
+    expect(parseTemplateKey('answer-1_key').success).toBe(true);
+  });
+
+  it('allows a key at the 255 character limit', () => {
+    expect(parseTemplateKey('a'.repeat(255)).success).toBe(true);
+  });
+
+  it('rejects a key over the 255 character limit', () => {
+    expect(parseTemplateKey('a'.repeat(256)).success).toBe(false);
+  });
+
+  it('rejects characters outside ASCII alphanumeric/_/-', () => {
+    expect(parseTemplateKey('質問キー').success).toBe(false);
+    expect(parseTemplateKey('key with space').success).toBe(false);
+  });
+
+  it.each(['username', 'form_name'])(
+    'rejects the reserved word "%s"',
+    (reserved) => {
+      expect(parseTemplateKey(reserved).success).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
## 概要
- seichi-portal-backend#1194 で回答タイトルの埋め込み記法が `$<template_key>` に統一され、#1197 で `$form_name`（フォーム名）が予約語として追加されたため、フロントエンドの説明文言・バリデーションを追従させる
- テンプレートキー・デフォルト回答タイトルのヘルプテキストを `$form_name` 対応の内容に更新
- テンプレートキーに ASCII 英数字・`_`・`-` のみ（1〜255文字）の文字種制約と、`username` / `form_name` の予約語チェックをフロントエンドの Zod スキーマにも追加し、バックエンドの制約と揃えた（従来はバックエンド任せで未検証だった）
- 新規フォーム作成時のデフォルト回答タイトルを空文字から `[$form_name] $username さんの回答` に変更し、そのままカスタムもできるようにした

## 確認事項
- `tsc --noEmit`、`eslint`、`prettier --check` がすべて成功（commit 時の lefthook pre-commit フックで確認）
- `pnpm test:unit` が成功（push 時の lefthook pre-push フックで確認）
- 追加した `tests/unit/formEditorSchema.test.ts` で、テンプレートキーの文字種制約（255文字境界含む）と予約語 `username` / `form_name` の拒否を確認
- 既存フォームの `default_answer_title` は API から取得した値（null なら空文字）をそのまま表示するため、今回の新規作成時デフォルト値の変更による既存フォームへの影響はない

🤖 Generated with Claude Code