### PR TITLE
feat: メッセージ・コメント機能のボタン横に説明ツールチップを追加

### DIFF
--- a/src/app/(protected)/_components/Conversation/Comments.tsx
+++ b/src/app/(protected)/_components/Conversation/Comments.tsx
@@ -98,6 +98,7 @@ const Comments = (props: {
         title="コメント"
         triggerLabel={`コメント (${entries.length})`}
         triggerStartIcon={<Typography component="span">💬</Typography>}
+        triggerDescription="回答について議論したり、メモを残したりするための機能です。基本的に、この回答を閲覧できる人であれば誰でも閲覧できます。"
         items={items}
         capabilities={capabilities}
         autoOpen={deepLinkState.autoOpen}

--- a/src/app/(protected)/_components/Conversation/ConversationSurface.tsx
+++ b/src/app/(protected)/_components/Conversation/ConversationSurface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import CloseIcon from '@mui/icons-material/Close';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Box,
   Button,
@@ -9,6 +10,7 @@ import {
   IconButton,
   Stack,
   Toolbar,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import type { ReactNode } from 'react';
@@ -30,6 +32,8 @@ type Props = {
   title?: string | undefined;
   triggerLabel?: string | undefined;
   triggerStartIcon?: ReactNode | undefined;
+  /** trigger ボタン横の i アイコンにホバーしたときに表示する、機能の説明文。 */
+  triggerDescription?: string | undefined;
   items: ConversationListItem[];
   capabilities: ConversationCapabilities;
   inputForm?: ReactNode | undefined;
@@ -104,6 +108,7 @@ const ConversationSurface = ({
   title,
   triggerLabel,
   triggerStartIcon,
+  triggerDescription,
   items,
   capabilities,
   inputForm,
@@ -165,15 +170,24 @@ const ConversationSurface = ({
 
   return (
     <>
-      <Button
-        variant="outlined"
-        onClick={() => {
-          setOpen(true);
-        }}
-        startIcon={triggerStartIcon}
-      >
-        {triggerLabel}
-      </Button>
+      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setOpen(true);
+          }}
+          startIcon={triggerStartIcon}
+        >
+          {triggerLabel}
+        </Button>
+        {triggerDescription !== undefined && (
+          <Tooltip title={triggerDescription} placement="top">
+            <IconButton size="small" aria-label="この機能について">
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Stack>
 
       <Drawer
         anchor="right"

--- a/src/app/(protected)/_components/Conversation/Messages.tsx
+++ b/src/app/(protected)/_components/Conversation/Messages.tsx
@@ -102,6 +102,7 @@ const Messages = (props: {
         title={props.title}
         triggerLabel={props.triggerLabel}
         triggerStartIcon={<MessageIcon />}
+        triggerDescription="回答者と運営チームの間でやり取りするための機能です。回答者と運営チーム以外は閲覧できません。"
         items={items}
         capabilities={capabilities}
         autoOpen={deepLinkState.autoOpen}


### PR DESCRIPTION
## 概要
- 回答詳細ページの「メッセージ」ボタンと「コメント」ボタンは名前が似ており、用途と閲覧範囲の違いが分かりにくかった
- 各ボタンの横に i アイコンを追加し、ホバー時にツールチップで以下を説明するようにした
  - メッセージ: 回答者と運営チームの間でやり取りするための機能で、回答者と運営チーム以外は閲覧できないこと
  - コメント: 回答について議論・メモを残すための機能で、基本的にこの回答を閲覧できる人であれば誰でも閲覧できること
- 実装は共通コンポーネント `ConversationSurface` に `triggerDescription` を追加する形にしたため、一般ユーザー向け画面・管理者向け画面の両方（Messages/Comments を利用する箇所すべて）に反映される
- i アイコン + Tooltip のパターンは `UserDetailCell.tsx` など既存の実装に合わせた

## 確認事項
- `pnpm tsc --noEmit`、`pnpm eslint`、`pnpm build` が通ることを確認
- コミット時の pre-commit / pre-push hook（lint, type-check, fmt, unit-test）がすべて成功
- この機能は MSAL 認証と実バックエンド API が前提のため、今回の環境では実ブラウザでの回答詳細ページの目視確認はできていない。表示崩れがないか、レビューで実際の画面での確認をお願いしたい

🤖 Generated with Claude Code