### PR TITLE
feat: グローバル Discord Webhook 設定画面を追加する

### DIFF
--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -48,6 +48,10 @@ const DashboardMenu = () => {
             label: 'Users',
             url: '/admin/users',
           },
+          {
+            label: 'Webhooks',
+            url: '/admin/webhooks',
+          },
         ].map((value) => {
           return (
             <MenuItem

--- a/src/app/(protected)/admin/webhooks/_components/GlobalWebhookSettings.tsx
+++ b/src/app/(protected)/admin/webhooks/_components/GlobalWebhookSettings.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import SaveAltIcon from '@mui/icons-material/SaveAlt';
+import {
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
+import { useGlobalDiscordWebhook } from '@/hooks/useGlobalDiscordWebhook';
+import type { GetGlobalDiscordWebhookResponse } from '@/lib/api-types';
+
+import {
+  defaultGlobalWebhookFormValues,
+  toGlobalWebhookUpdateUrl,
+} from '../_lib/globalWebhookForm';
+import type { GlobalWebhookFormValues } from '../_lib/globalWebhookForm';
+
+const GlobalWebhookSettings = ({
+  currentStatus,
+}: {
+  currentStatus: GetGlobalDiscordWebhookResponse;
+}) => {
+  const [enabled, setEnabled] = useState(currentStatus.enabled);
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<GlobalWebhookFormValues>({
+    defaultValues: defaultGlobalWebhookFormValues,
+  });
+
+  const { updateWebhook } = useGlobalDiscordWebhook();
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+
+  const onSubmit = async (data: GlobalWebhookFormValues) => {
+    const url = toGlobalWebhookUpdateUrl(data);
+    const result = await updateWebhook(url);
+    if (result.ok) {
+      setEnabled(url !== null);
+      reset(defaultGlobalWebhookFormValues);
+      showSnackbar(
+        url !== null ? 'Webhook を設定しました' : 'Webhook を無効化しました',
+        'success'
+      );
+    } else {
+      showSnackbar('Webhook 設定の更新に失敗しました', 'error');
+    }
+  };
+
+  return (
+    <Card sx={{ maxWidth: 600 }}>
+      <CardContent
+        component="form"
+        onSubmit={(e) => {
+          void handleSubmit(onSubmit)(e);
+        }}
+      >
+        <Stack spacing={1} direction="row" sx={{ alignItems: 'center', mb: 1 }}>
+          <Typography variant="h6" component="h2">
+            グローバル Discord Webhook
+          </Typography>
+          <Chip
+            label={enabled ? '有効' : '無効'}
+            color={enabled ? 'success' : 'default'}
+            size="small"
+          />
+        </Stack>
+        <Divider sx={{ mb: 2 }} />
+        <Stack spacing={2}>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            すべてのフォームの通知をまとめて送信する Discord Webhook
+            です。セキュリティのため設定済みの URL
+            は再表示されません。空欄のまま保存すると通知を無効化します。
+          </Typography>
+          <Controller
+            name="url"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Discord Webhook URL"
+                placeholder="https://discord.com/api/webhooks/..."
+                fullWidth
+              />
+            )}
+          />
+          <Button
+            variant="contained"
+            endIcon={<SaveAltIcon />}
+            type="submit"
+            sx={{ alignSelf: 'flex-start' }}
+            disabled={isSubmitting}
+          >
+            保存
+          </Button>
+        </Stack>
+      </CardContent>
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </Card>
+  );
+};
+
+export default GlobalWebhookSettings;

--- a/src/app/(protected)/admin/webhooks/_lib/globalWebhookForm.ts
+++ b/src/app/(protected)/admin/webhooks/_lib/globalWebhookForm.ts
@@ -1,0 +1,14 @@
+export type GlobalWebhookFormValues = {
+  url: string;
+};
+
+export const defaultGlobalWebhookFormValues: GlobalWebhookFormValues = {
+  url: '',
+};
+
+export const toGlobalWebhookUpdateUrl = (
+  values: GlobalWebhookFormValues
+): string | null => {
+  const trimmed = values.url.trim();
+  return trimmed === '' ? null : trimmed;
+};

--- a/src/app/(protected)/admin/webhooks/page.tsx
+++ b/src/app/(protected)/admin/webhooks/page.tsx
@@ -1,0 +1,35 @@
+import { Stack, Typography } from '@mui/material';
+import type { Metadata } from 'next';
+
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
+import { getAdminAccess } from '@/lib/server/session';
+
+import GlobalWebhookSettings from './_components/GlobalWebhookSettings';
+
+export const metadata: Metadata = {
+  title: 'Webhook 設定 | Seichi Portal',
+};
+
+const Page = async () => {
+  const { session } = await getAdminAccess();
+  const status = await requireBackendData(
+    serverApiClient.GET('/api/v1/settings/global-discord-webhook', {
+      headers: authorizationHeader(session.token),
+    })
+  );
+
+  return (
+    <Stack spacing={3} sx={{ width: '100%' }}>
+      <Typography variant="h4" component="h1">
+        Webhook 設定
+      </Typography>
+      <GlobalWebhookSettings currentStatus={status} />
+    </Stack>
+  );
+};
+
+export default Page;

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -497,6 +497,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/settings/global-discord-webhook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** グローバル Discord Webhook 設定の取得 */
+        get: operations["get_global_discord_webhook"];
+        /** グローバル Discord Webhook 設定の更新 */
+        put: operations["update_global_discord_webhook"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/user-groups": {
         parameters: {
             query?: never;
@@ -910,6 +928,13 @@ export interface components {
             questions?: components["schemas"]["QuestionSchema"][] | null;
             settings?: null | components["schemas"]["FormSettingsSchema"];
             title?: string | null;
+        };
+        GlobalDiscordWebhookStatusSchema: {
+            enabled: boolean;
+        };
+        GlobalDiscordWebhookUpdateSchema: {
+            /** @description Discord Webhook URL。`null` を指定すると通知を無効化する。 */
+            url: string | null;
         };
         /** @enum {string} */
         HistoryAction: "CREATE" | "UPDATE" | "DELETE";
@@ -4137,6 +4162,109 @@ export interface operations {
             };
             /** @description Client error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_global_discord_webhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GlobalDiscordWebhookStatusSchema"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    update_global_discord_webhook: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GlobalDiscordWebhookUpdateSchema"];
+            };
+        };
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/hooks/useGlobalDiscordWebhook.ts
+++ b/src/hooks/useGlobalDiscordWebhook.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
+import { proxyClient } from '@/lib/proxyClient';
+
+export const useGlobalDiscordWebhook = () => {
+  const updateWebhook = async (
+    url: string | null
+  ): Promise<{ ok: boolean }> => {
+    const { response } = await proxyClient.PUT(
+      '/api/v1/settings/global-discord-webhook',
+      { body: { url } }
+    );
+    return { ok: response.ok };
+  };
+
+  return { updateWebhook: useSingleFlightAction(updateWebhook) };
+};

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -22,6 +22,7 @@ export type {
   GetFormResponse,
   GetFormsPageResponse,
   GetFormsResponse,
+  GetGlobalDiscordWebhookResponse,
   GetMessageHistoryResponse,
   GetMessagesResponse,
   GetNotificationSettingsResponse,
@@ -38,6 +39,7 @@ export type {
   MessageHistoryResponseEntry,
   PutAnswerSubmitterRestrictionSchema,
   SearchResponse,
+  UpdateGlobalDiscordWebhookSchema,
   UpdateNotificationSettingsSchema,
   UserGroupSchema,
 } from '@/lib/api/types';

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -74,3 +74,7 @@ export type CreateUserGroupSchema =
   ApiPaths['/api/v1/user-groups']['post']['requestBody']['content']['application/json'];
 export type GetUserGroupMembersResponse =
   ApiPaths['/api/v1/user-groups/{group_id}/users']['get']['responses'][200]['content']['application/json'];
+export type GetGlobalDiscordWebhookResponse =
+  ApiPaths['/api/v1/settings/global-discord-webhook']['get']['responses'][200]['content']['application/json'];
+export type UpdateGlobalDiscordWebhookSchema =
+  ApiPaths['/api/v1/settings/global-discord-webhook']['put']['requestBody']['content']['application/json'];


### PR DESCRIPTION
## 概要
- バックエンドに全フォーム共通の Discord Webhook 送信設定 API（`GET/PUT /api/v1/settings/global-discord-webhook`）が追加されたため、`pnpm codegen` で型定義を更新し、管理者が設定できる画面 `/admin/webhooks` を新規追加した
- `src/lib/api/types.ts` / `src/lib/api-types.ts` に対応する型を追加し、`useGlobalDiscordWebhook` フックで PUT 呼び出しを実装
- 管理メニュー（`DashboardMenu`）に「Webhooks」項目を追加
- バックエンドの GET は `{ enabled: boolean }` のみを返し URL 自体は返さない仕様のため、画面では現在の URL を再表示せず、有効/無効の状態表示と新規入力用フォームのみを提供する（空欄で保存すると無効化）。フォーム個別の Discord Webhook URL 設定と同じ「空欄=無効化」という挙動に揃えた

## 確認事項
- `pnpm tsc --noEmit` / `pnpm eslint` / `pnpm build` がすべて成功することを確認
- pre-commit（lint / type-check / fmt）、pre-push（unit test 76件）のフックがすべて通過
- バックエンドの実データを用いた実機（ブラウザ）確認は未実施。レビューでは特に、GET レスポンスに URL が含まれない前提の UI 挙動（空欄保存で無効化する仕様）が意図通りか確認してほしい

## 補足
- `src/generated/api-types.ts` の差分は `pnpm codegen` によるコードベース全体の再生成結果で、今回追加された webhook 関連の型のみが純追加されている（既存部分への変更なし）

🤖 Generated with Claude Code