### PR TITLE
feat: フォーム回答一覧で回答内容の検索を可能にする

### DIFF
--- a/src/app/(protected)/(standard)/forms/[formId]/answers/_components/AnswersPageContent.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/_components/AnswersPageContent.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
 import type {
   GetFormAnswersPageResponse,
@@ -12,6 +14,8 @@ import { toAnswerListRows } from '../_lib/answerListRows';
 
 import AnswersView from './AnswersView';
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 const AnswersPageContent = ({
   form,
   initialAnswers,
@@ -20,6 +24,32 @@ const AnswersPageContent = ({
   initialAnswers: GetFormAnswersPageResponse;
 }) => {
   const router = useRouter();
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const trimmed = search.trim();
+    if (trimmed === '') {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedSearch(trimmed);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (value.trim() === '') {
+      setDebouncedSearch('');
+    }
+  };
+
+  const isSearching = debouncedSearch !== '';
+
   const {
     items: answers,
     hasMore,
@@ -33,13 +63,27 @@ const AnswersPageContent = ({
     }),
     initialAnswers
   );
-  const rows = toAnswerListRows(answers);
+
+  const { data: searchData, isLoading: isSearchLoading } = useApiQuery(
+    '/api/v1/search/answers',
+    isSearching
+      ? { query: { query: debouncedSearch, form_id: form.id } }
+      : null,
+    { keepPreviousData: true }
+  );
+
+  const rows = isSearching
+    ? toAnswerListRows(searchData?.answers ?? [])
+    : toAnswerListRows(answers);
 
   return (
     <AnswersView
       formTitle={form.title}
       rows={rows}
-      hasMore={hasMore}
+      search={search}
+      onSearchChange={handleSearchChange}
+      isSearchLoading={isSearching && isSearchLoading}
+      hasMore={!isSearching && hasMore}
       isLoadingMore={isLoadingMore}
       onLoadMore={loadMore}
       onAnswerClick={(answerId) => {

--- a/src/app/(protected)/(standard)/forms/[formId]/answers/_components/AnswersView.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/_components/AnswersView.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Search } from '@mui/icons-material';
+import {
+  Box,
+  CircularProgress,
+  InputAdornment,
+  LinearProgress,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { DataGrid, gridClasses, useGridApiRef } from '@mui/x-data-grid';
 import type {
   GridColDef,
@@ -16,6 +24,9 @@ const SCROLL_END_THRESHOLD_PX = 200;
 const AnswersView = ({
   formTitle,
   rows,
+  search,
+  onSearchChange,
+  isSearchLoading = false,
   hasMore,
   isLoadingMore,
   onLoadMore,
@@ -23,6 +34,9 @@ const AnswersView = ({
 }: {
   formTitle: string;
   rows: AnswerListRow[];
+  search: string;
+  onSearchChange: (value: string) => void;
+  isSearchLoading?: boolean;
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
@@ -65,31 +79,68 @@ const AnswersView = ({
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Typography variant="h5" component="h1" sx={{ mb: 2 }}>
-        {formTitle}
-      </Typography>
-      <DataGrid
-        apiRef={apiRef}
-        rows={rows}
-        columns={columns}
-        onRowClick={handleRowClick}
+      <Box
         sx={{
-          border: 0,
-          height: 560,
-          '& .MuiDataGrid-columnHeaders': {
-            backgroundColor: 'action.hover',
-          },
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 2,
+          mb: 2,
         }}
-        disableRowSelectionOnClick
-        slots={{
-          footer: () =>
-            isLoadingMore ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
-                <CircularProgress size={20} />
-              </Box>
-            ) : null,
-        }}
-      />
+      >
+        <Typography variant="h5" component="h1">
+          {formTitle}
+        </Typography>
+        <TextField
+          variant="standard"
+          size="small"
+          label="回答内容を検索"
+          value={search}
+          onChange={(e) => {
+            onSearchChange(e.target.value);
+          }}
+          sx={{ minWidth: 240 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search fontSize="small" />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </Box>
+      <Box sx={{ position: 'relative' }}>
+        {isSearchLoading && (
+          <LinearProgress
+            sx={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1 }}
+          />
+        )}
+        <DataGrid
+          apiRef={apiRef}
+          rows={rows}
+          columns={columns}
+          onRowClick={handleRowClick}
+          sx={{
+            border: 0,
+            height: 560,
+            '& .MuiDataGrid-columnHeaders': {
+              backgroundColor: 'action.hover',
+            },
+          }}
+          disableRowSelectionOnClick
+          slots={{
+            footer: () =>
+              isLoadingMore ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              ) : null,
+          }}
+        />
+      </Box>
     </Box>
   );
 };

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -445,6 +445,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/search/answers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 回答検索を行う */
+        get: operations["search_answers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/search/users": {
         parameters: {
             query?: never;
@@ -701,6 +718,9 @@ export interface components {
         AnswerListPageResponse: {
             items: components["schemas"]["FormAnswer"][];
             next_cursor?: string | null;
+        };
+        AnswerSearchResult: {
+            answers: components["schemas"]["FormAnswer"][];
         };
         AnswerSettingsSchema: {
             acceptance_period: components["schemas"]["AnswerAcceptancePeriodSchema"];
@@ -3845,6 +3865,67 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CrossSearchResult"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    search_answers: {
+        parameters: {
+            query: {
+                /** @description Search query */
+                query: string;
+                /** @description Limit results to the specified form */
+                form_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnswerSearchResult"];
                 };
             };
             /** @description The server could not understand the request due to invalid syntax. */

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2,6 +2,7 @@ export { errorResponseSchema } from '@/lib/api/errors';
 export type { ErrorResponse } from '@/lib/api/errors';
 export type {
   AnswerComment,
+  AnswerSearchResponse,
   CommentHistoryResponseEntry,
   CreateFormResponse,
   CreateFormSchema,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -54,6 +54,8 @@ export type SearchResponse =
 export type GetUserSearchPageResponse =
   ApiPaths['/api/v1/search/users']['get']['responses'][200]['content']['application/json'];
 export type GetUserSearchResponse = GetUserSearchPageResponse['users'];
+export type AnswerSearchResponse =
+  ApiPaths['/api/v1/search/answers']['get']['responses'][200]['content']['application/json'];
 export type GetNotificationSettingsResponse =
   ApiPaths['/api/v1/notifications/settings/me']['get']['responses'][200]['content']['application/json'];
 export type GetUserNotificationSettingsResponse =


### PR DESCRIPTION
## 概要
- closes #878
- seichi-portal-backend#1212 で追加された `GET /api/v1/search/answers?query=...&form_id=...` を用いて、フォーム回答一覧ページ (`/forms/[formId]/answers`) に検索欄を追加
- 検索文字列を入力すると対象フォームに絞り込んだ回答内容の全文検索結果に切り替わる（無入力時は従来どおりカーソルページネーションの一覧を表示）
- 管理者向け `UsersPageContent` と同じ debounce + SWR パターンを踏襲
- `pnpm codegen` を実行し、backend の OpenAPI スキーマ変更（`AnswerSearchResult` / `/api/v1/search/answers` の `form_id` パラメータ追加を含む）を取り込み

## 確認事項
- [x] `pnpm test:unit` (76 tests) が成功
- [x] `tsc --noEmit` が成功
- [x] `eslint` が成功
- [x] `pnpm build` が成功
- [ ] ブラウザでの実動作確認は MSAL 認証・backend 接続の関係で未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)