### PR TITLE
feat: Minecraft BAN履歴を確認できるようにする

### DIFF
--- a/src/app/(protected)/(standard)/punishments/_components/PunishmentHistoryView.tsx
+++ b/src/app/(protected)/(standard)/punishments/_components/PunishmentHistoryView.tsx
@@ -1,0 +1,25 @@
+import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
+
+import MinecraftPunishmentList from '@/app/(protected)/_components/MinecraftPunishmentList';
+import type { GetMinecraftPunishmentsResponse } from '@/lib/api-types';
+
+const PunishmentHistoryView = ({
+  punishments,
+}: {
+  punishments: GetMinecraftPunishmentsResponse;
+}) => (
+  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+    <Stack spacing={3} sx={{ maxWidth: 640, width: '100%' }}>
+      <Typography variant="h5" component="h1">
+        処罰履歴
+      </Typography>
+      <Card variant="outlined">
+        <CardContent>
+          <MinecraftPunishmentList punishments={punishments} />
+        </CardContent>
+      </Card>
+    </Stack>
+  </Box>
+);
+
+export default PunishmentHistoryView;

--- a/src/app/(protected)/(standard)/punishments/page.tsx
+++ b/src/app/(protected)/(standard)/punishments/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+
+import {
+  authorizationHeader,
+  requireBackendData,
+  serverApiClient,
+} from '@/lib/server/backend';
+import { requireUser } from '@/lib/server/session';
+
+import PunishmentHistoryView from './_components/PunishmentHistoryView';
+
+export const metadata: Metadata = {
+  title: '処罰履歴 | Seichi Portal',
+};
+
+const Home = async () => {
+  const session = await requireUser();
+  const punishments = await requireBackendData(
+    serverApiClient.GET('/api/v1/users/{uuid}/minecraft-punishments', {
+      headers: authorizationHeader(session.token),
+      params: {
+        path: { uuid: session.user.id },
+      },
+    })
+  );
+
+  return <PunishmentHistoryView punishments={punishments} />;
+};
+
+export default Home;

--- a/src/app/(protected)/_components/MinecraftPunishmentList.tsx
+++ b/src/app/(protected)/_components/MinecraftPunishmentList.tsx
@@ -1,0 +1,34 @@
+import { Divider, Stack, Typography } from '@mui/material';
+
+import { formatString } from '@/generic/DateFormatter';
+import type { GetMinecraftPunishmentsResponse } from '@/lib/api-types';
+
+const MinecraftPunishmentList = ({
+  punishments,
+}: {
+  punishments: GetMinecraftPunishmentsResponse;
+}) =>
+  punishments.length === 0 ? (
+    <Typography variant="body2" component="p" color="textSecondary">
+      処罰履歴はありません
+    </Typography>
+  ) : (
+    <Stack divider={<Divider />} spacing={1.5}>
+      {punishments.map((item, index) => (
+        <Stack key={index} spacing={0.5}>
+          <Typography component="p">
+            <strong>理由:</strong> {item.reason}
+          </Typography>
+          <Typography component="p">
+            <strong>処罰日時:</strong> {formatString(item.punished_at)}
+          </Typography>
+          <Typography component="p">
+            <strong>期限:</strong>{' '}
+            {item.expires_at ? formatString(item.expires_at) : '無期限'}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+
+export default MinecraftPunishmentList;

--- a/src/app/(protected)/admin/users/_components/UserDetailDialog/MinecraftPunishmentHistorySection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserDetailDialog/MinecraftPunishmentHistorySection.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
+
+import MinecraftPunishmentList from '@/app/(protected)/_components/MinecraftPunishmentList';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+
+const MinecraftPunishmentHistorySection = ({ uuid }: { uuid: string }) => {
+  const {
+    data: history,
+    error,
+    isLoading,
+  } = useApiQuery('/api/v1/users/{uuid}/minecraft-punishments', {
+    path: { uuid },
+  });
+
+  const count = history?.length ?? 0;
+
+  return (
+    <Accordion disableGutters>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle2" component="h3">
+          Minecraft BAN履歴（{count}件）
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        {isLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+            <CircularProgress size={24} />
+          </Box>
+        )}
+        {error && (
+          <Alert severity="error">
+            Minecraft BAN履歴の取得に失敗しました。
+          </Alert>
+        )}
+        {history && <MinecraftPunishmentList punishments={history} />}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default MinecraftPunishmentHistorySection;

--- a/src/app/(protected)/admin/users/_components/UserDetailDialog/UserDetailDialogBody.tsx
+++ b/src/app/(protected)/admin/users/_components/UserDetailDialog/UserDetailDialogBody.tsx
@@ -18,6 +18,7 @@ import { useApiQuery } from '@/app/_swr/useApiQuery';
 
 import RoleChip from '../RoleChip';
 
+import MinecraftPunishmentHistorySection from './MinecraftPunishmentHistorySection';
 import RestrictionHistorySection from './RestrictionHistorySection';
 import RestrictionManagementSection from './RestrictionManagementSection';
 import RoleSelectCell from './RoleSelectCell';
@@ -135,6 +136,7 @@ const UserDetailDialogBody = ({
           </Stack>
 
           <RestrictionHistorySection uuid={user.id} />
+          <MinecraftPunishmentHistorySection uuid={user.id} />
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -674,6 +674,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/{uuid}/minecraft-punishments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** MinecraftのBAN履歴の取得 */
+        get: operations["get_minecraft_punishments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -984,6 +1001,14 @@ export interface components {
         };
         MessageUpdateSchema: {
             body?: string | null;
+        };
+        MinecraftPunishmentResponse: {
+            /** Format: date-time */
+            expires_at?: string | null;
+            /** Format: date-time */
+            punished_at: string;
+            reason: string;
+            uuid: string;
         };
         NonEmptyString: string;
         NotificationSettingsResponse: {
@@ -5317,6 +5342,65 @@ export interface operations {
             };
             /** @description The server cannot find the requested resource. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_minecraft_punishments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID */
+                uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MinecraftPunishmentResponse"][];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -25,6 +25,7 @@ export type {
   GetGlobalDiscordWebhookResponse,
   GetMessageHistoryResponse,
   GetMessagesResponse,
+  GetMinecraftPunishmentsResponse,
   GetNotificationSettingsResponse,
   GetUserGroupMembersResponse,
   GetUserGroupsResponse,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -49,6 +49,8 @@ export type PutAnswerSubmitterRestrictionSchema =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction']['put']['requestBody']['content']['application/json'];
 export type GetAnswerSubmitterRestrictionHistoryResponse =
   ApiPaths['/api/v1/users/{uuid}/answer-submitter-restriction/history']['get']['responses'][200]['content']['application/json'];
+export type GetMinecraftPunishmentsResponse =
+  ApiPaths['/api/v1/users/{uuid}/minecraft-punishments']['get']['responses'][200]['content']['application/json'];
 export type SearchResponse =
   ApiPaths['/api/v1/search']['get']['responses'][200]['content']['application/json'];
 export type GetUserSearchPageResponse =

--- a/tests/component/MinecraftPunishmentHistorySection.test.tsx
+++ b/tests/component/MinecraftPunishmentHistorySection.test.tsx
@@ -1,0 +1,77 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MinecraftPunishmentHistorySection from '@/app/(protected)/admin/users/_components/UserDetailDialog/MinecraftPunishmentHistorySection';
+import type { GetMinecraftPunishmentsResponse } from '@/lib/api-types';
+
+import { renderWithProviders, screen } from './render';
+
+type HistoryQueryState = {
+  data: GetMinecraftPunishmentsResponse | undefined;
+  error: Error | null;
+  isLoading: boolean;
+};
+
+const queryState = vi.hoisted<HistoryQueryState>(() => ({
+  data: undefined,
+  error: null,
+  isLoading: false,
+}));
+
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: () => queryState,
+}));
+
+describe('MinecraftPunishmentHistorySection', () => {
+  beforeEach(() => {
+    queryState.data = undefined;
+    queryState.error = null;
+    queryState.isLoading = false;
+  });
+
+  it('BANの理由はMarkdownとして解釈されず、プレーンテキストのまま描画される', async () => {
+    const user = userEvent.setup();
+    queryState.data = [
+      {
+        uuid: 'user-uuid',
+        reason: '**チート行為**が確認されたため',
+        punished_at: '2024-01-01T00:00:00Z',
+        expires_at: null,
+      },
+    ];
+
+    renderWithProviders(<MinecraftPunishmentHistorySection uuid="user-uuid" />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Minecraft BAN履歴（1件）/ })
+    );
+
+    expect(
+      await screen.findByText('**チート行為**が確認されたため', {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+    // Markdownとして解釈された場合は "**" が取り除かれ、<strong>チート行為</strong> として分割描画される
+    expect(screen.queryByText('チート行為')).not.toBeInTheDocument();
+  });
+
+  it('expires_at が null の場合は「無期限」と表示される', async () => {
+    const user = userEvent.setup();
+    queryState.data = [
+      {
+        uuid: 'user-uuid',
+        reason: '迷惑行為',
+        punished_at: '2024-01-01T00:00:00Z',
+        expires_at: null,
+      },
+    ];
+
+    renderWithProviders(<MinecraftPunishmentHistorySection uuid="user-uuid" />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Minecraft BAN履歴（1件）/ })
+    );
+
+    expect(await screen.findByText(/無期限/)).toBeInTheDocument();
+  });
+});

--- a/tests/component/PunishmentHistoryView.test.tsx
+++ b/tests/component/PunishmentHistoryView.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import PunishmentHistoryView from '@/app/(protected)/(standard)/punishments/_components/PunishmentHistoryView';
+import type { GetMinecraftPunishmentsResponse } from '@/lib/api-types';
+
+import { renderWithProviders, screen } from './render';
+
+describe('PunishmentHistoryView', () => {
+  it('処罰履歴が空の場合は空状態メッセージを表示する', () => {
+    renderWithProviders(<PunishmentHistoryView punishments={[]} />);
+
+    expect(screen.getByText('処罰履歴はありません')).toBeInTheDocument();
+  });
+
+  it('BANの理由はMarkdownとして解釈されず、プレーンテキストのまま描画される', () => {
+    const punishments: GetMinecraftPunishmentsResponse = [
+      {
+        uuid: 'user-uuid',
+        reason: '**チート行為**が確認されたため',
+        punished_at: '2024-01-01T00:00:00Z',
+        expires_at: null,
+      },
+    ];
+
+    renderWithProviders(<PunishmentHistoryView punishments={punishments} />);
+
+    expect(
+      screen.getByText('**チート行為**が確認されたため', { exact: false })
+    ).toBeInTheDocument();
+    // Markdownとして解釈された場合は "**" が取り除かれ、<strong>チート行為</strong> として分割描画される
+    expect(screen.queryByText('チート行為')).not.toBeInTheDocument();
+  });
+
+  it('expires_at が null の場合は「無期限」と表示される', () => {
+    const punishments: GetMinecraftPunishmentsResponse = [
+      {
+        uuid: 'user-uuid',
+        reason: '迷惑行為',
+        punished_at: '2024-01-01T00:00:00Z',
+        expires_at: null,
+      },
+    ];
+
+    renderWithProviders(<PunishmentHistoryView punishments={punishments} />);
+
+    expect(screen.getByText(/無期限/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- seichi-portal-backend#1233 でマージされた `GET /api/v1/users/{uuid}/minecraft-punishments` を使い、ユーザーが自分のMinecraft BAN履歴を確認できるページ (`/punishments`、`MainMenu` に既存のリンクから遷移) を追加
- 管理者向けユーザー詳細ダイアログに、任意ユーザーのBAN履歴を確認できる「Minecraft BAN履歴」セクションを追加（既存の「処罰履歴」＝回答投稿制限履歴とは別機能のため見出しを区別）
- 自分/管理者どちらの画面でも同じ一覧描画ロジック（`MinecraftPunishmentList`）を共有し、`expires_at: null` は「無期限」として表示

## 確認事項
- `src/generated/api-types.ts` はbackend `main` から `pnpm codegen` で再生成したが、本PRと無関係な `AnswerPublication`（未実装の別機能、既存テスト5件が壊れる差分）は手動で除外し、`minecraft-punishments` 関連のみ反映したことを確認済み
- `tsc --noEmit` / `eslint` / `prettier --check` / `vitest run --config vitest.component.config.ts`（23ファイル・89テスト）をすべてpassすることを確認
- BANの理由(reason)はLiteBans由来の自由記述テキストのため、既存の `MarkdownText`（回答投稿制限の理由用）は使わずプレーンテキストで描画。この非Markdown描画と `expires_at: null → 無期限` の2点はテストで固定化済み
- バックエンドの権限制御（本人 or 管理者のみ、それ以外は403）に依存しており、フロント側の追加ガードは不要と判断

## 補足
- 管理画面ダイアログの見出しは「Minecraft BAN履歴」、既存の「処罰履歴」（回答投稿制限履歴）とは意図的に区別している

🤖 Generated with Claude Code