### PR TITLE
fix: 検索候補Autocompleteのkeyが一意にならない問題を修正

### DIFF
--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -102,6 +102,9 @@ const SearchField = () => {
         getOptionLabel={(option) =>
           typeof option === 'string' ? option : option.title
         }
+        getOptionKey={(option) =>
+          typeof option === 'string' ? option : option.id
+        }
         onInputChange={(_event, value, reason) => {
           if (reason === 'input' || reason === 'clear') {
             handleInputChange(value);


### PR DESCRIPTION
## 概要
- 管理画面の検索フィールド（`SearchField.tsx`）で、Autocomplete の候補一覧に React の「Each child in a list should have a unique "key" prop」警告が発生していた
- `renderOption` 側では `key={key}` を正しく設定していたが、Autocomplete 自体に `getOptionKey` を渡していなかったため、内部デフォルトの `getOptionLabel(option)`（= `option.title`）がキーとして使われていた
- フォーム・回答・ユーザー・ラベル・コメントなど異なる種類の検索結果でタイトル文字列が重複しうるため、キーが衝突・不安定になっていた
- 各候補は生成時に一意な連番 `id` を持っている（`toSearchResultRows` 参照）ため、`getOptionKey` で `option.id` を明示的に使うよう修正

## 確認事項
- `pnpm tsc --noEmit` / `pnpm eslint` で型・lintエラーなし
- コミット時の lefthook pre-commit（lint / type-check / fmt）、pre-push（unit-test 76件）はすべて成功

## 補足
- ブラウザでの実機確認（検索実行して警告が消えることの確認）は未実施。レビューまたは動作確認時に管理画面の検索フィールドでコンソール警告が出ないか確認いただけると安心です

🤖 Generated with Claude Code