### PR TITLE
fix: prepare release workflow の CI 再トリガーを削除する

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -95,9 +95,3 @@ jobs:
             --head "$BRANCH" \
             --title "Prepare release v$VERSION" \
             --body "package.json のバージョンを v$VERSION に更新します。"
-
-      - name: Start Checking workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ steps.release.outputs.branch }}
-        run: gh workflow run ci.yaml --ref "$BRANCH"


### PR DESCRIPTION
## 概要
- `prepare-release.yaml` の「Start Checking workflow」ステップが常に失敗していた原因を調査した
- デフォルトの `GITHUB_TOKEN` は `workflow_dispatch` イベントを発火できず、`gh workflow run ci.yaml --ref "$BRANCH"` が `HTTP 403: Resource not accessible by integration` で失敗していた
- `ci.yaml` は `pull_request` トリガーを持つため、直前の「Create release pull request」ステップで PR を作成した時点で CI はすでに自動実行されている。このステップ自体が不要だったため削除した
- 参考: https://github.com/GiganticMinecraft/seichi-portal-frontend/actions/runs/30681022473/job/91317895547

## 確認事項
- 失敗した実行のログを `gh run view --log-failed` で確認し、403 エラーの発生箇所を特定した
- 同じ実行で作成された release PR (#928) の CI (`pull_request` イベント) がすでに走っていることを `gh run list` で確認した
- ローカルで `type-check` / `fmt` / `unit-test` が通ることを確認した（pre-commit / pre-push フック経由）

🤖 Generated with Claude Code