### PR TITLE
fix: リリースワークフローから GitHub Release 作成を削除する

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 concurrency:
@@ -94,10 +94,3 @@ jobs:
           tags: |
             ${{ steps.image.outputs.name }}:${{ needs.prepare.outputs.version }}
             ${{ steps.image.outputs.name }}:${{ github.sha }}
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-          TARGET: ${{ github.sha }}
-        run: gh release create "v$VERSION" --target "$TARGET" --title "v$VERSION" --generate-notes


### PR DESCRIPTION
## 概要
- リリースノートを運用していないため、`image-release.yaml` の `Create GitHub Release` ステップを削除
- ghcr へのイメージ publish には不要な処理であり、`GITHUB_TOKEN` の権限不足（`Resource not accessible by integration`）で失敗し続けていた
- 併せて `permissions.contents` を、release 作成用の `write` から checkout に必要な最小権限 `read` に変更

## 確認事項
- https://github.com/GiganticMinecraft/seichi-portal-frontend/actions/runs/30681168441/job/91318332369 で当該ステップが 403 で失敗していることを確認済み
- リポジトリの Actions デフォルト権限は `write` になっており、ワークフロー側の権限設定不足が原因ではないことを確認（org 側ポリシーの可能性はあるが、削除により切り分け不要になる）
- ローカルの type-check / fmt / unit-test は pre-commit・pre-push フックで実行され、いずれも成功

## 補足
- 今後リリースノートの運用を始める場合は、別途権限周りを解消した上でステップを復活させる必要がある

🤖 Generated with Claude Code