### PR TITLE
feat: k8s デプロイに向けて Docker イメージ化とリリース CI を追加する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+**/node_modules
+**/.next
+**/.git
+**/.env*
+**/.direnv
+**/coverage
+**/test-results
+**/playwright-report
+
+# GitHub 関連(ビルドに不要)
+.github
+
+# テストツール関連(ビルドに不要)
+tests
+playwright.config.ts
+vitest.config.ts
+vitest.unit.config.ts
+vitest.component.config.ts
+
+# codegen 関連(ビルド時には src/generated の生成済み結果を使うため不要)
+scripts
+
+# その他ビルドに不要なファイル
+.editorconfig
+Dockerfile
+.dockerignore
+.gitignore
+.prettierignore
+AGENTS.md
+CLAUDE.md
+CONTRIBUTING.md
+LICENSE
+README.md
+eslint.config.mjs
+lefthook.yml
+mise.toml
+prettier.config.mjs
+tsconfig.tsbuildinfo

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,0 +1,103 @@
+name: Release docker images
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: image-release-main
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Check release eligibility
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.release.outputs.publish }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Check package.json version and release tag
+        id: release
+        run: |
+          if ! git rev-parse "$GITHUB_SHA^" >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          previous_version="$(git show "$GITHUB_SHA^:package.json" | jq -r '.version')"
+          current_version="$(jq -r '.version' package.json)"
+
+          if ! printf '%s\n' "$current_version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "Invalid package.json version: $current_version" >&2
+            exit 1
+          fi
+          if [ "$previous_version" = "$current_version" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tag="v$current_version"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag"; then
+            echo "Release tag $tag already exists" >&2
+            exit 1
+          fi
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "version=$current_version" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Build and push docker image
+    needs: prepare
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Prepare image name
+        id: image
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: echo "name=ghcr.io/${OWNER,,}/seichi-portal-frontend" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          push: true
+          build-args: |
+            NEXT_PUBLIC_DEBUG_MODE=false
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ needs.prepare.outputs.version }}
+            ${{ steps.image.outputs.name }}:${{ github.sha }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TARGET: ${{ github.sha }}
+        run: gh release create "v$VERSION" --target "$TARGET" --title "v$VERSION" --generate-notes

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,103 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: SemVer component to increment
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Calculate release version
+        id: release
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          current_version="$(jq -r '.version' package.json)"
+          if ! printf '%s\n' "$current_version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "Invalid package.json version: $current_version" >&2
+            exit 1
+          fi
+
+          IFS=. read -r major minor patch <<< "$current_version"
+          case "$BUMP" in
+            major) next_version="$((major + 1)).0.0" ;;
+            minor) next_version="$major.$((minor + 1)).0" ;;
+            patch) next_version="$major.$minor.$((patch + 1))" ;;
+            *) echo "Unsupported version bump: $BUMP" >&2; exit 1 ;;
+          esac
+          branch="release/v$next_version"
+          tag="v$next_version"
+
+          if git ls-remote --exit-code --heads origin "refs/heads/$branch"; then
+            echo "Release branch $branch already exists" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag"; then
+            echo "Release tag $tag already exists" >&2
+            exit 1
+          fi
+
+          echo "version=$next_version" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Update package.json version
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.next
+          mv package.json.next package.json
+          test "$(jq -r '.version' package.json)" = "$VERSION"
+
+      - name: Commit and push release branch
+        env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git switch -c "$BRANCH"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add package.json
+          git commit -m "chore: release v$VERSION の準備をする"
+          git push origin "$BRANCH"
+
+      - name: Create release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.release.outputs.branch }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Prepare release v$VERSION" \
+            --body "package.json のバージョンを v$VERSION に更新します。"
+
+      - name: Start Checking workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.release.outputs.branch }}
+        run: gh workflow run ci.yaml --ref "$BRANCH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24.17.0-alpine AS base
+WORKDIR /app
+RUN corepack enable
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_DEBUG_MODE=false
+ARG NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_DEBUG_MODE=$NEXT_PUBLIC_DEBUG_MODE
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm run build
+
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder --chown=65532:65532 /app/public ./public
+COPY --from=builder --chown=65532:65532 /app/.next/standalone ./
+COPY --from=builder --chown=65532:65532 /app/.next/static ./.next/static
+
+USER 65532:65532
+
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+EXPOSE 3000
+
+CMD ["server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,9 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'standalone',
+};
 
 module.exports = withSentryConfig(nextConfig, {
   silent: true,


### PR DESCRIPTION
## 概要
- seichi_infra 上の k8s (ArgoCD + GitOps) で稼働させることを見据え、backend (`seichi-portal-backend`) と同じ構成に揃えて Docker イメージ化した
- distroless ベースのマルチステージ Dockerfile を追加。ビルドは pnpm が使える alpine で行い、実行ステージは `gcr.io/distroless/nodejs24-debian12:nonroot`(シェル・パッケージマネージャーなし、UID 65532 の nonroot)にすることで攻撃対象領域を減らした
- リリース CI を2本追加
  - `prepare-release.yaml`: 手動 dispatch で `package.json` の version を patch/minor/major で bump し、リリース PR を自動作成
  - `image-release.yaml`: main マージ時に version bump を検知したら `linux/amd64`/`linux/arm64/v8` のイメージをビルドして `ghcr.io/giganticminecraft/seichi-portal-frontend` に push し、GitHub Release も作成
- `.dockerignore` に GitHub 関連・テストツール・codegen スクリプトなどビルドに不要なファイルを追加

## 確認事項
- ローカルで `docker build --no-cache` → `docker run` まで実施し、以下を確認済み
  - ビルド・起動が成功する
  - 実行ユーザーが distroless の nonroot(UID 65532)になっている
  - 必須の server 側環境変数(`BACKEND_SERVER_URL` 等)を渡すと HTTP 200 で応答する
- `.dockerignore` 更新後も `--no-cache` でフルリビルドし、ビルドに必要なファイルが欠けていないことを確認済み
- `prepare-release.yaml` / `image-release.yaml` は backend 側の既存ワークフローと同じ構造で作成したが、実際にワークフローを動かしての確認(GHCR への push・GitHub Release 作成)は未実施。マージ後に初回リリースで動作を見る必要がある

## 補足
- リポジトリの GitHub Actions 設定で GITHUB_TOKEN の `packages: write` 権限が有効になっているか未確認。無効の場合 `image-release.yaml` の push が失敗する
- `NEXT_PUBLIC_SENTRY_DSN` はビルド引数として渡していない。本番で Sentry を有効化する場合は別途対応が必要
- seichi_infra 側への deployment/service manifest 追加は本 PR の範囲外(別途対応予定)

🤖 Generated with Claude Code