### PR TITLE
fix: デフォルト回答タイトルのテンプレートキー記法の説明を修正する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -248,7 +248,7 @@ const AnswerSettings = ({
         <FieldLabel label="デフォルトの回答タイトル" />
         <TextField
           {...register('settings.default_answer_title')}
-          helperText="回答送信時のタイトルを設定します。$<テンプレートキー> で指定の質問の回答を、$username で回答者名を、$form_name でフォームタイトルをタイトルに埋め込むことができます。例: [$form_name] $username さんの回答"
+          helperText="回答送信時のタイトルを設定します。$テンプレートキー で指定の質問の回答を、$username で回答者名を、$form_name でフォームタイトルをタイトルに埋め込むことができます。例: [$form_name] $username さんの回答"
           slotProps={{
             htmlInput: { 'aria-label': 'デフォルトの回答タイトル' },
           }}


### PR DESCRIPTION
## 概要
- #903 で報告された、フォーム設定画面「デフォルトの回答タイトル」のヘルパーテキストの誤りを修正
- バックエンド（seichi-portal-backend `server/domain/src/form/service.rs`）の置換処理は正規表現 `\$([A-Za-z0-9_-]+)` にのみマッチするため、`$<テンプレートキー>` のように山括弧を付けても実際には置換されない
- `$username` `$form_name` と同じ書式である `$テンプレートキー`（山括弧なし）に表記を統一

## 確認事項
- バックエンドリポジトリのコード（`service.rs` の `template_placeholder_regex` および `test_embedded_answer_title` 等のテスト）を確認し、実際の置換対象記法が `$テンプレートキー` であることを確認済み
- `pnpm lint` / `pnpm type-check` / `pnpm fmt` / `pnpm test:unit` は pre-commit・pre-push フックで実行され、いずれも成功
- 文言修正のみのためE2Eでの追加検証は行っていない

🤖 Generated with Claude Code