### PR TITLE
fix: 回答詳細のラベルAutocompleteをcontrolledにする

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AnswerAdminControls.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerAdminControls.tsx
@@ -95,6 +95,9 @@ export const AdminAnswerLabels = (props: {
     props.answer.form_id,
     props.answer.id
   );
+  const [value, setValue] = useState(() =>
+    props.answer.labels.map((label) => label.name)
+  );
 
   return (
     <Autocomplete
@@ -102,7 +105,7 @@ export const AdminAnswerLabels = (props: {
       id="label"
       options={props.labelOptions.map((label) => label.name)}
       getOptionLabel={(option) => option}
-      defaultValue={props.answer.labels.map((label) => label.name)}
+      value={value}
       renderOption={(renderProps, option) => (
         <Box {...renderProps} key={option} component="span">
           {option}
@@ -115,9 +118,10 @@ export const AdminAnswerLabels = (props: {
           sx={{ borderBottom: (theme) => `1px solid ${theme.palette.divider}` }}
         />
       )}
-      onChange={(_event, value) => {
+      onChange={(_event, newValue) => {
+        setValue(newValue);
         const selectedIds = props.labelOptions
-          .filter((label) => value.includes(label.name))
+          .filter((label) => newValue.includes(label.name))
           .map((label) => label.id);
         void updateLabels(selectedIds);
       }}


### PR DESCRIPTION
## 概要
- 回答詳細画面（`AnswerDetailsPageContent`）は `refreshInterval: 1000` でポーリングしており、`AdminAnswerLabels` の `Autocomplete` は `defaultValue={props.answer.labels.map(...)}` で毎回新しい配列を渡していたため、マウント後も値が変わり続け MUI の「uncontrolled Autocomplete の default 値が初期化後に変わった」という警告が発生していた
- `AdminAnswerLabels` をローカル `useState` で選択状態を保持する controlled Autocomplete に変更し、ポーリングによる再レンダーの影響を受けないようにした
- 影響範囲は管理者向けの回答詳細画面のラベル編集 UI のみ

## 確認事項
- `pnpm tsc --noEmit` で型エラーがないことを確認
- コミット時の lefthook pre-commit（lint / type-check / fmt）と pre-push（unit test 88件）がすべて通過
- ブラウザでの実機確認は未実施。ラベル選択・更新の挙動に問題がないか、レビューで確認してもらえると助かります

🤖 Generated with Claude Code