### PR TITLE
feat: 回答一覧にラベル列と絞り込みを追加する

### DIFF
--- a/src/app/(protected)/_components/AnswersList/AnswerLabelFilter.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswerLabelFilter.tsx
@@ -1,0 +1,47 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import type { Dispatch, SetStateAction } from 'react';
+
+import type { GetAnswerLabelsResponse } from '@/lib/api-types';
+
+const AnswerLabelFilter = (props: {
+  labelOptions: GetAnswerLabelsResponse;
+  setLabelFilter: Dispatch<SetStateAction<GetAnswerLabelsResponse>>;
+}) => {
+  return (
+    <Autocomplete
+      multiple
+      id="answer-label-filter"
+      options={props.labelOptions.map((label) => label.name)}
+      getOptionLabel={(option) => option}
+      sx={{ minWidth: 240, flexGrow: 1 }}
+      slotProps={{
+        listbox: {
+          sx: {
+            '& .MuiAutocomplete-option': {
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            },
+          },
+        },
+        popper: { sx: { minWidth: 240 } },
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          size="small"
+          label="ラベルで絞り込み"
+        />
+      )}
+      onChange={(_event, value) => {
+        props.setLabelFilter(
+          props.labelOptions.filter((label) => value.includes(label.name))
+        );
+      }}
+    />
+  );
+};
+
+export default AnswerLabelFilter;

--- a/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
 import type {
+  GetAnswerLabelsResponse,
   GetFormAnswersPageResponse,
   GetFormResponse,
 } from '@/lib/api-types';
 
+import { filterAnswers } from './answerListFilters';
 import { toAnswerListRows } from './answerListRows';
 import AnswersView from './AnswersView';
 
@@ -27,6 +29,7 @@ const AnswersPageContent = ({
   const router = useRouter();
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [labelFilter, setLabelFilter] = useState<GetAnswerLabelsResponse>([]);
 
   useEffect(() => {
     const trimmed = search.trim();
@@ -73,9 +76,24 @@ const AnswersPageContent = ({
     { keepPreviousData: true }
   );
 
-  const rows = isSearching
-    ? toAnswerListRows(searchData?.answers ?? [])
-    : toAnswerListRows(answers);
+  const sourceAnswers = useMemo(
+    () => (isSearching ? (searchData?.answers ?? []) : answers),
+    [isSearching, searchData, answers]
+  );
+
+  const labelOptions = useMemo(() => {
+    const byId = new Map<string, GetAnswerLabelsResponse[number]>();
+    for (const answer of sourceAnswers) {
+      for (const label of answer.labels) {
+        byId.set(label.id, label);
+      }
+    }
+    return Array.from(byId.values());
+  }, [sourceAnswers]);
+
+  const rows = toAnswerListRows(
+    filterAnswers(sourceAnswers, { labels: labelFilter })
+  );
 
   return (
     <AnswersView
@@ -84,6 +102,8 @@ const AnswersPageContent = ({
       search={search}
       onSearchChange={handleSearchChange}
       isSearchLoading={isSearching && isSearchLoading}
+      labelOptions={labelOptions}
+      onLabelFilterChange={setLabelFilter}
       hasMore={!isSearching && hasMore}
       isLoadingMore={isLoadingMore}
       onLoadMore={loadMore}

--- a/src/app/(protected)/_components/AnswersList/AnswersView.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersView.tsx
@@ -3,9 +3,11 @@
 import { Search } from '@mui/icons-material';
 import {
   Box,
+  Chip,
   CircularProgress,
   InputAdornment,
   LinearProgress,
+  Stack,
   TextField,
   Typography,
 } from '@mui/material';
@@ -13,10 +15,15 @@ import { DataGrid, gridClasses, useGridApiRef } from '@mui/x-data-grid';
 import type {
   GridColDef,
   GridEventListener,
+  GridRenderCellParams,
   GridRowParams,
 } from '@mui/x-data-grid';
 import * as React from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
+import type { GetAnswerLabelsResponse } from '@/lib/api-types';
+
+import AnswerLabelFilter from './AnswerLabelFilter';
 import type { AnswerListRow } from './answerListRows';
 
 const SCROLL_END_THRESHOLD_PX = 200;
@@ -27,6 +34,8 @@ const AnswersView = ({
   search,
   onSearchChange,
   isSearchLoading = false,
+  labelOptions,
+  onLabelFilterChange,
   hasMore,
   isLoadingMore,
   onLoadMore,
@@ -37,6 +46,8 @@ const AnswersView = ({
   search: string;
   onSearchChange: (value: string) => void;
   isSearchLoading?: boolean;
+  labelOptions: GetAnswerLabelsResponse;
+  onLabelFilterChange: Dispatch<SetStateAction<GetAnswerLabelsResponse>>;
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
@@ -75,6 +86,27 @@ const AnswersView = ({
   const columns: GridColDef[] = [
     { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
     { field: 'date', headerName: '投稿日時', minWidth: 200, flex: 0.8 },
+    {
+      field: 'labels',
+      headerName: 'ラベル',
+      minWidth: 200,
+      flex: 1,
+      sortable: false,
+      renderCell: (
+        params: GridRenderCellParams<AnswerListRow, AnswerListRow['labels']>
+      ) => (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          useFlexGap
+          sx={{ flexWrap: 'wrap', py: 0.75 }}
+        >
+          {params.value?.map((label) => (
+            <Chip key={label.id} label={label.name} size="small" />
+          ))}
+        </Stack>
+      ),
+    },
   ];
 
   return (
@@ -92,25 +124,31 @@ const AnswersView = ({
         <Typography variant="h5" component="h1">
           {formTitle}
         </Typography>
-        <TextField
-          variant="standard"
-          size="small"
-          label="回答内容を検索"
-          value={search}
-          onChange={(e) => {
-            onSearchChange(e.target.value);
-          }}
-          sx={{ minWidth: 240 }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search fontSize="small" />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+          <TextField
+            variant="standard"
+            size="small"
+            label="回答内容を検索"
+            value={search}
+            onChange={(e) => {
+              onSearchChange(e.target.value);
+            }}
+            sx={{ minWidth: 240 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+          <AnswerLabelFilter
+            labelOptions={labelOptions}
+            setLabelFilter={onLabelFilterChange}
+          />
+        </Stack>
       </Box>
       <Box sx={{ position: 'relative' }}>
         {isSearchLoading && (

--- a/src/app/(protected)/_components/AnswersList/answerListFilters.ts
+++ b/src/app/(protected)/_components/AnswersList/answerListFilters.ts
@@ -1,0 +1,23 @@
+import type {
+  GetAnswerLabelsResponse,
+  GetFormAnswersResponse,
+} from '@/lib/api-types';
+
+export interface AnswerListFilter {
+  labels: GetAnswerLabelsResponse;
+}
+
+export const filterAnswers = (
+  answers: GetFormAnswersResponse,
+  filter: AnswerListFilter
+): GetFormAnswersResponse => {
+  if (filter.labels.length === 0) {
+    return answers;
+  }
+
+  return answers.filter((answer) =>
+    filter.labels.every((label) =>
+      answer.labels.some((answerLabel) => answerLabel.id === label.id)
+    )
+  );
+};

--- a/src/app/(protected)/_components/AnswersList/answerListRows.ts
+++ b/src/app/(protected)/_components/AnswersList/answerListRows.ts
@@ -1,11 +1,15 @@
 import { formatString } from '@/generic/DateFormatter';
-import type { GetFormAnswersResponse } from '@/lib/api-types';
+import type {
+  GetAnswerLabelsResponse,
+  GetFormAnswersResponse,
+} from '@/lib/api-types';
 import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 
 export type AnswerListRow = {
   id: string;
   title: string;
   date: string;
+  labels: GetAnswerLabelsResponse;
 };
 
 export const toAnswerListRows = (
@@ -15,4 +19,5 @@ export const toAnswerListRows = (
     id: answer.id,
     title: resolveAnswerTitle(answer.title),
     date: formatString(answer.timestamp),
+    labels: answer.labels,
   }));

--- a/tests/unit/answerListFilters.test.ts
+++ b/tests/unit/answerListFilters.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterAnswers } from '@/app/(protected)/_components/AnswersList/answerListFilters';
+import type {
+  GetAnswerLabelsResponse,
+  GetFormAnswersResponse,
+} from '@/lib/api-types';
+
+const labels = {
+  urgent: { id: 'label-urgent', name: '緊急' },
+  reviewed: { id: 'label-reviewed', name: '確認済み' },
+  spam: { id: 'label-spam', name: 'スパム' },
+} satisfies Record<string, GetAnswerLabelsResponse[number]>;
+
+const answer = (
+  id: string,
+  answerLabels: GetAnswerLabelsResponse
+): GetFormAnswersResponse[number] => ({
+  id,
+  form_id: 'form-id',
+  answers: [],
+  author: {
+    type: 'AUTHENTICATED_USER',
+    user: {
+      uuid: 'user-id',
+      name: 'ユーザー',
+      role: 'STANDARD_USER',
+    },
+  },
+  labels: answerLabels,
+  timestamp: '2026-06-01T10:00:00+09:00',
+});
+
+const answers = [
+  answer('answer-1', [labels.urgent, labels.reviewed]),
+  answer('answer-2', [labels.reviewed]),
+  answer('answer-3', [labels.spam]),
+] satisfies GetFormAnswersResponse;
+
+describe('filterAnswers', () => {
+  it('ラベル未選択のときは全件を返す', () => {
+    const filtered = filterAnswers(answers, { labels: [] });
+
+    expect(filtered.map((answer) => answer.id)).toEqual([
+      'answer-1',
+      'answer-2',
+      'answer-3',
+    ]);
+  });
+
+  it('選択したラベルをすべて持つ回答だけを残す', () => {
+    const filtered = filterAnswers(answers, {
+      labels: [labels.urgent, labels.reviewed],
+    });
+
+    expect(filtered.map((answer) => answer.id)).toEqual(['answer-1']);
+  });
+
+  it('どの回答も持たないラベルを選択した場合は空になる', () => {
+    const filtered = filterAnswers(answers, {
+      labels: [labels.urgent, labels.spam],
+    });
+
+    expect(filtered).toEqual([]);
+  });
+});

--- a/tests/unit/answerListRows.test.ts
+++ b/tests/unit/answerListRows.test.ts
@@ -25,7 +25,11 @@ const createAnswer = (
 describe('toAnswerListRows', () => {
   it('回答一覧の行へ表示用の値を渡す', () => {
     const rows = toAnswerListRows([
-      createAnswer({ id: 'with-title', title: '回答タイトル' }),
+      createAnswer({
+        id: 'with-title',
+        title: '回答タイトル',
+        labels: [{ id: 'label-id', name: 'ラベル' }],
+      }),
     ]);
 
     expect(rows).toEqual([
@@ -33,6 +37,7 @@ describe('toAnswerListRows', () => {
         id: 'with-title',
         title: '回答タイトル',
         date: '2026年06月01日 10時00分',
+        labels: [{ id: 'label-id', name: 'ラベル' }],
       },
     ]);
   });


### PR DESCRIPTION
## 概要
- #902 対応。回答一覧はこれまでラベル表示・絞り込みが無く、詳細を開かないとラベルがわからなかった
- 一覧取得API (`/api/v1/forms/{id}/answers` 等) のレスポンスには既にラベル情報が含まれているため、バックエンド変更なしでフロントの表示・絞り込みのみ対応
- 変更点:
  - `answerListRows.ts`: `AnswerListRow` に `labels` を追加
  - `AnswersView.tsx`: 一覧に「ラベル」列(Chip表示)と `AnswerLabelFilter`(ラベル絞り込みAutocomplete)を追加
  - `AnswersPageContent.tsx`: ロード済み回答からラベル選択肢を動的に集計し、選択ラベルで絞り込む
  - フォーム一覧のラベル絞り込み(`FormLabelFilter`/`formListFilters.ts`)と同じ設計パターンを踏襲

## 確認事項
- ラベルの選択肢はロード済みの回答から集計する方式にした。ラベル一覧を返す `/api/v1/labels/answers` は一般ユーザーからは呼べない想定(`AnswerDetailsPageContent.tsx` の既存コメント「ラベル選択肢は管理者操作にのみ必要なため、管理者以外では取得しない」を参照)であり、この admin 専用 API に依存すると一般ユーザー向け回答一覧ページが壊れるリスクがあったため
- `pnpm build` が成功することを確認
- `pnpm type-check` / `pnpm lint` / `pnpm fmt` が通ることを確認(pre-commit/pre-push フックでも実行済み)
- 既存の `answerListRows.test.ts` を `labels` フィールド追加に合わせて更新し、新設した `filterAnswers` の絞り込みロジックに `answerListFilters.test.ts` を追加。`pnpm test:unit` は全件パス
- 開発サーバーを起動し `/forms/[formId]/answers` と `/admin/forms/[formId]/answers` にアクセスして 307(未ログインリダイレクト)が返り 500 エラーが出ないことを確認。ログインした実ブラウザでの見た目確認は環境上できていないため、レビューで見てほしい

## 補足
- インフィニットスクロールで未ロードの回答に含まれるラベルはまだ絞り込みの選択肢に出てこない(スクロールして読み込むと選択肢が増える)。既存の全文検索と同様、現在ロード済みのデータに対するクライアントサイド絞り込みという設計方針を踏襲したもの

🤖 Generated with Claude Code