### PR TITLE
feat: 管理者が回答詳細から関連回答を追加・解除できるようにする

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+
+import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
+import type { AnswerSearchResponse } from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+type SearchedAnswer = AnswerSearchResponse['answers'][number];
+
+const AdminRelatedAnswerAdder = ({
+  formId,
+  answerId,
+  excludedAnswerIds,
+}: {
+  formId: string;
+  answerId: string;
+  excludedAnswerIds: string[];
+}) => {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const { addRelatedAnswer } = useRelatedAnswerActions(formId, answerId);
+
+  useEffect(() => {
+    const trimmed = search.trim();
+    if (trimmed === '') {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedSearch(trimmed);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (value.trim() === '') {
+      setDebouncedSearch('');
+    }
+  };
+
+  const { data, isLoading } = useApiQuery(
+    '/api/v1/search/answers',
+    debouncedSearch === '' ? null : { query: { query: debouncedSearch } },
+    { keepPreviousData: true }
+  );
+
+  const excluded = new Set([answerId, ...excludedAnswerIds]);
+  const options = (data?.answers ?? []).filter(
+    (answer) => !excluded.has(answer.id)
+  );
+
+  return (
+    <Autocomplete<SearchedAnswer>
+      options={options}
+      loading={isLoading}
+      filterOptions={(options) => options}
+      inputValue={search}
+      onInputChange={(_event, value) => {
+        handleSearchChange(value);
+      }}
+      getOptionLabel={(option) => resolveAnswerTitle(option.title)}
+      isOptionEqualToValue={(a, b) => a.id === b.id}
+      value={null}
+      onChange={(_event, option) => {
+        if (option === null) {
+          return;
+        }
+        handleSearchChange('');
+        void addRelatedAnswer(option.form_id, option.id);
+      }}
+      renderInput={(params) => (
+        <TextField {...params} label="関連付ける回答を検索" size="small" />
+      )}
+      sx={{ minWidth: 280 }}
+    />
+  );
+};
+
+export default AdminRelatedAnswerAdder;

--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
@@ -119,7 +119,12 @@ const AnswerDetailsPageView = ({
         }
       />
       <AnswerDetails answer={data.answer} questions={data.form.questions} />
-      <RelatedAnswers relations={data.relatedAnswers} isAdmin={data.isAdmin} />
+      <RelatedAnswers
+        relations={data.relatedAnswers}
+        isAdmin={data.isAdmin}
+        formId={formId}
+        answerId={answerId}
+      />
       <Comments
         comments={data.comments}
         formId={formId}

--- a/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
@@ -10,9 +10,11 @@ import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
 const RelatedAnswerItem = ({
   relation,
   isAdmin,
+  onRemove,
 }: {
   relation: RelatedAnswerResponse;
   isAdmin: boolean;
+  onRemove?: (() => void) | undefined;
 }) => {
   const answerQuery = useApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}',
@@ -33,6 +35,7 @@ const RelatedAnswerItem = ({
       label={label}
       clickable
       variant="outlined"
+      onDelete={onRemove}
     />
   );
 };

--- a/src/app/(protected)/_components/AnswerDetail/RelatedAnswers.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/RelatedAnswers.tsx
@@ -2,35 +2,59 @@
 
 import { Stack, Typography } from '@mui/material';
 
+import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
 import type { RelatedAnswerResponse } from '@/lib/api-types';
 
+import AdminRelatedAnswerAdder from './AdminRelatedAnswerAdder';
 import RelatedAnswerItem from './RelatedAnswerItem';
 
 const RelatedAnswers = ({
   relations,
   isAdmin,
+  formId,
+  answerId,
 }: {
   relations: RelatedAnswerResponse[];
   isAdmin: boolean;
-}) => (
-  <Stack spacing={1}>
-    <Typography variant="subtitle1">関連する回答</Typography>
-    {relations.length === 0 ? (
-      <Typography color="textSecondary">
-        関連付けられた回答はありません
-      </Typography>
-    ) : (
-      <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
-        {relations.map((relation) => (
-          <RelatedAnswerItem
-            key={`${relation.form_id}:${relation.answer_id}`}
-            relation={relation}
-            isAdmin={isAdmin}
-          />
-        ))}
-      </Stack>
-    )}
-  </Stack>
-);
+  formId: string;
+  answerId: string;
+}) => {
+  const { removeRelatedAnswer } = useRelatedAnswerActions(formId, answerId);
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="subtitle1">関連する回答</Typography>
+      {relations.length === 0 ? (
+        <Typography color="textSecondary">
+          関連付けられた回答はありません
+        </Typography>
+      ) : (
+        <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+          {relations.map((relation) => (
+            <RelatedAnswerItem
+              key={`${relation.form_id}:${relation.answer_id}`}
+              relation={relation}
+              isAdmin={isAdmin}
+              onRemove={
+                isAdmin
+                  ? () => {
+                      void removeRelatedAnswer(relation.answer_id);
+                    }
+                  : undefined
+              }
+            />
+          ))}
+        </Stack>
+      )}
+      {isAdmin && (
+        <AdminRelatedAnswerAdder
+          formId={formId}
+          answerId={answerId}
+          excludedAnswerIds={relations.map((relation) => relation.answer_id)}
+        />
+      )}
+    </Stack>
+  );
+};
 
 export default RelatedAnswers;

--- a/src/hooks/useRelatedAnswerActions.ts
+++ b/src/hooks/useRelatedAnswerActions.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useSWRConfig } from 'swr';
+
+import { handleMutationResponse } from '@/hooks/useApiMutation';
+import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
+import { proxyClient } from '@/lib/proxyClient';
+
+type RelatedAnswerActionResult = { ok: boolean; forbidden?: boolean };
+
+export const useRelatedAnswerActions = (formId: string, answerId: string) => {
+  const { mutate } = useSWRConfig();
+  const relatedAnswersKey = [
+    '/api/v1/forms/{form_id}/answers/{answer_id}/related-answers',
+    { path: { form_id: formId, answer_id: answerId } },
+  ];
+
+  const addRelatedAnswer = async (
+    targetFormId: string,
+    targetAnswerId: string
+  ): Promise<RelatedAnswerActionResult> => {
+    const { data, error, response } = await proxyClient.POST(
+      '/api/v1/forms/{form_id}/answers/{answer_id}/related-answers',
+      {
+        params: {
+          path: { form_id: formId, answer_id: answerId },
+        },
+        body: { form_id: targetFormId, answer_id: targetAnswerId },
+      }
+    );
+    const result = handleMutationResponse(response, data, error);
+    if (result.success) {
+      void mutate(relatedAnswersKey).catch(() => {});
+      return { ok: true };
+    }
+
+    return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
+  };
+
+  const removeRelatedAnswer = async (
+    relatedAnswerId: string
+  ): Promise<RelatedAnswerActionResult> => {
+    const { data, error, response } = await proxyClient.DELETE(
+      '/api/v1/forms/{form_id}/answers/{answer_id}/related-answers/{related_answer_id}',
+      {
+        params: {
+          path: {
+            form_id: formId,
+            answer_id: answerId,
+            related_answer_id: relatedAnswerId,
+          },
+        },
+      }
+    );
+    const result = handleMutationResponse(response, data, error);
+    if (result.success) {
+      void mutate(relatedAnswersKey).catch(() => {});
+      return { ok: true };
+    }
+
+    return { ok: false, ...(result.forbidden ? { forbidden: true } : {}) };
+  };
+
+  return {
+    addRelatedAnswer: useSingleFlightAction(addRelatedAnswer),
+    removeRelatedAnswer: useSingleFlightAction(removeRelatedAnswer),
+  };
+};


### PR DESCRIPTION
backend PR #1249 で追加されたPOST/DELETE .../related-answers を使い、
管理者が回答詳細ページから他の回答(フォームをまたいでも可)を検索して
関連付けたり、既存の関連付けを解除したりできるようにする。

検索は既存のAnswersPageContentと同じデバウンスパターンで
/api/v1/search/answers をform_id指定なしに呼び出し、全フォーム横断で
候補を探せるようにした。追加・解除ともに成功後は関連回答一覧のSWR
キーを再検証し、画面に即時反映する。

Co-authored-by: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>