### PR TITLE
feat: EditorConfigを追加する

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## 概要
- エディタ間でインデント幅・改行コード・文字コードなどの基本的なコーディングスタイルを統一するため、`.editorconfig` を追加
- 既存の Prettier 設定（`tabWidth: 2`）に合わせ、インデント幅2・スペース・LF・UTF-8・末尾空白除去・ファイル末尾改行を設定
- Markdown は行末スペースが改行として意味を持つため、末尾空白除去の対象から除外

## 確認事項
- `pre-commit` の type-check・fmt、`pre-push` の unit-test がすべて通過することを確認済み

Closes #298

🤖 Generated with Claude Code