### PR TITLE
fix: 質問が1つのときは削除ボタンを無効化する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
@@ -21,6 +21,7 @@ const QuestionEditor = (props: {
   register: UseFormRegister<FormEditorValues>;
   removeQuestion: (index: number) => void;
   questionIndex: number;
+  removeDisabled: boolean;
 }) => {
   return (
     <Stack spacing={2}>
@@ -30,6 +31,7 @@ const QuestionEditor = (props: {
       <Button
         variant="outlined"
         startIcon={<DeleteIcon />}
+        disabled={props.removeDisabled}
         onClick={() => {
           props.removeQuestion(props.questionIndex);
         }}

--- a/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
@@ -102,6 +102,7 @@ const FormCreateForm = (props: {
                   register={register}
                   removeQuestion={remove}
                   questionIndex={index}
+                  removeDisabled={fields.length <= 1}
                 />
               ),
             }))}

--- a/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -117,6 +117,7 @@ const FormEditForm = (props: {
                     register={register}
                     removeQuestion={remove}
                     questionIndex={index}
+                    removeDisabled={fields.length <= 1}
                   />
                 ),
               }))}


### PR DESCRIPTION
## 概要
- フォームは質問0個の状態では保存できない仕様だが、質問の削除ボタンは残り1個の質問でも有効なままになっており、実質的に質問0個の状態を作れてしまっていた
- `QuestionEditor` に `removeDisabled` プロパティを追加し、質問数が1個のときに削除ボタンを無効化するよう変更
- 作成画面 (`FormCreateForm`) と編集画面 (`FormEditForm`) の両方で `fields.length <= 1` を渡すよう修正

## 確認事項
- `pnpm tsc --noEmit`、対象ファイルの `pnpm eslint` が成功することを確認
- push 時の lefthook pre-push フックでユニットテスト (85件) が全て通過することを確認
- UI 上での動作確認は未実施（ブラウザでの実機確認をお願いします）

🤖 Generated with Claude Code