### PR TITLE
feat: フォーム編集画面から回答者を隠す設定を変更できるようにする

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -204,6 +204,15 @@ const AnswerSettings = ({
         label="未ログインユーザーの回答を許可する"
         control={<Checkbox {...register('settings.allow_temporary_answers')} />}
       />
+      <Stack spacing={0}>
+        <FormControlLabel
+          label="回答者を隠して公開する"
+          control={<Checkbox {...register('settings.hide_author')} />}
+        />
+        <Typography variant="caption" color="textSecondary">
+          一般ユーザーには回答者を匿名として表示します。管理者には従来どおり回答者情報が表示されます。
+        </Typography>
+      </Stack>
       <Stack spacing={0.5}>
         <Stack spacing={1} direction="row" sx={{ alignItems: 'center' }}>
           <FieldLabel label="Webhook URL" />

--- a/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorDefaults.ts
@@ -29,5 +29,6 @@ export const createEmptyFormEditorValues = (): FormEditorValues => ({
     answer_visibility: 'PRIVATE',
     answer_group_ids: [],
     allow_temporary_answers: false,
+    hide_author: false,
   },
 });

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -136,6 +136,7 @@ export const fromFormResponseToEditorValues = (
       answer_group_ids: form.settings.answer_settings.answer_group_ids,
       allowed_group_ids: form.settings.allowed_group_ids,
       allow_temporary_answers: form.settings.allow_temporary_answers,
+      hide_author: form.settings.answer_settings.hide_author,
     },
   };
 };
@@ -196,8 +197,7 @@ export const toFormUpdateBody = (
         acceptance_period: acceptancePeriod,
         visibility: data.settings.answer_visibility,
         answer_group_ids: data.settings.answer_group_ids,
-        // UI未実装のため常にfalseで送信する。回答者を隠す設定はこのフォームからは変更できない。
-        hide_author: false,
+        hide_author: data.settings.hide_author,
       },
     },
   };

--- a/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
+++ b/src/app/(protected)/admin/forms/_schema/formEditorSchema.ts
@@ -88,6 +88,7 @@ export const formEditorSchema = z.object({
     answer_visibility: visibilitySchema,
     answer_group_ids: z.array(z.string()),
     allow_temporary_answers: z.boolean(),
+    hide_author: z.boolean(),
   }),
 });
 

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -38,6 +38,7 @@ const baseValues: FormEditorValues = {
     answer_visibility: 'PUBLIC',
     answer_group_ids: [],
     allow_temporary_answers: false,
+    hide_author: false,
   },
 };
 
@@ -358,6 +359,37 @@ describe('form request builders', () => {
     );
 
     expect(body.settings?.allow_temporary_answers).toBe(true);
+  });
+
+  it('回答者を隠す設定を更新ボディへ反映する', () => {
+    const body = toFormUpdateBody(
+      {
+        ...baseValues,
+        settings: {
+          ...baseValues.settings,
+          hide_author: true,
+        },
+      },
+      false
+    );
+
+    expect(body.settings?.answer_settings?.hide_author).toBe(true);
+  });
+
+  it('回答者を隠す設定をフォーム取得レスポンスから画面内部表現へ変換する', () => {
+    const values = fromFormResponseToEditorValues(
+      createFormResponse({
+        settings: {
+          ...createFormResponse().settings,
+          answer_settings: {
+            ...createFormResponse().settings.answer_settings,
+            hide_author: true,
+          },
+        },
+      })
+    );
+
+    expect(values.settings.hide_author).toBe(true);
   });
 
   it('回答期間の画面内部表現を API の日時フィールドへ変換する', () => {


### PR DESCRIPTION
## 概要
- backend PR #1227（回答者を隠して回答を公開できるようにする）で回答設定に `hide_author` が API から取得・更新できるようになったのを受け、フォーム編集画面から変更できるようにした
- 回答表示側（`AnswerMeta.tsx` の `ANONYMOUS` 分岐）は対応済みだったが、編集画面には変更手段がなく、更新リクエストで常に `hide_author: false` を固定送信していたため、実質どのフォームでも無効化できなかった
- `formEditorSchema` / `formEditorDefaults` / `formEditorMappers` に `settings.hide_author` を追加し、`FormSettings.tsx` に「回答者を隠して公開する」チェックボックスを追加した

## 確認事項
- `pnpm tsc --noEmit`、対象ファイルの ESLint、`formEditorMappers.test.ts`（往復変換のテストを追加、計22件）がすべて成功することを確認した
- `pnpm vitest run` で `usePendingAction.test.tsx` 系のテストが失敗するが、`main` ブランチでも同様に失敗することを確認済みで、本変更とは無関係（`document is not defined` という環境設定起因の既知の問題）
- UI 側の実機確認（ブラウザでのチェックボックス操作・保存確認）は未実施

## 補足
- 管理者には従来どおり回答者情報が表示される旨をチェックボックス直下の補足文言で明記した

🤖 Generated with Claude Code