### PR TITLE
fix: 権限のないユーザーが公開回答を開くとメッセージ取得失敗でページ全体が落ちる不具合を修正

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
@@ -46,11 +46,20 @@ const AnswerDetailsPageContent = ({
     { refreshInterval: 1000 }
   );
 
+  const isAuthor =
+    answer !== undefined &&
+    answer.author.type === 'AUTHENTICATED_USER' &&
+    answer.author.user.uuid === currentUser.id;
+
+  // メッセージは管理者・投稿者本人にのみ閲覧権限があるため、権限がないと
+  // わかっている場合はバックエンドへリクエストしない。
+  const canAccessMessages = isAdmin || isAuthor;
+
   const messagesQuery = useApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}/messages',
-    {
-      path: { form_id: formId, answer_id: answerId },
-    },
+    canAccessMessages
+      ? { path: { form_id: formId, answer_id: answerId } }
+      : null,
     { refreshInterval: 1000 }
   );
 
@@ -71,7 +80,6 @@ const AnswerDetailsPageContent = ({
   const requiredQueries = {
     answer: answerQuery,
     form: formQuery,
-    messages: messagesQuery,
     comments: commentsQuery,
   };
   const queryError = getRequiredQueryGroupError(requiredQueries);
@@ -87,7 +95,7 @@ const AnswerDetailsPageContent = ({
   const data: AnswerDetailsPageData = {
     answer: requiredQueries.answer.data,
     form: requiredQueries.form.data,
-    messages: requiredQueries.messages.data,
+    messages: getOptionalQueryData(messagesQuery) ?? [],
     comments: requiredQueries.comments.data,
     currentUserId: currentUser.id,
     isAdmin,

--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
@@ -43,75 +43,89 @@ const AnswerDetailsPageView = ({
   data: AnswerDetailsPageData;
   messageDeepLink: ConversationDeepLinkProps;
   commentDeepLink: ConversationDeepLinkProps;
-}) => (
-  <Stack
-    direction="column"
-    spacing={4}
-    sx={{
-      width: '100%',
-      justifyContent: 'flex-start',
-      alignItems: 'stretch',
-    }}
-  >
-    {data.isAdmin ? (
-      <AdminAnswerTitle answer={data.answer} />
-    ) : (
-      <Typography
-        variant="h4"
-        component="h1"
-        sx={
-          !data.answer.title?.trim() ? { color: 'text.secondary' } : undefined
-        }
-      >
-        {resolveAnswerTitle(data.answer.title)}
-      </Typography>
-    )}
-    <AnswerMeta
-      answer={data.answer}
-      labelsSlot={
-        data.isAdmin ? (
-          <AdminAnswerLabels
-            labelOptions={data.labelOptions}
-            answer={data.answer}
-          />
-        ) : undefined
-      }
-      publicationSlot={
-        data.isAdmin ? (
-          <AdminAnswerPublicationToggle answer={data.answer} />
-        ) : undefined
-      }
-      extraActions={
-        data.isAdmin ? <AdminAnswerLabelManagementButton /> : undefined
-      }
-      messageAction={
-        <Messages
-          messages={data.messages}
-          formId={formId}
-          answerId={answerId}
-          title="メッセージ"
-          triggerLabel={
-            data.isAdmin
-              ? `回答者にメッセージを送信 (${data.messages.length})`
-              : `メッセージ (${data.messages.length})`
+}) => {
+  const { author } = data.answer;
+  const isAuthenticatedAuthor = author.type === 'AUTHENTICATED_USER';
+  const isAuthor =
+    author.type === 'AUTHENTICATED_USER' &&
+    author.user.uuid === data.currentUserId;
+  const canAccessMessages = data.isAdmin || isAuthor;
+  const messagesDisabled = !isAuthenticatedAuthor || !canAccessMessages;
+  const messagesDisabledReason = !isAuthenticatedAuthor
+    ? '未ログインユーザーの回答のため、メッセージを送信できません'
+    : 'この回答の管理者または投稿者本人のみメッセージを閲覧できます';
+
+  return (
+    <Stack
+      direction="column"
+      spacing={4}
+      sx={{
+        width: '100%',
+        justifyContent: 'flex-start',
+        alignItems: 'stretch',
+      }}
+    >
+      {data.isAdmin ? (
+        <AdminAnswerTitle answer={data.answer} />
+      ) : (
+        <Typography
+          variant="h4"
+          component="h1"
+          sx={
+            !data.answer.title?.trim() ? { color: 'text.secondary' } : undefined
           }
-          isAdmin={data.isAdmin}
-          deepLink={messageDeepLink}
-          disabled={data.answer.author.type !== 'AUTHENTICATED_USER'}
-        />
-      }
-    />
-    <AnswerDetails answer={data.answer} questions={data.form.questions} />
-    <Comments
-      comments={data.comments}
-      formId={formId}
-      answerId={answerId}
-      currentUserId={data.currentUserId}
-      showDeleteButton={data.isAdmin ? true : undefined}
-      isAdmin={data.isAdmin}
-      deepLink={commentDeepLink}
-    />
-  </Stack>
-);
+        >
+          {resolveAnswerTitle(data.answer.title)}
+        </Typography>
+      )}
+      <AnswerMeta
+        answer={data.answer}
+        labelsSlot={
+          data.isAdmin ? (
+            <AdminAnswerLabels
+              labelOptions={data.labelOptions}
+              answer={data.answer}
+            />
+          ) : undefined
+        }
+        publicationSlot={
+          data.isAdmin ? (
+            <AdminAnswerPublicationToggle answer={data.answer} />
+          ) : undefined
+        }
+        extraActions={
+          data.isAdmin ? <AdminAnswerLabelManagementButton /> : undefined
+        }
+        messageAction={
+          <Messages
+            messages={data.messages}
+            formId={formId}
+            answerId={answerId}
+            title="メッセージ"
+            triggerLabel={
+              data.isAdmin
+                ? `回答者にメッセージを送信 (${data.messages.length})`
+                : `メッセージ (${data.messages.length})`
+            }
+            isAdmin={data.isAdmin}
+            deepLink={messageDeepLink}
+            disabled={messagesDisabled}
+            disabledReason={messagesDisabledReason}
+          />
+        }
+      />
+      <AnswerDetails answer={data.answer} questions={data.form.questions} />
+      <Comments
+        comments={data.comments}
+        formId={formId}
+        answerId={answerId}
+        currentUserId={data.currentUserId}
+        showDeleteButton={data.isAdmin ? true : undefined}
+        isAdmin={data.isAdmin}
+        deepLink={commentDeepLink}
+      />
+    </Stack>
+  );
+};
 
 export default AnswerDetailsPageView;

--- a/src/app/(protected)/_components/Conversation/Messages.tsx
+++ b/src/app/(protected)/_components/Conversation/Messages.tsx
@@ -39,13 +39,16 @@ const Messages = (props: {
   triggerLabel: string;
   isAdmin: boolean;
   deepLink: ConversationDeepLinkProps;
-  /** true のとき、未ログインユーザーの回答であることを理由にメッセージ送信を無効化する。 */
+  /** true のとき、メッセージの閲覧・送信を無効化する(バックエンドへのリクエストも行わない)。 */
   disabled?: boolean | undefined;
+  /** disabled が true のときに trigger ボタンのホバーで表示する理由。 */
+  disabledReason?: string | undefined;
 }) => {
   const actions = useMessageConversationActions(props.formId, props.answerId);
   const { historyByTargetId, isLoading: isHistoryLoading } = useMessageHistory(
     props.formId,
-    props.answerId
+    props.answerId,
+    !props.disabled
   );
 
   const entries: ConversationEntryViewModel[] = props.messages.map(
@@ -106,7 +109,7 @@ const Messages = (props: {
         triggerStartIcon={<MessageIcon />}
         triggerDescription="回答者と運営チームの間でやり取りするための機能です。回答者と運営チーム以外は閲覧できません。"
         triggerDisabled={props.disabled}
-        triggerDisabledReason="未ログインユーザーの回答のため、メッセージを送信できません"
+        triggerDisabledReason={props.disabledReason}
         items={items}
         capabilities={capabilities}
         autoOpen={deepLinkState.autoOpen}

--- a/src/app/(protected)/_components/Conversation/useConversationHistory.ts
+++ b/src/app/(protected)/_components/Conversation/useConversationHistory.ts
@@ -139,8 +139,16 @@ export const useCommentHistory = (formId: string, answerId: string) => {
   };
 };
 
-/** メッセージの変更履歴を全ページ取得し、message_id ごとにグルーピングする。 */
-export const useMessageHistory = (formId: string, answerId: string) => {
+/**
+ * メッセージの変更履歴を全ページ取得し、message_id ごとにグルーピングする。
+ * enabled が false のときはバックエンドへリクエストしない
+ * (メッセージの閲覧権限がない場合に使う)。
+ */
+export const useMessageHistory = (
+  formId: string,
+  answerId: string,
+  enabled = true
+) => {
   const { items, hasMore, isLoadingMore, loadMore } = useInfiniteApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}/messages/history',
     (cursor) => ({
@@ -148,7 +156,7 @@ export const useMessageHistory = (formId: string, answerId: string) => {
       query: cursor === undefined ? {} : { cursor },
     }),
     EMPTY_MESSAGE_HISTORY_PAGE,
-    { refreshInterval: HISTORY_REFRESH_INTERVAL_MS }
+    { refreshInterval: HISTORY_REFRESH_INTERVAL_MS, enabled }
   );
   useAutoLoadAll(hasMore, isLoadingMore, loadMore);
   const hasCompletedInitialLoad = useHasCompletedInitialLoad(

--- a/src/app/_swr/useInfiniteApiQuery.ts
+++ b/src/app/_swr/useInfiniteApiQuery.ts
@@ -21,6 +21,8 @@ type KeysetPath = {
 export type UseInfiniteApiQueryOptions = {
   /** ミリ秒間隔で全ページを再取得し続ける。指定しなければ再取得しない。 */
   refreshInterval?: number;
+  /** false のとき、バックエンドへのリクエストを行わない。既定は true。 */
+  enabled?: boolean;
 };
 
 /**
@@ -42,7 +44,7 @@ export const useInfiniteApiQuery = <P extends KeysetPath>(
     _pageIndex: number,
     previousPageData: GetResponse<P> | null
   ) => {
-    if (!hasHydrated) return null;
+    if (!hasHydrated || options?.enabled === false) return null;
     const previousPage = previousPageData && asPage(previousPageData);
     if (previousPage && !previousPage.next_cursor) return null;
 

--- a/tests/component/AnswerDetailsPageView.test.tsx
+++ b/tests/component/AnswerDetailsPageView.test.tsx
@@ -155,3 +155,60 @@ describe('AnswerDetailsPageView の isAdmin 分岐(#統合)', () => {
     expect(await screen.findByRole('menuitem', { name: '削除' })).toBeVisible();
   });
 });
+
+describe('AnswerDetailsPageView のメッセージボタンの権限制御', () => {
+  it('管理者でも投稿者本人でもない場合、メッセージボタンは disabled になる', () => {
+    renderWithProviders(
+      <AnswerDetailsPageView
+        formId="form-id"
+        answerId="answer-id"
+        data={baseData}
+        messageDeepLink={deepLink}
+        commentDeepLink={deepLink}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /^メッセージ \(0\)$/ })
+    ).toBeDisabled();
+  });
+
+  it('投稿者本人の場合、メッセージボタンは disabled にならない', () => {
+    const authorData: AnswerDetailsPageData = {
+      ...baseData,
+      currentUserId: 'user-1',
+    };
+
+    renderWithProviders(
+      <AnswerDetailsPageView
+        formId="form-id"
+        answerId="answer-id"
+        data={authorData}
+        messageDeepLink={deepLink}
+        commentDeepLink={deepLink}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /^メッセージ \(0\)$/ })
+    ).not.toBeDisabled();
+  });
+
+  it('管理者の場合、メッセージボタンは disabled にならない', () => {
+    const adminData: AnswerDetailsPageData = { ...baseData, isAdmin: true };
+
+    renderWithProviders(
+      <AnswerDetailsPageView
+        formId="form-id"
+        answerId="answer-id"
+        data={adminData}
+        messageDeepLink={deepLink}
+        commentDeepLink={deepLink}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /^回答者にメッセージを送信 \(0\)$/ })
+    ).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 概要
- 回答自体が公開設定でも、メッセージ一覧・変更履歴APIは管理者・投稿者本人にしか閲覧権限がなく、それ以外のユーザーが公開回答ページを開くとバックエンドが403を返していた
- 従来はメッセージ取得を必須クエリとして扱っていたため、この403がページ全体のエラー表示に波及していた
- 管理者・投稿者本人と判定できる場合にのみメッセージ関連API(一覧・変更履歴)をリクエストするようにし、それ以外ではメッセージボタン自体をdisabledにしてリクエストが発生しないようにした

## 確認事項
- `tsc --noEmit`、ESLint、Prettier のチェックがすべて通過することを確認
- 既存の `AnswerDetailsPageView.test.tsx` を実行し、isAdmin による表示分岐が壊れていないことを確認
- 新たに、管理者でも投稿者本人でもない場合にメッセージボタンが disabled になること、投稿者本人・管理者の場合は disabled にならないことを検証するテストを追加し、通過を確認
- `pnpm test:unit` (88件) がすべて通過することを確認
- バックエンド側のAPI(メッセージ一覧・履歴)への実リクエストが権限なし時に発生しないことは、フロントのSWR key制御(`useApiQuery`/`useInfiniteApiQuery`のenabled/nullガード)による実装であり、既存の同種パターン(ラベル選択肢取得の`isAdmin`ガード)と同じ仕組みを踏襲している

## 補足
- コメント機能は「この回答を閲覧できる人であれば誰でも閲覧できる」設計のため、今回のガード対象には含めていない

🤖 Generated with Claude Code