### PR TITLE
ci: OpenAPI 生成物の整合性チェックを追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,17 @@ jobs:
       - name: Type check
         run: pnpm run type-check
 
+  codegen-check:
+    name: OpenAPI codegen check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      # backend main の docs/openapi.json から型を再生成し、src/generated/ に
+      # 差分が出ないこと（生成物が最新であること）を検証する。
+      - name: Check generated API types are up to date
+        run: pnpm run codegen:check
+
   unit-test:
     name: Unit test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,6 @@
 
 ## 重要な規約
 
-- `src/generated/` は手動編集禁止。スキーマ変更後は `pnpm codegen` を実行する。
+- `src/generated/` は手動編集禁止。スキーマ変更後は `pnpm codegen` を実行する。整合性は CI の `pnpm codegen:check` で検証される。
 - パス alias `@/*` → `./src/*`
 - 保護ルートの認証確認はサーバ側で行う。middleware は入口判定のみ。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ API 型定義の正の情報源は [seichi-portal-backend](https://github.com/Gi
 
 - `src/generated/` は `pnpm codegen` で生成されるファイルだけを置きます。手動で編集しないでください。
 - バックエンドのスキーマが変わったら `pnpm codegen` を再実行してください。
+- 生成物が backend `main` のスキーマと一致しているかは CI の `OpenAPI codegen check` ジョブ（`pnpm codegen:check`）で自動検証されます。
 - 詳しい使い方は [README.md](./README.md) の「API 定義」を参照してください。
 
 ## 開発環境の起動

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ pnpm codegen
 OPENAPI_URL=http://localhost:9000/api-docs/openapi.json pnpm codegen
 ```
 
+### 生成物の整合性チェック
+
+`src/generated/` が backend `main` の OpenAPI スキーマと一致しているかは、CI（`OpenAPI codegen check` ジョブ）で `pnpm codegen:check` により自動検証されます。ローカルでも同じコマンドで確認できます。
+
+```sh
+pnpm codegen:check
+```
+
+backend 側でスキーマが更新されると、このチェックは生成物が再生成されるまで失敗します。その場合は `pnpm codegen` を実行して `src/generated/` の差分をコミットしてください。
+
 ## 開発環境とミドルウェア
 
 [CONTRIBUTING.md](./CONTRIBUTING.md)を参照してください。


### PR DESCRIPTION
## 概要

CI で `src/generated/` の OpenAPI 生成物が最新であることを検証します（#667）。

## 背景

issue 起票時点では `scripts/codegen.ts` が `http://localhost:9000/api-docs/openapi.json` 前提で CI 実行不可でしたが、現在は **backend `main` の `docs/openapi.json`（raw.githubusercontent.com）をデフォルト入力**とするよう変更済みです。つまり issue の検討ポイントだった「CI で利用する OpenAPI JSON の供給方法」は既に解決しており、CI にジョブを足すだけで検証できる状態でした。

## 変更内容

- CI に `codegen-check` ジョブを追加: `pnpm codegen:check`（型を再生成して `git diff --exit-code src/generated`）を実行
- 検証方法を README（「生成物の整合性チェック」節を追加）/ CONTRIBUTING / AGENTS に明記

## 挙動

- backend でスキーマが更新されたのに `src/generated/` が古い場合、CI が失敗して検出できます
- その場合の復旧手順（`pnpm codegen` を実行して差分をコミット）を README に記載しました

## 確認

- ローカルで `pnpm codegen:check` がパスすること（生成物は現時点の backend main と一致）✔
- workflow YAML の構文チェック ✔

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
