### PR TITLE
fix: 投稿制限があるユーザーには回答フォームを事前にdisabledにする

### DIFF
--- a/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerForm.tsx
@@ -6,6 +6,8 @@ import { SigninButton } from '@/app/_components/SigninButton';
 import type { GetQuestionsResponse } from '@/lib/api-types';
 import { formatRestrictionExpiration } from '@/lib/restrictions/expiration';
 
+import type { SubmissionRestriction } from '../_lib/submissionErrors';
+
 import AnswerSubmissionForm from './AnswerSubmissionForm';
 import AnswerSubmissionSuccess from './AnswerSubmissionSuccess';
 import type { SubmissionState } from './useAnswerSubmission';
@@ -18,6 +20,7 @@ interface Props {
   description: string;
   isAuthenticated: boolean;
   allowTemporaryAnswers: boolean;
+  restriction: SubmissionRestriction | null;
 }
 
 /**
@@ -31,6 +34,7 @@ const AnswerForm = ({
   description,
   isAuthenticated,
   allowTemporaryAnswers,
+  restriction,
 }: Props) => {
   // 未ログインかつフォームが未ログイン回答を許可している場合のみ匿名回答モード。
   const isTemporary = !isAuthenticated && allowTemporaryAnswers;
@@ -61,6 +65,14 @@ const AnswerForm = ({
 
   return (
     <Stack spacing={0} sx={{ width: '100%' }}>
+      {restriction && (
+        <Alert
+          severity="error"
+          sx={{ width: '100%', maxWidth: 800, mx: 'auto', mb: 2 }}
+        >
+          <RestrictionMessage restriction={restriction} />
+        </Alert>
+      )}
       <SubmissionErrorAlert submissionState={submissionState} />
       <AnswerSubmissionForm
         questions={questions}
@@ -68,6 +80,7 @@ const AnswerForm = ({
         description={description}
         isTemporary={isTemporary}
         onSubmitAnswers={submitAnswers}
+        disabled={Boolean(restriction)}
       />
     </Stack>
   );
@@ -95,12 +108,11 @@ const SubmissionErrorAlert = ({
       const restriction = submissionState.error.restriction;
       return (
         <Alert severity="error" sx={alertSx}>
-          現在、回答の投稿が制限されています。
-          {restriction?.reason && `（理由: ${restriction.reason}）`}
-          {restriction?.expiration.kind === 'expiresAt' &&
-            ` 制限解除予定: ${formatRestrictionExpiration(
-              restriction.expiration
-            )}`}
+          {restriction ? (
+            <RestrictionMessage restriction={restriction} />
+          ) : (
+            '現在、回答の投稿が制限されています。'
+          )}
         </Alert>
       );
     }
@@ -112,5 +124,18 @@ const SubmissionErrorAlert = ({
       );
   }
 };
+
+const RestrictionMessage = ({
+  restriction,
+}: {
+  restriction: SubmissionRestriction;
+}) => (
+  <>
+    現在、回答の投稿が制限されています。
+    {restriction.reason && `（理由: ${restriction.reason}）`}
+    {restriction.expiration.kind === 'expiresAt' &&
+      ` 制限解除予定: ${formatRestrictionExpiration(restriction.expiration)}`}
+  </>
+);
 
 export default AnswerForm;

--- a/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -25,6 +25,7 @@ type Props = {
   description: string;
   isTemporary: boolean;
   onSubmitAnswers: (data: AnswerFormInput) => Promise<{ ok: boolean }>;
+  disabled?: boolean;
 };
 
 /**
@@ -37,6 +38,7 @@ const AnswerSubmissionForm = ({
   description,
   isTemporary,
   onSubmitAnswers,
+  disabled = false,
 }: Props) => {
   const {
     control,
@@ -82,6 +84,7 @@ const AnswerSubmissionForm = ({
                   })}
                   label="お名前"
                   required
+                  disabled={disabled}
                   error={Boolean(errors[TEMPORARY_USER_FIELDS.name])}
                   helperText={errors[TEMPORARY_USER_FIELDS.name]?.message}
                 />
@@ -91,6 +94,7 @@ const AnswerSubmissionForm = ({
                   })}
                   label="連絡先"
                   required
+                  disabled={disabled}
                   helperText={
                     errors[TEMPORARY_USER_FIELDS.contactText]?.message ??
                     'Discord ユーザー名やメールアドレスなど、連絡が取れる情報を入力してください。'
@@ -119,6 +123,7 @@ const AnswerSubmissionForm = ({
                   control={control}
                   register={register}
                   errors={errors}
+                  disabled={disabled}
                 />
               </Stack>
             </Paper>
@@ -136,7 +141,7 @@ const AnswerSubmissionForm = ({
               variant="contained"
               size="large"
               endIcon={<SendIcon />}
-              disabled={isSubmitting}
+              disabled={isSubmitting || disabled}
             >
               送信
             </Button>

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -21,6 +21,7 @@ type Props = {
   control: Control<AnswerFormInput>;
   register: UseFormRegister<AnswerFormInput>;
   errors: FieldErrors<AnswerFormInput>;
+  disabled?: boolean;
 };
 
 const requiredMultiSelectMessage =
@@ -35,6 +36,7 @@ const QuestionFieldRenderer = ({
   control,
   register,
   errors,
+  disabled = false,
 }: Props) => {
   const questionId = question.id;
 
@@ -48,6 +50,7 @@ const QuestionFieldRenderer = ({
             required={question.is_required}
             multiline
             fullWidth
+            disabled={disabled}
           />
           <FormHelperText>Markdown に対応しています。</FormHelperText>
         </FormControl>
@@ -76,6 +79,7 @@ const QuestionFieldRenderer = ({
                 <Select
                   {...field}
                   fullWidth
+                  disabled={disabled}
                   labelId={`select-label-${questionId}`}
                   label="選択してください"
                   value={fieldValue}
@@ -137,6 +141,7 @@ const QuestionFieldRenderer = ({
                         },
                       })}
                       value={choice.label}
+                      disabled={disabled}
                     />
                   }
                   label={choice.label}

--- a/src/app/(public)/forms/[formId]/_lib/submissionErrors.ts
+++ b/src/app/(public)/forms/[formId]/_lib/submissionErrors.ts
@@ -1,5 +1,6 @@
 import { errorResponseSchema } from '@/lib/api/errors';
 import type { ErrorRestriction } from '@/lib/api/errors';
+import type { GetAnswerSubmitterRestrictionResponse } from '@/lib/api/types';
 import { toRestrictionExpiration } from '@/lib/restrictions/expiration';
 import type { RestrictionExpiration } from '@/lib/restrictions/expiration';
 
@@ -26,6 +27,12 @@ const toSubmissionRestriction = (
   reason: restriction.reason,
   expiration: toRestrictionExpiration(restriction.expires_at),
 });
+
+// フォーム表示時点で有効な投稿制限を、送信時エラーと同じ形に揃えて事前表示に使えるようにする。
+export const toActiveSubmissionRestriction = (
+  restriction: GetAnswerSubmitterRestrictionResponse
+): SubmissionRestriction | null =>
+  restriction ? toSubmissionRestriction(restriction) : null;
 
 export const parseSubmissionError = (
   error: unknown

--- a/src/app/(public)/forms/[formId]/page.tsx
+++ b/src/app/(public)/forms/[formId]/page.tsx
@@ -2,15 +2,42 @@ import type { Metadata } from 'next';
 
 import {
   authorizationHeader,
+  BackendError,
   requireBackendData,
   serverApiClient,
 } from '@/lib/server/backend';
 import { getSession } from '@/lib/server/session';
 
 import AnswerForm from './_components/AnswerForm';
+import { toActiveSubmissionRestriction } from './_lib/submissionErrors';
 
 export const metadata: Metadata = {
   title: 'フォーム回答 | Seichi Portal',
+};
+
+// 自分自身の有効な投稿制限を取得する。取得できない場合(権限不足など)は
+// 制限なしとして扱い、送信時のエラー表示に判定を委ねる。
+const fetchOwnRestriction = async (session: {
+  token: string;
+  user: { id: string };
+}) => {
+  try {
+    const restriction = await requireBackendData(
+      serverApiClient.GET('/api/v1/users/{uuid}/answer-submitter-restriction', {
+        headers: authorizationHeader(session.token),
+        params: {
+          path: { uuid: session.user.id },
+        },
+      })
+    );
+
+    return toActiveSubmissionRestriction(restriction);
+  } catch (error) {
+    if (error instanceof BackendError) {
+      return null;
+    }
+    throw error;
+  }
 };
 
 const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
@@ -30,6 +57,10 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
     })
   );
 
+  const restriction = isAuthenticated
+    ? await fetchOwnRestriction(session)
+    : null;
+
   return (
     <AnswerForm
       questions={form.questions}
@@ -38,6 +69,7 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
       description={form.description}
       isAuthenticated={isAuthenticated}
       allowTemporaryAnswers={form.settings.allow_temporary_answers}
+      restriction={restriction}
     />
   );
 };


### PR DESCRIPTION
## 概要
- これまでは投稿制限中でも回答フォームを操作でき、送信ボタン押下後にエラーで初めて気づく形だった
- フォーム表示時(サーバーコンポーネント)に自分自身の有効な投稿制限を取得し、制限中は入力欄・送信ボタンをdisabledにして、理由と解除予定日を上部アラートで表示するようにした
- フォーム自体は非表示にせず、内容確認や下書き目的での閲覧はできる状態を保っている

## 確認事項
- `pnpm exec tsc --noEmit`・`pnpm exec eslint`・`pnpm exec prettier --check`・`pnpm build` がすべて通ることを確認済み
- 投稿制限取得API(`GET /api/v1/users/{uuid}/answer-submitter-restriction`)は元々管理画面がADMINISTRATOR権限で他ユーザーを照会するためのエンドポイントで、一般ユーザーが自分のUUIDで呼んだ場合に許可されるかはバックエンド実装次第のため未検証。403等が返ってきても`BackendError`を握りつぶし「制限なし」扱いにフォールバックするようにしており、その場合は従来通り送信時のエラー表示でブロックされるため、権限が無くても機能が壊れることはない
- レビューでは、このフォールバック方針(事前チェックが失敗しても送信時ブロックに委ねる設計)が妥当か見ていただきたい

## 補足
- バックエンド側で自己アクセス時の権限仕様が確認できたら、フォールバックの要否を見直す想定

🤖 Generated with Claude Code