### PR TITLE
fix: SearchFieldのPaperでhydrationミスマッチ警告を解消する

### DIFF
--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -71,6 +71,7 @@ const SearchField = () => {
 
   return (
     <Paper
+      suppressHydrationWarning
       sx={(theme) => ({
         p: '2px 4px',
         display: 'flex',


### PR DESCRIPTION
## 概要
- 管理画面の `SearchField`（`Paper` コンポーネント）で、コンソールに hydration mismatch エラーが発生していた
- 原因は ProtonPass などのパスワードマネージャー拡張が、React の hydration 前に対象 DOM へ `data-protonpass-form` 属性を注入し、SSR 出力とクライアント出力が食い違うこと
- 拡張機能側の挙動でありアプリ側では制御できないため、`Paper` に `suppressHydrationWarning` を付与して警告を抑制する

## 確認事項
- `pnpm type-check` が成功することを確認
- コミット時の pre-commit（lint / type-check / fmt）、pre-push（unit test）フックがすべて成功することを確認
- ブラウザ拡張が注入する属性は環境依存のため、実際の再現・非再現確認は拡張機能がインストールされたブラウザでの手動確認が必要（未実施）。レビューではこの対処法の妥当性（`suppressHydrationWarning` の付与範囲）を見てもらいたい

🤖 Generated with Claude Code