### PR TITLE
fix: 非公開回答のコメント取得403でページ全体が落ちないようにする

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
@@ -12,6 +12,7 @@ import {
   isQueryGroupReady,
 } from '@/app/_swr/queryState';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { isHttpError } from '@/lib/httpError';
 
 import AnswerDetailsPageView from './AnswerDetailsPageView';
 import type { AnswerDetailsPageData } from './AnswerDetailsPageView';
@@ -71,6 +72,13 @@ const AnswerDetailsPageContent = ({
     { refreshInterval: 1000 }
   );
 
+  // 回答が非公開になっている場合、管理者以外はコメントの閲覧権限を持たない
+  // (投稿者本人であっても例外はない)。事前に判定できないため、403は
+  // コメントセクションのみを無効化する個別のエラーとして扱い、ページ全体の
+  // 表示を妨げないようにする。
+  const commentsForbidden =
+    isHttpError(commentsQuery.error) && commentsQuery.error.status === 403;
+
   // ラベル選択肢は管理者操作(ラベル編集)にのみ必要なため、管理者以外では取得しない
   const labelOptionsQuery = useApiQuery(
     '/api/v1/labels/answers',
@@ -80,15 +88,20 @@ const AnswerDetailsPageContent = ({
   const requiredQueries = {
     answer: answerQuery,
     form: formQuery,
-    comments: commentsQuery,
   };
-  const queryError = getRequiredQueryGroupError(requiredQueries);
+  const queryError =
+    getRequiredQueryGroupError(requiredQueries) ??
+    (commentsForbidden ? undefined : commentsQuery.error);
 
   if (queryError !== undefined) {
     return <ErrorDialog />;
   }
 
-  if (!isQueryGroupReady(requiredQueries)) {
+  const commentsReady =
+    commentsForbidden ||
+    (!commentsQuery.isLoading && commentsQuery.data !== undefined);
+
+  if (!isQueryGroupReady(requiredQueries) || !commentsReady) {
     return <LoadingCircular />;
   }
 
@@ -96,7 +109,8 @@ const AnswerDetailsPageContent = ({
     answer: requiredQueries.answer.data,
     form: requiredQueries.form.data,
     messages: getOptionalQueryData(messagesQuery) ?? [],
-    comments: requiredQueries.comments.data,
+    comments: commentsForbidden ? [] : (commentsQuery.data ?? []),
+    commentsDisabled: commentsForbidden,
     currentUserId: currentUser.id,
     isAdmin,
     labelOptions: getOptionalQueryData(labelOptionsQuery) ?? [],

--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
@@ -26,6 +26,7 @@ export type AnswerDetailsPageData = {
   form: GetFormResponse;
   messages: GetMessagesResponse;
   comments: AnswerComment[];
+  commentsDisabled: boolean;
   currentUserId: string;
   isAdmin: boolean;
   labelOptions: GetAnswerLabelsResponse;
@@ -123,6 +124,12 @@ const AnswerDetailsPageView = ({
         showDeleteButton={data.isAdmin ? true : undefined}
         isAdmin={data.isAdmin}
         deepLink={commentDeepLink}
+        disabled={data.commentsDisabled}
+        disabledReason={
+          data.commentsDisabled
+            ? 'この回答が非公開のため、管理者以外はコメントを閲覧できません'
+            : undefined
+        }
       />
     </Stack>
   );

--- a/src/app/(protected)/_components/Conversation/Comments.tsx
+++ b/src/app/(protected)/_components/Conversation/Comments.tsx
@@ -30,11 +30,16 @@ const Comments = (props: {
   showDeleteButton: boolean | undefined;
   isAdmin: boolean;
   deepLink: ConversationDeepLinkProps;
+  /** true のとき、コメントの閲覧・投稿を無効化する(バックエンドへのリクエストも行わない)。 */
+  disabled?: boolean | undefined;
+  /** disabled が true のときに trigger ボタンのホバーで表示する理由。 */
+  disabledReason?: string | undefined;
 }) => {
   const actions = useCommentConversationActions(props.formId, props.answerId);
   const { historyByTargetId, isLoading: isHistoryLoading } = useCommentHistory(
     props.formId,
-    props.answerId
+    props.answerId,
+    !props.disabled
   );
 
   const entries: ConversationEntryViewModel[] = props.comments.map(
@@ -99,13 +104,15 @@ const Comments = (props: {
         triggerLabel={`コメント (${entries.length})`}
         triggerStartIcon={<Typography component="span">💬</Typography>}
         triggerDescription="回答について議論したり、メモを残したりするための機能です。基本的に、この回答を閲覧できる人であれば誰でも閲覧できます。"
+        triggerDisabled={props.disabled}
+        triggerDisabledReason={props.disabledReason}
         items={items}
         capabilities={capabilities}
         autoOpen={deepLinkState.autoOpen}
         highlightedEntryId={deepLinkState.highlightedEntryId}
         onDrawerClose={deepLinkState.onDrawerClose}
         inputForm={
-          capabilities.canCompose ? (
+          props.disabled ? null : capabilities.canCompose ? (
             <Box
               sx={{
                 p: 2,

--- a/src/app/(protected)/_components/Conversation/useConversationHistory.ts
+++ b/src/app/(protected)/_components/Conversation/useConversationHistory.ts
@@ -112,8 +112,16 @@ const toMessageHistoryViewModel = (
  * 画面の再読み込みを不要にする。 */
 const HISTORY_REFRESH_INTERVAL_MS = 1000;
 
-/** コメントの変更履歴を全ページ取得し、comment_id ごとにグルーピングする。 */
-export const useCommentHistory = (formId: string, answerId: string) => {
+/**
+ * コメントの変更履歴を全ページ取得し、comment_id ごとにグルーピングする。
+ * enabled が false のときはバックエンドへリクエストしない
+ * (コメントの閲覧権限がない場合に使う)。
+ */
+export const useCommentHistory = (
+  formId: string,
+  answerId: string,
+  enabled = true
+) => {
   const { items, hasMore, isLoadingMore, loadMore } = useInfiniteApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}/comments/history',
     (cursor) => ({
@@ -121,7 +129,7 @@ export const useCommentHistory = (formId: string, answerId: string) => {
       query: cursor === undefined ? {} : { cursor },
     }),
     EMPTY_COMMENT_HISTORY_PAGE,
-    { refreshInterval: HISTORY_REFRESH_INTERVAL_MS }
+    { refreshInterval: HISTORY_REFRESH_INTERVAL_MS, enabled }
   );
   useAutoLoadAll(hasMore, isLoadingMore, loadMore);
   const hasCompletedInitialLoad = useHasCompletedInitialLoad(

--- a/tests/component/AnswerDetailsPageView.test.tsx
+++ b/tests/component/AnswerDetailsPageView.test.tsx
@@ -86,6 +86,7 @@ const baseData: AnswerDetailsPageData = {
   form,
   messages: [],
   comments: [otherUserComment],
+  commentsDisabled: false,
   currentUserId: 'current-user',
   isAdmin: false,
   labelOptions: [],


### PR DESCRIPTION
backend PR #1247 でコメントの認可が強化され、回答が非公開の場合は
投稿者本人であっても管理者以外はコメントを閲覧できなくなった
(例外なし)。既存のAnswerDetailsPageContentはコメント取得を必須
クエリ扱いにしており、この403が発生すると回答詳細ページ全体が
ErrorDialogで表示不能になっていた。

メッセージ機能が使っているdisabled/disabledReasonパターンを
コメントにも適用し、コメント取得の403はセクション単位で無効化
表示するだけにとどめ、ページ全体には影響しないようにする。

Co-authored-by: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>