### PR TITLE
fix: proxy の Authorization 注入を request.headers 方式に変更

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,18 +35,22 @@ const isAnonymousAllowedApi = (request: NextRequest) => {
 
 const proxyToBackend = (request: NextRequest, token: string | null) => {
   const backendServerUrl = getBackendServerUrl();
-  const nextResponse = NextResponse.rewrite(
+
+  // Authorization はリクエストヘッダとして注入する。レスポンスヘッダ経由の
+  // 注入は undocumented な挙動依存であり、Bearer トークンがブラウザへの
+  // レスポンスにもエコーされてしまう。
+  const headers = new Headers(request.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return NextResponse.rewrite(
     `${backendServerUrl}${request.nextUrl.pathname.replace(
       '/api/proxy',
       ''
-    )}${request.nextUrl.search}`
+    )}${request.nextUrl.search}`,
+    { request: { headers } }
   );
-
-  if (token) {
-    nextResponse.headers.set('Authorization', `Bearer ${token}`);
-  }
-
-  return nextResponse;
 };
 
 const continueWithCurrentPath = (request: NextRequest) => {


### PR DESCRIPTION
> [!IMPORTANT]
> セキュリティ修正のため最優先・単独対応。OTel 導入（#932 以降）を待たない。

## 概要

`src/proxy.ts` の `proxyToBackend` は、`NextResponse.rewrite(...)` の**戻り値のレスポンスヘッダ**に `Authorization` をセットしていました。この方式は Next.js の undocumented な挙動（proxy が返したレスポンスヘッダを `req.headers` と `resHeaders` の**両方**へコピーする）に依存しており、**Bearer トークンが `/api/proxy/*` のレスポンスヘッダとしてブラウザにもエコーされる**問題がありました。

### リスク

トークンの元は **HttpOnly cookie** で管理されており本来 JS から読めませんが、レスポンスヘッダとしてエコーされることで:

- ページ内の JS がレスポンスヘッダから Bearer トークンを読み取れ、**HttpOnly による防御が実質無効化**される
- XSS 成立時に cookie を盗めなくても**セッション（トークン）窃取の経路**になる
- 経路上の**中間キャッシュ・各種ログ**にトークンが**残留**しうる

### 修正

documented な `NextResponse.rewrite(url, { request: { headers } })` 方式（`x-middleware-override-headers` 経由、リクエストヘッダのみに適用されクライアントへ漏れない）に切り替えます。

今後の OTel 導入（#932）では `traceparent` ヘッダを同じ経路で注入できます。

## 変更内容

- `proxyToBackend` を `request.headers` init 方式に変更（issue 記載の設計どおり）

## 確認

- `pnpm type-check` / `pnpm lint` / `pnpm fmt` / `pnpm test:unit` すべて通過

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)
