### PR TITLE
feat: 回答単位で公開・非公開を切り替えられるようにする

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AnswerAdminControls.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerAdminControls.tsx
@@ -5,6 +5,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -14,6 +15,7 @@ import { useForm } from 'react-hook-form';
 
 import { useAnswerActions } from '@/hooks/useAnswerActions';
 import type {
+  AnswerPublication,
   GetAnswerLabelsResponse,
   GetAnswerResponse,
 } from '@/lib/api-types';
@@ -84,6 +86,41 @@ export const AdminAnswerTitle = (props: { answer: GetAnswerResponse }) => {
         </Button>
       )}
     </Stack>
+  );
+};
+
+export const AdminAnswerPublicationToggle = (props: {
+  answer: GetAnswerResponse;
+}) => {
+  const [publication, setPublication] = useState(props.answer.publication);
+  const { updatePublication } = useAnswerActions(
+    props.answer.form_id,
+    props.answer.id
+  );
+
+  const onChange = async (next: AnswerPublication) => {
+    const previous = publication;
+    setPublication(next);
+    const result = await updatePublication(next);
+    if (!result.ok) {
+      setPublication(previous);
+    }
+  };
+
+  return (
+    <TextField
+      select
+      size="small"
+      value={publication}
+      onChange={(event) => {
+        void onChange(event.target.value === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC');
+      }}
+      sx={{ minWidth: 140 }}
+      slotProps={{ select: { 'aria-label': 'この回答の公開状態' } }}
+    >
+      <MenuItem value="PUBLIC">公開</MenuItem>
+      <MenuItem value="PRIVATE">非公開</MenuItem>
+    </TextField>
   );
 };
 

--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
@@ -15,6 +15,7 @@ import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 import {
   AdminAnswerLabelManagementButton,
   AdminAnswerLabels,
+  AdminAnswerPublicationToggle,
   AdminAnswerTitle,
 } from './AnswerAdminControls';
 import AnswerDetails from './AnswerDetails';
@@ -73,6 +74,11 @@ const AnswerDetailsPageView = ({
             labelOptions={data.labelOptions}
             answer={data.answer}
           />
+        ) : undefined
+      }
+      publicationSlot={
+        data.isAdmin ? (
+          <AdminAnswerPublicationToggle answer={data.answer} />
         ) : undefined
       }
       extraActions={

--- a/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
@@ -37,10 +37,22 @@ const AuthorName = ({ author }: { author: Author }) => {
   return <Typography>{author.user.name}</Typography>;
 };
 
+const AnswerPublicationChip = ({
+  publication,
+}: {
+  publication: GetAnswerResponse['publication'];
+}) =>
+  publication === 'PRIVATE' ? (
+    <Chip label="非公開" size="small" color="warning" />
+  ) : (
+    <Chip label="公開" size="small" color="default" />
+  );
+
 const AnswerMeta = (props: {
   answer: GetAnswerResponse;
   messageAction: ReactNode;
   labelsSlot?: ReactNode;
+  publicationSlot?: ReactNode;
   extraActions?: ReactNode;
 }) => (
   <Paper variant="outlined" sx={{ p: 2 }}>
@@ -62,6 +74,16 @@ const AnswerMeta = (props: {
           ラベル
         </Typography>
         <Box>{props.labelsSlot ?? <AnswerLabels answers={props.answer} />}</Box>
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6 }}>
+        <Typography variant="caption" color="textSecondary">
+          この回答の公開状態
+        </Typography>
+        <Box>
+          {props.publicationSlot ?? (
+            <AnswerPublicationChip publication={props.answer.publication} />
+          )}
+        </Box>
       </Grid>
       <Grid size={{ xs: 12, sm: 6 }}>
         <Stack

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -757,6 +757,8 @@ export interface components {
             items: components["schemas"]["FormAnswer"][];
             next_cursor?: string | null;
         };
+        /** @enum {string} */
+        AnswerPublication: "PUBLIC" | "PRIVATE";
         AnswerSearchResult: {
             answers: components["schemas"]["FormAnswer"][];
         };
@@ -796,6 +798,7 @@ export interface components {
             submitter_id: string;
         };
         AnswerUpdateSchema: {
+            publication?: string | null;
             title?: string | null;
         };
         /** @enum {string} */
@@ -888,6 +891,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             labels: components["schemas"]["AnswerLabels"][];
+            publication: components["schemas"]["AnswerPublication"];
             /** Format: date-time */
             timestamp: string;
             title?: string | null;

--- a/src/hooks/useAnswerActions.ts
+++ b/src/hooks/useAnswerActions.ts
@@ -2,6 +2,7 @@
 
 import { handleMutationResponse } from '@/hooks/useApiMutation';
 import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
+import type { AnswerPublication } from '@/lib/api-types';
 import { proxyClient } from '@/lib/proxyClient';
 
 export const useAnswerActions = (formId: string, answerId: string) => {
@@ -11,6 +12,20 @@ export const useAnswerActions = (formId: string, answerId: string) => {
       {
         params: { path: { form_id: formId, answer_id: answerId } },
         body: { title },
+      }
+    );
+    const result = handleMutationResponse(response, data, error);
+    return { ok: result.success };
+  };
+
+  const updatePublication = async (
+    publication: AnswerPublication
+  ): Promise<{ ok: boolean }> => {
+    const { data, error, response } = await proxyClient.PATCH(
+      '/api/v1/forms/{form_id}/answers/{answer_id}',
+      {
+        params: { path: { form_id: formId, answer_id: answerId } },
+        body: { publication },
       }
     );
     const result = handleMutationResponse(response, data, error);
@@ -31,6 +46,7 @@ export const useAnswerActions = (formId: string, answerId: string) => {
 
   return {
     updateTitle: useSingleFlightAction(updateTitle),
+    updatePublication: useSingleFlightAction(updatePublication),
     updateLabels: useSingleFlightAction(updateLabels),
   };
 };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2,6 +2,7 @@ export { errorResponseSchema } from '@/lib/api/errors';
 export type { ErrorResponse } from '@/lib/api/errors';
 export type {
   AnswerComment,
+  AnswerPublication,
   AnswerSearchResponse,
   CommentHistoryResponseEntry,
   CreateFormResponse,

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -4,6 +4,7 @@ export type ApiPaths = paths;
 export type ApiComponents = components;
 
 export type AnswerComment = components['schemas']['AnswerComment'];
+export type AnswerPublication = components['schemas']['AnswerPublication'];
 export type CommentHistoryResponseEntry =
   components['schemas']['CommentHistoryResponseEntry'];
 export type MessageHistoryResponseEntry =

--- a/tests/component/AnswerDetails.test.tsx
+++ b/tests/component/AnswerDetails.test.tsx
@@ -36,6 +36,7 @@ const answer: GetAnswerResponse = {
   timestamp: '2024-01-01T00:00:00Z',
   title: null,
   labels: [],
+  publication: 'PUBLIC',
   author: {
     type: 'AUTHENTICATED_USER',
     user: { name: 'Alice', role: 'STANDARD_USER', uuid: 'user-1' },

--- a/tests/component/AnswerDetailsPageView.test.tsx
+++ b/tests/component/AnswerDetailsPageView.test.tsx
@@ -76,6 +76,7 @@ const baseData: AnswerDetailsPageData = {
     timestamp: '2024-01-01T00:00:00Z',
     title: '回答タイトル',
     labels: [],
+    publication: 'PUBLIC',
     author: {
       type: 'AUTHENTICATED_USER',
       user: { name: 'Alice', role: 'STANDARD_USER', uuid: 'user-1' },

--- a/tests/unit/answerListFilters.test.ts
+++ b/tests/unit/answerListFilters.test.ts
@@ -28,6 +28,7 @@ const answer = (
     },
   },
   labels: answerLabels,
+  publication: 'PUBLIC',
   timestamp: '2026-06-01T10:00:00+09:00',
 });
 

--- a/tests/unit/answerListRows.test.ts
+++ b/tests/unit/answerListRows.test.ts
@@ -18,6 +18,7 @@ const createAnswer = (
     },
   },
   labels: [],
+  publication: 'PUBLIC',
   timestamp: '2026-06-01T10:00:00+09:00',
   ...overrides,
 });

--- a/tests/unit/searchResultRows.test.ts
+++ b/tests/unit/searchResultRows.test.ts
@@ -41,6 +41,7 @@ const createAnswer = (
     user: { uuid: 'user-id', name: 'ユーザー', role: 'STANDARD_USER' },
   },
   labels: [],
+  publication: 'PUBLIC',
   timestamp: '2026-06-01T10:00:00+09:00',
   ...overrides,
 });


### PR DESCRIPTION
## 概要
- backend PR [#1232](https://github.com/GiganticMinecraft/seichi-portal-backend/pull/1232) (`seichi-portal-backend`) で回答ごとの公開状態(`publication`: `PUBLIC`/`PRIVATE`)が追加されたため、フロント側を追従させる。
- `pnpm codegen` でマージ済みの最新 `openapi.json` から型を再生成し、`AnswerPublication` 型と `FormAnswer.publication` フィールドを取り込んだ。
- 回答詳細画面に公開状態の表示(Chip)を追加し、管理者は同画面から個別の回答を非公開に切り替えられるようにした。
- `PRIVATE` の回答は管理者・回答者本人以外には元々バックエンド側で除外されるため、一覧・検索画面への表示追加は行っていない。

## 確認事項
- `tsc --noEmit`、`pnpm lint`、`test:unit`(88件)、`test:component`(89件)がすべて成功することを確認した。
- 型追加に伴い既存テストの fixture に `publication` フィールドが必須になったため、5ファイルへ `publication: 'PUBLIC'` を追加して対応した。
- 実ブラウザでの動作確認は、管理者権限でのバックエンド接続が必要なため未実施。レビューでは特に公開状態トグルの表示・切り替え・ロールバック挙動(`AnswerAdminControls.tsx` の `AdminAnswerPublicationToggle`)を重点的に見てほしい。

🤖 Generated with Claude Code