### PR TITLE
fix: お知らせ機能への導線ボタンを削除する

### DIFF
--- a/src/app/(protected)/(standard)/_components/MainMenu.tsx
+++ b/src/app/(protected)/(standard)/_components/MainMenu.tsx
@@ -2,7 +2,6 @@
 
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import AssignmentIcon from '@mui/icons-material/Assignment';
-import CampaignIcon from '@mui/icons-material/Campaign';
 import GavelIcon from '@mui/icons-material/Gavel';
 import {
   Box,
@@ -34,13 +33,6 @@ const menuItems = [
     description: '自分の処罰履歴を確認できます',
     icon: GavelIcon,
     color: '#d32f2f',
-  },
-  {
-    href: '/announcements',
-    title: 'お知らせ一覧',
-    description: '運営からのお知らせを確認できます',
-    icon: CampaignIcon,
-    color: '#388e3c',
   },
 ];
 

--- a/src/app/(protected)/(standard)/_components/MainMenu.tsx
+++ b/src/app/(protected)/(standard)/_components/MainMenu.tsx
@@ -73,7 +73,6 @@ const MainMenu = ({ accessDenied }: { accessDenied?: string | undefined }) => {
             gridTemplateColumns: {
               xs: '1fr',
               sm: 'repeat(2, 1fr)',
-              md: 'repeat(3, 1fr)',
             },
             gap: 3,
             alignItems: 'stretch',

--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -41,10 +41,6 @@ const DashboardMenu = () => {
             url: '/admin/forms',
           },
           {
-            label: 'Announcements',
-            url: '/admin/announcements',
-          },
-          {
             label: 'Users',
             url: '/admin/users',
           },


### PR DESCRIPTION
## 概要
- 初期リリースでお知らせ機能を追加する予定がなくなったため、一般ユーザー向け・管理者向けメニューにあった「お知らせ」への導線ボタンを削除
- リンク先の `/announcements`・`/admin/announcements` ページは実装されておらず、いずれもデッドリンクだった
- 対象: `src/app/(protected)/(standard)/_components/MainMenu.tsx`、`src/app/(protected)/admin/_components/DashboardMenu.tsx`

## 確認事項
- リポジトリ全体を grep し、お知らせ機能に関連する API ルート・hooks・型定義・生成コードが他に存在しないことを確認（メニュー項目のみが先行して置かれていた状態）
- lint / type-check / unit test（pre-commit, pre-push フック経由）がすべて成功

🤖 Generated with Claude Code