### PR TITLE
fix: 管理者フォーム編集画面の必須項目表示を一般公開フォームと統一する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/ChoiceEditor.tsx
@@ -25,6 +25,8 @@ import {
   type FormEditorValues,
 } from '../../_schema/formEditorSchema';
 
+import FieldLabel from './FieldLabel';
+
 const SortableChoiceItem = (props: {
   id: string;
   index: number;
@@ -50,39 +52,37 @@ const SortableChoiceItem = (props: {
   };
 
   return (
-    <Stack
-      direction="row"
-      ref={setNodeRef}
-      style={style}
-      spacing={1}
-      sx={{ alignItems: 'center' }}
-    >
-      <IconButton size="small" {...attributes} {...listeners}>
-        <DragIndicator fontSize="small" />
-      </IconButton>
-      <TextField
-        {...props.register(
-          `questions.${props.questionIndex}.choices.${props.index}.choice`
-        )}
-        label={`選択肢${props.index + 1}`}
-        required
-        fullWidth
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
-            event.preventDefault();
-            props.onAppendChoice();
-          }
-        }}
-      />
-      <IconButton
-        size="small"
-        onClick={() => {
-          props.removeChoice(props.index);
-        }}
-        disabled={!props.canRemove}
-      >
-        <DeleteIcon fontSize="small" />
-      </IconButton>
+    <Stack ref={setNodeRef} style={style} spacing={0.5}>
+      <FieldLabel label={`選択肢${props.index + 1}`} required />
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <IconButton size="small" {...attributes} {...listeners}>
+          <DragIndicator fontSize="small" />
+        </IconButton>
+        <TextField
+          {...props.register(
+            `questions.${props.questionIndex}.choices.${props.index}.choice`
+          )}
+          fullWidth
+          slotProps={{
+            htmlInput: { 'aria-label': `選択肢${props.index + 1}` },
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+              event.preventDefault();
+              props.onAppendChoice();
+            }
+          }}
+        />
+        <IconButton
+          size="small"
+          onClick={() => {
+            props.removeChoice(props.index);
+          }}
+          disabled={!props.canRemove}
+        >
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      </Stack>
     </Stack>
   );
 };
@@ -134,24 +134,27 @@ const QuestionTypeField = (props: {
   };
 
   return (
-    <TextField
-      {...questionTypeField}
-      value={questionTypeField.value}
-      label="質問の種類"
-      select
-      required
-      helperText="質問の種類を選択してください。"
-      onChange={(event) => {
-        const parsed = questionTypeSchema.safeParse(event.target.value);
-        if (parsed.success) {
-          handleQuestionTypeChange(parsed.data);
-        }
-      }}
-    >
-      <MenuItem value="Text">テキスト</MenuItem>
-      <MenuItem value="SingleChoice">単一選択</MenuItem>
-      <MenuItem value="MultipleChoice">複数選択</MenuItem>
-    </TextField>
+    <Stack spacing={0.5}>
+      <FieldLabel label="質問の種類" required />
+      <TextField
+        {...questionTypeField}
+        value={questionTypeField.value}
+        select
+        fullWidth
+        helperText="質問の種類を選択してください。"
+        slotProps={{ select: { 'aria-label': '質問の種類' } }}
+        onChange={(event) => {
+          const parsed = questionTypeSchema.safeParse(event.target.value);
+          if (parsed.success) {
+            handleQuestionTypeChange(parsed.data);
+          }
+        }}
+      >
+        <MenuItem value="Text">テキスト</MenuItem>
+        <MenuItem value="SingleChoice">単一選択</MenuItem>
+        <MenuItem value="MultipleChoice">複数選択</MenuItem>
+      </TextField>
+    </Stack>
   );
 };
 

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FieldLabel.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FieldLabel.tsx
@@ -1,0 +1,19 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import RequiredChip from '@/app/_components/RequiredChip';
+
+const FieldLabel = ({
+  label,
+  required = false,
+}: {
+  label: string;
+  required?: boolean;
+}) => (
+  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+    <Typography variant="body1">{label}</Typography>
+    {required && <RequiredChip />}
+  </Stack>
+);
+
+export default FieldLabel;

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -22,6 +22,7 @@ import type {
 
 import type { FormEditorValues } from '../../_schema/formEditorSchema';
 
+import FieldLabel from './FieldLabel';
 import FormGroupField from './FormGroupField';
 import FormLabelField from './FormLabelField';
 
@@ -39,14 +40,24 @@ const BasicFormSettings = ({
   labelOptions,
 }: Pick<FormSettingsProps, 'register' | 'control' | 'labelOptions'>) => (
   <>
-    <TextField {...register('title')} label="フォームタイトル" required />
-    <TextField
-      {...register('description')}
-      label="フォームの説明"
-      required
-      multiline
-      helperText="Markdown に対応しています。"
-    />
+    <Stack spacing={0.5}>
+      <FieldLabel label="フォームタイトル" required />
+      <TextField
+        {...register('title')}
+        fullWidth
+        slotProps={{ htmlInput: { 'aria-label': 'フォームタイトル' } }}
+      />
+    </Stack>
+    <Stack spacing={0.5}>
+      <FieldLabel label="フォームの説明" required />
+      <TextField
+        {...register('description')}
+        multiline
+        fullWidth
+        helperText="Markdown に対応しています。"
+        slotProps={{ htmlInput: { 'aria-label': 'フォームの説明' } }}
+      />
+    </Stack>
     <FormLabelField control={control} labelOptions={labelOptions} />
   </>
 );
@@ -85,18 +96,24 @@ const AcceptancePeriodSettings = ({
       />
       {hasAcceptancePeriod && (
         <>
-          <TextField
-            {...register('settings.acceptance_period.startAt')}
-            label="回答開始日"
-            type="datetime-local"
-            helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
-          />
-          <TextField
-            {...register('settings.acceptance_period.endAt')}
-            label="回答終了日"
-            type="datetime-local"
-            helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
-          />
+          <Stack spacing={0.5}>
+            <FieldLabel label="回答開始日" />
+            <TextField
+              {...register('settings.acceptance_period.startAt')}
+              type="datetime-local"
+              helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
+              slotProps={{ htmlInput: { 'aria-label': '回答開始日' } }}
+            />
+          </Stack>
+          <Stack spacing={0.5}>
+            <FieldLabel label="回答終了日" />
+            <TextField
+              {...register('settings.acceptance_period.endAt')}
+              type="datetime-local"
+              helperText="回答開始日と回答終了日はどちらも指定する必要があります。"
+              slotProps={{ htmlInput: { 'aria-label': '回答終了日' } }}
+            />
+          </Stack>
         </>
       )}
     </>
@@ -114,17 +131,20 @@ const FormVisibilitySettings = ({
 
   return (
     <>
-      <TextField
-        {...visibilityField}
-        value={visibilityField.value}
-        label="フォーム公開設定"
-        helperText="この設定を公開にすると、一般ユーザーがこのフォームに回答できるようになります。"
-        select
-        required
-      >
-        <MenuItem value="PUBLIC">公開</MenuItem>
-        <MenuItem value="PRIVATE">非公開</MenuItem>
-      </TextField>
+      <Stack spacing={0.5}>
+        <FieldLabel label="フォーム公開設定" required />
+        <TextField
+          {...visibilityField}
+          value={visibilityField.value}
+          helperText="この設定を公開にすると、一般ユーザーがこのフォームに回答できるようになります。"
+          select
+          fullWidth
+          slotProps={{ select: { 'aria-label': 'フォーム公開設定' } }}
+        >
+          <MenuItem value="PUBLIC">公開</MenuItem>
+          <MenuItem value="PRIVATE">非公開</MenuItem>
+        </TextField>
+      </Stack>
       <FormGroupField
         control={control}
         name="settings.allowed_group_ids"
@@ -148,17 +168,20 @@ const AnswerSettings = ({
 
   return (
     <>
-      <TextField
-        {...answerVisibilityField}
-        value={answerVisibilityField.value}
-        label="回答の公開設定"
-        helperText="この設定を公開にすると、すべての回答が一般ユーザーから確認できるようになります。"
-        select
-        required
-      >
-        <MenuItem value="PUBLIC">公開</MenuItem>
-        <MenuItem value="PRIVATE">非公開</MenuItem>
-      </TextField>
+      <Stack spacing={0.5}>
+        <FieldLabel label="回答の公開設定" required />
+        <TextField
+          {...answerVisibilityField}
+          value={answerVisibilityField.value}
+          helperText="この設定を公開にすると、すべての回答が一般ユーザーから確認できるようになります。"
+          select
+          fullWidth
+          slotProps={{ select: { 'aria-label': '回答の公開設定' } }}
+        >
+          <MenuItem value="PUBLIC">公開</MenuItem>
+          <MenuItem value="PRIVATE">非公開</MenuItem>
+        </TextField>
+      </Stack>
       <FormGroupField
         control={control}
         name="settings.answer_group_ids"
@@ -170,16 +193,24 @@ const AnswerSettings = ({
         label="未ログインユーザーの回答を許可する"
         control={<Checkbox {...register('settings.allow_temporary_answers')} />}
       />
-      <TextField
-        {...register('settings.discord_webhook_url')}
-        label="Webhook URL"
-        type="url"
-      />
-      <TextField
-        {...register('settings.default_answer_title')}
-        label="デフォルトの回答タイトル"
-        helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名を、$form_name でフォームタイトルをタイトルに埋め込むことができます。例: [$form_name] $username さんの回答"
-      />
+      <Stack spacing={0.5}>
+        <FieldLabel label="Webhook URL" />
+        <TextField
+          {...register('settings.discord_webhook_url')}
+          type="url"
+          slotProps={{ htmlInput: { 'aria-label': 'Webhook URL' } }}
+        />
+      </Stack>
+      <Stack spacing={0.5}>
+        <FieldLabel label="デフォルトの回答タイトル" />
+        <TextField
+          {...register('settings.default_answer_title')}
+          helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名を、$form_name でフォームタイトルをタイトルに埋め込むことができます。例: [$form_name] $username さんの回答"
+          slotProps={{
+            htmlInput: { 'aria-label': 'デフォルトの回答タイトル' },
+          }}
+        />
+      </Stack>
     </>
   );
 };

--- a/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
@@ -14,6 +14,7 @@ import type { Control, UseFormRegister } from 'react-hook-form';
 import type { FormEditorValues } from '../../_schema/formEditorSchema';
 
 import ChoiceEditor from './ChoiceEditor';
+import FieldLabel from './FieldLabel';
 
 const QuestionEditor = (props: {
   control: Control<FormEditorValues>;
@@ -35,22 +36,31 @@ const QuestionEditor = (props: {
       >
         質問の削除
       </Button>
-      <TextField
-        {...props.register(`questions.${props.questionIndex}.title`)}
-        label="質問タイトル"
-        required
-      />
-      <TextField
-        {...props.register(`questions.${props.questionIndex}.description`)}
-        label="質問の説明"
-        multiline
-        helperText="Markdown に対応しています。"
-      />
-      <TextField
-        {...props.register(`questions.${props.questionIndex}.template_key`)}
-        label="テンプレートキー"
-        helperText="回答タイトルへの埋め込みに使う識別キーです。半角英数字・_・- のみ使用できます（1〜255文字）。username と form_name は予約語のため使用できません。空欄のままでも構いません。"
-      />
+      <Stack spacing={0.5}>
+        <FieldLabel label="質問タイトル" required />
+        <TextField
+          {...props.register(`questions.${props.questionIndex}.title`)}
+          fullWidth
+          slotProps={{ htmlInput: { 'aria-label': '質問タイトル' } }}
+        />
+      </Stack>
+      <Stack spacing={0.5}>
+        <FieldLabel label="質問の説明" />
+        <TextField
+          {...props.register(`questions.${props.questionIndex}.description`)}
+          multiline
+          helperText="Markdown に対応しています。"
+          slotProps={{ htmlInput: { 'aria-label': '質問の説明' } }}
+        />
+      </Stack>
+      <Stack spacing={0.5}>
+        <FieldLabel label="テンプレートキー" />
+        <TextField
+          {...props.register(`questions.${props.questionIndex}.template_key`)}
+          helperText="回答タイトルへの埋め込みに使う識別キーです。半角英数字・_・- のみ使用できます（1〜255文字）。username と form_name は予約語のため使用できません。空欄のままでも構いません。"
+          slotProps={{ htmlInput: { 'aria-label': 'テンプレートキー' } }}
+        />
+      </Stack>
       <FormControlLabel
         label="この質問への回答を必須にする"
         control={

--- a/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -4,7 +4,6 @@ import SendIcon from '@mui/icons-material/Send';
 import {
   Box,
   Button,
-  Chip,
   Paper,
   Stack,
   TextField,
@@ -13,6 +12,7 @@ import {
 import { useForm } from 'react-hook-form';
 
 import MarkdownText from '@/app/_components/MarkdownText';
+import RequiredChip from '@/app/_components/RequiredChip';
 import type { GetQuestionsResponse } from '@/lib/api-types';
 
 import { TEMPORARY_USER_FIELDS } from './answerFormTypes';
@@ -108,12 +108,7 @@ const AnswerSubmissionForm = ({
                     {question.title}
                   </Typography>
                   {question.is_required && (
-                    <Chip
-                      size="small"
-                      color="error"
-                      label="必須"
-                      sx={{ ml: 1, verticalAlign: 'middle' }}
-                    />
+                    <RequiredChip sx={{ ml: 1, verticalAlign: 'middle' }} />
                   )}
                 </Box>
                 {question.description && (

--- a/src/app/_components/RequiredChip.tsx
+++ b/src/app/_components/RequiredChip.tsx
@@ -1,0 +1,8 @@
+import Chip from '@mui/material/Chip';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+const RequiredChip = ({ sx }: { sx?: SxProps<Theme> }) => (
+  <Chip size="small" color="error" label="必須" sx={sx} />
+);
+
+export default RequiredChip;


### PR DESCRIPTION
## 概要
- 管理者向けフォーム編集画面（フォームタイトル・説明・公開設定・質問タイトル・質問の種類・選択肢等）は `TextField` の `required`（アスタリスク）で必須項目を示していたが、一般公開フォーム（回答画面）は「必須」Chip で示しており表示が統一されていなかった（issue #880）
- 共通の `RequiredChip` を切り出し、公開フォームと管理者フォーム編集画面の両方から使うように統一
- 必須項目のみ独自スタイルのラベルとして実装した結果、非必須項目とフォントサイズ・太さが揃っていなかったため、`FieldLabel` でラベル表示自体（必須/非必須問わず）も統一

## 確認事項
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` / `pnpm exec prettier --check` はすべて通過
- 既存のコンポーネントテスト（`AnswerSubmissionForm.test.tsx`, `ChoiceEditor.test.tsx`）が通過し、フィールドのアクセシブルネーム（`getByRole` でのラベル名）が変更後も壊れていないことを確認
- ラベルの上に「必須」Chip が並ぶ表示、必須/非必須ラベルの Typography クラスが一致することを一時テストで確認済み（テストとしては残していない。純粋な見た目の確認のため）
- 認証・バックエンドが必要な admin 画面を実ブラウザでは確認できていない。レビューではラベルの配置・サイズ感を実画面で見てもらえると安心

## 補足
- 本 PR とは無関係な `ThemeModeToggle.tsx` 由来の hydration mismatch 警告が開発中に確認されたが、今回の変更ファイルには含まれておらず、別 issue で扱うのが適切

🤖 Generated with Claude Code