### PR TITLE
fix: 検索候補のrenderOption内要素にkeyを明示しkey警告を解消する

### DIFF
--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -133,12 +133,13 @@ const SearchField = () => {
               sx={{ alignItems: 'center', width: '100%' }}
             >
               <Chip
+                key="category"
                 label={option.category}
                 color={SEARCH_RESULT_CATEGORY_COLOR[option.category]}
                 size="small"
                 variant="outlined"
               />
-              <Typography variant="body2" noWrap sx={{ flex: 1 }}>
+              <Typography key="title" variant="body2" noWrap sx={{ flex: 1 }}>
                 {option.title}
               </Typography>
             </Stack>

--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -139,7 +139,13 @@ const SearchField = () => {
                 size="small"
                 variant="outlined"
               />
-              <Typography key="title" variant="body2" noWrap sx={{ flex: 1 }}>
+              <Typography
+                key="title"
+                component="span"
+                variant="body2"
+                noWrap
+                sx={{ flex: 1 }}
+              >
                 {option.title}
               </Typography>
             </Stack>


### PR DESCRIPTION
## 概要
- 管理画面の検索窓(`SearchField`)で候補一覧を開くと、React の「Each child in a list should have a unique "key" prop.」警告が console に出続けていた
- 外側の `<Stack component="li">` には `getOptionKey` 由来の `key` を既に付与済みだったが、その内側の `Chip`/`Typography` に明示的な `key` がなく、Turbopack 環境下では `renderOption` コールバック内で作成した要素が Autocomplete をownerとして記録されるため、React の validated マーキングを受けられずリスト内の未keyな子要素として警告される状態だった
- `Chip`/`Typography` にも固定文字列の `key` を追加し、警告条件(`key == null`)を直接解消した

## 確認事項
- 実機の dev サーバー(Next.js 16.2.9 / Turbopack)で `/admin` の検索窓に文字を入力し、候補一覧を開いて警告が再現することを確認
- 修正後、同じ操作で警告が発生しないことを実際の画面で確認済み(報告者にも確認してもらい再現しないことを確認)
- `pnpm lint` / `pnpm type-check` / `pnpm test:unit` はコミット時・push時のフックで通過済み

🤖 Generated with Claude Code