### PR TITLE
fix: SearchFieldの検索inputでもhydrationミスマッチ警告を抑制する

### DIFF
--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -155,6 +155,7 @@ const SearchField = () => {
               htmlInput: {
                 ...params.slotProps.htmlInput,
                 'aria-label': 'search...',
+                suppressHydrationWarning: true,
               },
             }}
             sx={{ ml: 1, flex: 1 }}


### PR DESCRIPTION
## 概要
- #875 で `SearchField` の `Paper` に `suppressHydrationWarning` を付与したが、gemini-code-assist のレビュー指摘の通り、`suppressHydrationWarning` は付与した要素自身の属性差分のみを抑制し、子孫要素の差分までは抑制しない
- パスワードマネージャー拡張は `Paper` のコンテナだけでなく、中の `<input>` 要素にも自動入力用の属性を注入することが一般的なため、そちらでも hydration mismatch 警告が発生し得る
- `TextField` の `slotProps.htmlInput` にも `suppressHydrationWarning` を付与し、`<input>` 要素側の警告も抑制する

## 確認事項
- `pnpm type-check` が成功することを確認
- コミット時の pre-commit（lint / type-check / fmt）、pre-push（unit test）フックがすべて成功することを確認
- ブラウザ拡張が注入する属性は環境依存のため、実際の再現・非再現確認は拡張機能がインストールされたブラウザでの手動確認が必要（未実施）

🤖 Generated with Claude Code