### PR TITLE
fix: フォーム一覧カードの説明文をMarkdown描画に対応させる

### DIFF
--- a/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
@@ -17,6 +17,7 @@ import {
 import NextLink from 'next/link';
 
 import InfiniteScrollSentinel from '@/app/_components/InfiniteScrollSentinel';
+import MarkdownText from '@/app/_components/MarkdownText';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
 import type { GetFormsPageResponse, GetFormsResponse } from '@/lib/api-types';
 import {
@@ -54,10 +55,10 @@ const EachForm = ({ form }: { form: FormItem }) => {
           sx={{ mb: 1.5 }}
         />
         {form.description && (
-          <Typography
-            variant="body2"
-            color="textSecondary"
+          <MarkdownText
             sx={{
+              typography: 'body2',
+              color: 'text.secondary',
               display: '-webkit-box',
               WebkitLineClamp: 3,
               WebkitBoxOrient: 'vertical',
@@ -65,7 +66,7 @@ const EachForm = ({ form }: { form: FormItem }) => {
             }}
           >
             {form.description}
-          </Typography>
+          </MarkdownText>
         )}
       </CardContent>
       <CardActions>

--- a/src/app/(public)/_components/PublicFormList.tsx
+++ b/src/app/(public)/_components/PublicFormList.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import NextLink from 'next/link';
 
+import MarkdownText from '@/app/_components/MarkdownText';
 import type { GetFormsResponse } from '@/lib/api-types';
 import {
   formatResponsePeriod,
@@ -44,10 +45,10 @@ const EachForm = ({ form }: { form: FormItem }) => {
             sx={{ mb: 1.5 }}
           />
           {form.description && (
-            <Typography
-              variant="body2"
-              color="textSecondary"
+            <MarkdownText
               sx={{
+                typography: 'body2',
+                color: 'text.secondary',
                 display: '-webkit-box',
                 WebkitLineClamp: 3,
                 WebkitBoxOrient: 'vertical',
@@ -55,7 +56,7 @@ const EachForm = ({ form }: { form: FormItem }) => {
               }}
             >
               {form.description}
-            </Typography>
+            </MarkdownText>
           )}
         </CardContent>
       </CardActionArea>


### PR DESCRIPTION
## 概要
- フォーム一覧カード(未ログイン向け `PublicFormList.tsx` / ログイン後 `FormsView.tsx`)では `form.description` を生の `Typography` で表示しており、回答送信ページ(`AnswerSubmissionForm.tsx`)など他の説明表示箇所と挙動が不揃いだった
- 共通コンポーネント `MarkdownText` に統一し、Markdown 記法(太字・リンク等)が一覧カードでも描画されるようにした
- 見た目(body2 相当のフォント・色・3行クランプ)は `sx` で維持

## 確認事項
- `pnpm tsc --noEmit` / `pnpm eslint` で型・lintエラーがないことを確認
- コミット時の pre-commit フック(lint / type-check / fmt)、push時の pre-push フック(unit-test 85件)がすべて通過
- 太字が反映されない事象(`** text **` のように `**` の内側にスペースがある記法は CommonMark 仕様上エミュファシスと認識されない)をユーザーと一緒に切り分け、記法修正後に一覧・回答送信ページの両方で正しく描画されることを確認済み

## 補足
- 一覧カードは3行クランプ表示のため、見出しやリストなど複数ブロックにまたがる Markdown を書いた場合のクランプ挙動は単純なテキストと多少異なる可能性がある

🤖 Generated with Claude Code