### PR TITLE
fix: フォーム編集時のチェック状態を正しく表示する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -179,8 +179,20 @@ const AcceptancePeriodSettings = ({
 const AnswerSettings = ({
   register,
   control,
+  setValue,
   groupOptions,
-}: Pick<FormSettingsProps, 'register' | 'control' | 'groupOptions'>) => {
+}: Pick<
+  FormSettingsProps,
+  'register' | 'control' | 'setValue' | 'groupOptions'
+>) => {
+  const hideAuthor = useWatch({
+    control,
+    name: 'settings.hide_author',
+  });
+  const allowTemporaryAnswers = useWatch({
+    control,
+    name: 'settings.allow_temporary_answers',
+  });
   const { field: answerVisibilityField } = useController({
     control,
     name: 'settings.answer_visibility',
@@ -222,7 +234,10 @@ const AnswerSettings = ({
           label="回答者を隠して公開する"
           control={
             <Checkbox
-              {...register('settings.hide_author')}
+              checked={hideAuthor}
+              onChange={(_, checked) => {
+                setValue('settings.hide_author', checked);
+              }}
               disabled={hideAuthorHasNoEffect}
             />
           }
@@ -242,7 +257,14 @@ const AnswerSettings = ({
       />
       <FormControlLabel
         label="未ログインユーザーの回答を許可する"
-        control={<Checkbox {...register('settings.allow_temporary_answers')} />}
+        control={
+          <Checkbox
+            checked={allowTemporaryAnswers}
+            onChange={(_, checked) => {
+              setValue('settings.allow_temporary_answers', checked);
+            }}
+          />
+        }
       />
       <Stack spacing={0.5}>
         <FieldLabel label="デフォルトの回答タイトル" />
@@ -261,10 +283,11 @@ const AnswerSettings = ({
 const NotificationSettings = ({
   register,
   control,
+  setValue,
   discordWebhookEnabled,
 }: Pick<
   FormSettingsProps,
-  'register' | 'control' | 'discordWebhookEnabled'
+  'register' | 'control' | 'setValue' | 'discordWebhookEnabled'
 >) => {
   const discordWebhookDisabled = useWatch({
     control,
@@ -295,7 +318,12 @@ const NotificationSettings = ({
       <FormControlLabel
         label="Webhook 通知を無効化する(URL入力より優先されます)"
         control={
-          <Checkbox {...register('settings.discord_webhook_disabled')} />
+          <Checkbox
+            checked={discordWebhookDisabled}
+            onChange={(_, checked) => {
+              setValue('settings.discord_webhook_disabled', checked);
+            }}
+          />
         }
       />
     </Stack>
@@ -331,6 +359,7 @@ const FormSettings = (props: FormSettingsProps) => {
       <AnswerSettings
         register={props.register}
         control={props.control}
+        setValue={props.setValue}
         groupOptions={props.groupOptions}
       />
 
@@ -338,6 +367,7 @@ const FormSettings = (props: FormSettingsProps) => {
       <NotificationSettings
         register={props.register}
         control={props.control}
+        setValue={props.setValue}
         discordWebhookEnabled={props.discordWebhookEnabled}
       />
     </Stack>

--- a/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/QuestionEditor.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
+import { useController, useWatch } from 'react-hook-form';
 import type { Control, UseFormRegister } from 'react-hook-form';
 
 import FieldLabel from '@/app/_components/FieldLabel';
@@ -25,6 +26,15 @@ const QuestionEditor = (props: {
   questionIndex: number;
   removeDisabled: boolean;
 }) => {
+  const { field: isRequiredField } = useController({
+    control: props.control,
+    name: `questions.${props.questionIndex}.is_required`,
+  });
+  const isRequired = useWatch({
+    control: props.control,
+    name: `questions.${props.questionIndex}.is_required`,
+  });
+
   return (
     <Stack spacing={2}>
       <Typography variant="h6" component="h2" sx={{ fontWeight: 'bold' }}>
@@ -76,7 +86,10 @@ const QuestionEditor = (props: {
         label="この質問への回答を必須にする"
         control={
           <Checkbox
-            {...props.register(`questions.${props.questionIndex}.is_required`)}
+            checked={isRequired}
+            onChange={(_, checked) => {
+              isRequiredField.onChange(checked);
+            }}
           />
         }
       />

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -117,38 +117,84 @@ const QuestionFieldRenderer = ({
     case 'MultipleChoice':
       return (
         <>
-          <Grid container spacing={2} sx={{ mt: 1 }}>
-            {question.choices.map((choice, index) => (
-              <Grid
-                size={{ xs: 12, sm: 6, md: 4 }}
-                key={`q-${questionId}.a-${index}`}
-              >
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      {...register(questionId, {
-                        validate: {
-                          itemMustBeChecked: (value) => {
-                            if (!question.is_required) return true;
-                            if (typeof value === 'boolean') {
-                              return requiredMultiSelectMessage;
-                            }
+          <Controller
+            control={control}
+            name={questionId}
+            defaultValue={question.choices.length === 1 ? false : []}
+            rules={{
+              validate: {
+                itemMustBeChecked: (value) => {
+                  if (!question.is_required) return true;
 
-                            return (
-                              value.length >= 1 || requiredMultiSelectMessage
-                            );
-                          },
-                        },
-                      })}
-                      value={choice.label}
-                      disabled={disabled}
-                    />
-                  }
-                  label={choice.label}
-                />
-              </Grid>
-            ))}
-          </Grid>
+                  return (
+                    (Array.isArray(value) && value.length >= 1) ||
+                    (typeof value === 'string' && value !== '') ||
+                    requiredMultiSelectMessage
+                  );
+                },
+              },
+            }}
+            render={({ field }) => {
+              const selectedValues: string[] =
+                typeof field.value === 'string'
+                  ? field.value === ''
+                    ? []
+                    : [field.value]
+                  : Array.isArray(field.value)
+                    ? field.value
+                    : [];
+              const choiceOrder = new Map(
+                question.choices.map((item, itemIndex) => [
+                  item.label,
+                  itemIndex,
+                ])
+              );
+
+              return (
+                <Grid container spacing={2} sx={{ mt: 1 }}>
+                  {question.choices.map((choice, index) => (
+                    <Grid
+                      size={{ xs: 12, sm: 6, md: 4 }}
+                      key={`q-${questionId}.a-${index}`}
+                    >
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={selectedValues.includes(choice.label)}
+                            onChange={(_, checked) => {
+                              if (question.choices.length === 1) {
+                                field.onChange(checked ? choice.label : false);
+                                return;
+                              }
+
+                              const nextValues = checked
+                                ? selectedValues.includes(choice.label)
+                                  ? selectedValues
+                                  : [...selectedValues, choice.label]
+                                : selectedValues.filter(
+                                    (value) => value !== choice.label
+                                  );
+                              const orderedValues = [...nextValues].sort(
+                                (left, right) =>
+                                  (choiceOrder.get(left) ?? -1) -
+                                  (choiceOrder.get(right) ?? -1)
+                              );
+
+                              field.onChange(orderedValues);
+                            }}
+                            onBlur={field.onBlur}
+                            ref={index === 0 ? field.ref : undefined}
+                            disabled={disabled}
+                          />
+                        }
+                        label={choice.label}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              );
+            }}
+          />
           {errors[questionId] && (
             <FormHelperText sx={{ color: 'error.main' }}>
               {errors[questionId].message}

--- a/src/app/(public)/forms/[formId]/_components/answerFormTypes.ts
+++ b/src/app/(public)/forms/[formId]/_components/answerFormTypes.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import type { NonEmptyArray } from '@/generic/Types';
 import type { GetQuestionsResponse } from '@/lib/api-types';
 
 /**
@@ -8,7 +7,7 @@ import type { GetQuestionsResponse } from '@/lib/api-types';
  * 質問タイプごとの違いを吸収して submit 前の共通形にしている。
  */
 export interface AnswerFormInput {
-  [key: string]: string | NonEmptyArray<string> | boolean;
+  [key: string]: string | string[] | boolean;
 }
 
 export type AnswerQuestion = GetQuestionsResponse[number];

--- a/tests/component/AnswerSubmissionForm.test.tsx
+++ b/tests/component/AnswerSubmissionForm.test.tsx
@@ -97,6 +97,63 @@ describe('AnswerSubmissionForm', () => {
     });
   });
 
+  it('複数選択の回答を成功送信後にリセットし、次の回答を選択できる', async () => {
+    const user = userEvent.setup();
+    const onSubmitAnswers = vi
+      .fn<(data: AnswerFormInput) => Promise<{ ok: boolean }>>()
+      .mockResolvedValue({ ok: true });
+
+    renderWithProviders(
+      <AnswerSubmissionForm
+        questions={questions}
+        title="お問い合わせ"
+        description=""
+        isTemporary={false}
+        onSubmitAnswers={onSubmitAnswers}
+      />
+    );
+
+    const firstChoice = screen.getByRole('checkbox', {
+      name: '運営に相談したい',
+    });
+    const secondChoice = screen.getByRole('checkbox', {
+      name: '申請内容を確認したい',
+    });
+
+    await user.click(secondChoice);
+    await user.click(firstChoice);
+    expect(firstChoice).toBeChecked();
+    expect(secondChoice).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    await waitFor(() => {
+      expect(onSubmitAnswers).toHaveBeenCalledTimes(1);
+    });
+    expect(onSubmitAnswers).toHaveBeenNthCalledWith(1, {
+      '8f98a37f-9070-4624-b161-f288769160d5': [
+        '運営に相談したい',
+        '申請内容を確認したい',
+      ],
+    });
+    expect(firstChoice).not.toBeChecked();
+    expect(
+      firstChoice.parentElement?.querySelector('[data-testid="CheckBoxIcon"]')
+    ).toBeNull();
+    expect(secondChoice).not.toBeChecked();
+
+    await user.click(secondChoice);
+    expect(secondChoice).toBeChecked();
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    await waitFor(() => {
+      expect(onSubmitAnswers).toHaveBeenCalledTimes(2);
+    });
+    expect(onSubmitAnswers).toHaveBeenNthCalledWith(2, {
+      '8f98a37f-9070-4624-b161-f288769160d5': ['申請内容を確認したい'],
+    });
+  });
+
   it('単一選択の回答を未選択へ戻せる', async () => {
     const user = userEvent.setup();
     const onSubmitAnswers = vi

--- a/tests/component/FormEditForm.test.tsx
+++ b/tests/component/FormEditForm.test.tsx
@@ -1,0 +1,125 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import FormEditForm from '@/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm';
+import type { ApiPaths } from '@/lib/api/types';
+import type { GetFormResponse } from '@/lib/api-types';
+
+import { renderWithProviders, screen, waitFor } from './render';
+
+type FormUpdateBody =
+  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
+
+const { updateFormMock } = vi.hoisted(() => ({
+  updateFormMock: vi
+    .fn<(body: FormUpdateBody) => Promise<{ ok: boolean }>>()
+    .mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('@/hooks/useFormEditActions', () => ({
+  useFormEditActions: () => ({ updateForm: updateFormMock }),
+}));
+
+const form: GetFormResponse = {
+  id: 'form-id',
+  title: 'フォームタイトル',
+  description: 'フォームの説明',
+  labels: [],
+  metadata: {
+    created_at: '2026-06-01T00:00:00+09:00',
+    updated_at: '2026-06-01T00:00:00+09:00',
+  },
+  questions: [
+    {
+      id: 'question-id',
+      title: '質問タイトル',
+      description: null,
+      question_type: 'Text',
+      is_required: true,
+      position: 0,
+      template_key: 'question_1',
+    },
+  ],
+  settings: {
+    visibility: 'PUBLIC',
+    allowed_group_ids: [],
+    allow_temporary_answers: true,
+    discord_webhook_enabled: false,
+    answer_settings: {
+      default_answer_title: null,
+      acceptance_period: {
+        start_at: null,
+        end_at: null,
+      },
+      visibility: 'PUBLIC',
+      answer_group_ids: [],
+      hide_author: true,
+    },
+  },
+};
+
+const expectCheckedIcon = (label: string) => {
+  const checkbox = screen.getByRole('checkbox', { name: label });
+
+  expect(checkbox).toBeChecked();
+  expect(
+    checkbox.parentElement?.querySelector('[data-testid="CheckBoxIcon"]')
+  ).not.toBeNull();
+};
+
+describe('FormEditForm', () => {
+  beforeEach(() => {
+    updateFormMock.mockClear();
+  });
+
+  it('取得した true の設定をチェック済みで表示する', () => {
+    renderWithProviders(
+      <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
+    );
+
+    expectCheckedIcon('未ログインユーザーの回答を許可する');
+    expectCheckedIcon('回答者を隠して公開する');
+    expectCheckedIcon('この質問への回答を必須にする');
+  });
+
+  it('Webhook 無効化のチェックで URL 入力を無効にする', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
+    );
+
+    const webhookDisabled = screen.getByRole('checkbox', {
+      name: 'Webhook 通知を無効化する(URL入力より優先されます)',
+    });
+    const webhookUrl = screen.getByRole('textbox', { name: 'Webhook URL' });
+
+    expect(webhookDisabled).not.toBeChecked();
+    expect(webhookUrl).not.toBeDisabled();
+
+    await user.click(webhookDisabled);
+
+    expect(webhookDisabled).toBeChecked();
+    expect(webhookUrl).toBeDisabled();
+  });
+
+  it('取得した Checkbox の値を保存データへ反映する', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '設定内容を保存' }));
+
+    await waitFor(() => {
+      expect(updateFormMock).toHaveBeenCalledTimes(1);
+    });
+
+    const updateFormBody = updateFormMock.mock.calls[0]?.[0];
+
+    expect(updateFormBody?.questions?.[0]?.is_required).toBe(true);
+    expect(updateFormBody?.settings?.allow_temporary_answers).toBe(true);
+    expect(updateFormBody?.settings?.answer_settings?.hide_author).toBe(true);
+  });
+});

--- a/tests/unit/formEditorMappers.test.ts
+++ b/tests/unit/formEditorMappers.test.ts
@@ -254,6 +254,19 @@ describe('form request builders', () => {
     expect(values.settings.discord_webhook_disabled).toBe(false);
   });
 
+  it('未ログイン回答の許可設定をフォーム取得レスポンスから画面内部表現へ変換する', () => {
+    const values = fromFormResponseToEditorValues(
+      createFormResponse({
+        settings: {
+          ...createFormResponse().settings,
+          allow_temporary_answers: true,
+        },
+      })
+    );
+
+    expect(values.settings.allow_temporary_answers).toBe(true);
+  });
+
   it('未知の公開設定は画面内部表現へ変換しない', () => {
     const form = createFormResponse({
       settings: {


### PR DESCRIPTION
## 概要
- React Hook Form の値を MUI Checkbox の checked 状態へ明示的に反映
- フォーム設定・質問の必須設定・複数選択回答のリセット表示を修正
- 複数選択の payload を選択肢定義順に維持し、既存の1件選択時の値形を保持

## 確認事項
- pnpm test:unit（16 files / 89 tests）
- pnpm test:component（24 files / 96 tests）
- pnpm type-check
- pnpm lint
- pnpm fmt
- pnpm build
- 編集画面の取得値表示、保存 payload、Webhook 入力の無効化、回答送信後のリセットを component test で確認

🤖 Generated with Codex