### PR TITLE
fix: backend の OpenAPI 更新（form_id 統一）に生成物とコードを追随させる

### DIFF
--- a/src/app/(protected)/(standard)/forms/[formId]/answers/page.tsx
+++ b/src/app/(protected)/(standard)/forms/[formId]/answers/page.tsx
@@ -17,18 +17,18 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
   const { formId } = await params;
   const [initialAnswers, form] = await Promise.all([
     requireBackendData(
-      serverApiClient.GET('/api/v1/forms/{id}/answers', {
+      serverApiClient.GET('/api/v1/forms/{form_id}/answers', {
         headers: authorizationHeader(session.token),
         params: {
-          path: { id: formId },
+          path: { form_id: formId },
         },
       })
     ),
     requireBackendData(
-      serverApiClient.GET('/api/v1/forms/{id}', {
+      serverApiClient.GET('/api/v1/forms/{form_id}', {
         headers: authorizationHeader(session.token),
         params: {
-          path: { id: formId },
+          path: { form_id: formId },
         },
       })
     ),

--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageContent.tsx
@@ -40,9 +40,9 @@ const AnswerDetailsPageContent = ({
   const { data: answer } = answerQuery;
 
   const formQuery = useApiQuery(
-    '/api/v1/forms/{id}',
+    '/api/v1/forms/{form_id}',
     {
-      path: { id: answer?.form_id ?? '' },
+      path: { form_id: answer?.form_id ?? '' },
     },
     { refreshInterval: 1000 }
   );

--- a/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
@@ -60,9 +60,9 @@ const AnswersPageContent = ({
     isLoadingMore,
     loadMore,
   } = useInfiniteApiQuery(
-    '/api/v1/forms/{id}/answers',
+    '/api/v1/forms/{form_id}/answers',
     (cursor) => ({
-      path: { id: form.id },
+      path: { form_id: form.id },
       query: cursor === undefined ? {} : { cursor },
     }),
     initialAnswers

--- a/src/app/(protected)/admin/forms/[formId]/answers/page.tsx
+++ b/src/app/(protected)/admin/forms/[formId]/answers/page.tsx
@@ -17,18 +17,18 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
   const { formId } = await params;
   const [initialAnswers, form] = await Promise.all([
     requireBackendData(
-      serverApiClient.GET('/api/v1/forms/{id}/answers', {
+      serverApiClient.GET('/api/v1/forms/{form_id}/answers', {
         headers: authorizationHeader(session.token),
         params: {
-          path: { id: formId },
+          path: { form_id: formId },
         },
       })
     ),
     requireBackendData(
-      serverApiClient.GET('/api/v1/forms/{id}', {
+      serverApiClient.GET('/api/v1/forms/{form_id}', {
         headers: authorizationHeader(session.token),
         params: {
-          path: { id: formId },
+          path: { form_id: formId },
         },
       })
     ),

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -17,7 +17,7 @@ import { visibilitySchema } from '../_schema/formEditorSchema';
 type CreateFormBody =
   ApiPaths['/api/v1/forms']['post']['requestBody']['content']['application/json'];
 type FormUpdateBody =
-  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}']['put']['requestBody']['content']['application/json'];
 type ApiAcceptancePeriod =
   GetFormResponse['settings']['answer_settings']['acceptance_period'];
 type ApiVisibility = GetFormResponse['settings']['visibility'];

--- a/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
+++ b/src/app/(protected)/admin/forms/create/_hooks/useCreateForm.ts
@@ -39,9 +39,9 @@ export const useCreateForm = () => {
       const createdFormId = createdForm.id;
 
       const { response: setFormMetadataResponse } = await proxyClient.PUT(
-        '/api/v1/forms/{id}',
+        '/api/v1/forms/{form_id}',
         {
-          params: { path: { id: createdFormId } },
+          params: { path: { form_id: createdFormId } },
           body: toFormUpdateBody(data, false),
         }
       );

--- a/src/app/(protected)/admin/forms/edit/[id]/page.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/page.tsx
@@ -18,10 +18,10 @@ const Home = async ({ params }: { params: Promise<{ id: number }> }) => {
   const { id } = await params;
   const [form, labels, groups] = await Promise.all([
     requireBackendData(
-      serverApiClient.GET('/api/v1/forms/{id}', {
+      serverApiClient.GET('/api/v1/forms/{form_id}', {
         headers: authorizationHeader(session.token),
         params: {
-          path: { id: String(id) },
+          path: { form_id: String(id) },
         },
       })
     ),

--- a/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
+++ b/src/app/(public)/forms/[formId]/_components/useAnswerSubmission.ts
@@ -13,9 +13,9 @@ import { isTemporaryUserField, TEMPORARY_USER_FIELDS } from './answerFormTypes';
 import type { AnswerFormInput } from './answerFormTypes';
 
 type AnswerCreateBody =
-  ApiPaths['/api/v1/forms/{id}/answers']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}/answers']['post']['requestBody']['content']['application/json'];
 type TemporaryAnswerCreateBody =
-  ApiPaths['/api/v1/forms/{id}/temporary-answers']['post']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}/temporary-answers']['post']['requestBody']['content']['application/json'];
 type AnswerContents = AnswerCreateBody['contents'];
 
 export type SubmissionState =
@@ -85,10 +85,10 @@ export const useAnswerSubmission = (
   });
 
   const postAnswers = (data: AnswerFormInput) => {
-    const params = { path: { id: formId } };
+    const params = { path: { form_id: formId } };
 
     if (isTemporary) {
-      return proxyClient.POST('/api/v1/forms/{id}/temporary-answers', {
+      return proxyClient.POST('/api/v1/forms/{form_id}/temporary-answers', {
         params,
         body: {
           contents: toAnswerContents(data),
@@ -97,7 +97,7 @@ export const useAnswerSubmission = (
       });
     }
 
-    return proxyClient.POST('/api/v1/forms/{id}/answers', {
+    return proxyClient.POST('/api/v1/forms/{form_id}/answers', {
       params,
       body: { contents: toAnswerContents(data) },
     });

--- a/src/app/(public)/forms/[formId]/page.tsx
+++ b/src/app/(public)/forms/[formId]/page.tsx
@@ -47,12 +47,12 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
 
   // ログイン時は認証ヘッダ付き、未ログイン時は匿名でフォームを取得する。
   const form = await requireBackendData(
-    serverApiClient.GET('/api/v1/forms/{id}', {
+    serverApiClient.GET('/api/v1/forms/{form_id}', {
       ...(isAuthenticated
         ? { headers: authorizationHeader(session.token) }
         : {}),
       params: {
-        path: { id: formId },
+        path: { form_id: formId },
       },
     })
   );

--- a/src/generated/api-types.ts
+++ b/src/generated/api-types.ts
@@ -21,7 +21,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/archived-forms/{id}": {
+    "/api/v1/archived-forms/{form_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -38,7 +38,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/archived-forms/{id}/restore": {
+    "/api/v1/archived-forms/{form_id}/restore": {
         parameters: {
             query?: never;
             header?: never;
@@ -100,6 +100,45 @@ export interface paths {
         get?: never;
         put: operations["replace_answer_labels"];
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/forms/{form_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** フォームの取得 */
+        get: operations["get_form_handler"];
+        /**
+         * フォームの更新
+         * @description questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。
+         */
+        put: operations["update_form_handler"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/forms/{form_id}/answers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 回答の一覧取得 */
+        get: operations["get_answer_by_form_id_handler"];
+        put?: never;
+        /** 回答の作成 */
+        post: operations["post_answer_handler"];
         delete?: never;
         options?: never;
         head?: never;
@@ -265,46 +304,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/forms/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** フォームの取得 */
-        get: operations["get_form_handler"];
-        /**
-         * フォームの更新
-         * @description questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。
-         */
-        put: operations["update_form_handler"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/forms/{id}/answers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** 回答の一覧取得 */
-        get: operations["get_answer_by_form_id_handler"];
-        put?: never;
-        /** 回答の作成 */
-        post: operations["post_answer_handler"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/forms/{id}/archive": {
+    "/api/v1/forms/{form_id}/archive": {
         parameters: {
             query?: never;
             header?: never;
@@ -321,7 +321,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/forms/{id}/temporary-answers": {
+    "/api/v1/forms/{form_id}/temporary-answers": {
         parameters: {
             query?: never;
             header?: never;
@@ -1268,7 +1268,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Form ID */
-                id: string;
+                form_id: string;
             };
             cookie?: never;
         };
@@ -1336,7 +1336,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Form ID */
-                id: string;
+                form_id: string;
             };
             cookie?: never;
         };
@@ -1639,6 +1639,316 @@ export interface operations {
             };
             /** @description The server cannot find the requested resource. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_form_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                form_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FormSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    update_form_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                form_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FormUpdateSchema"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FormSchema"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Client error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_answer_by_form_id_handler: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of answers to return */
+                limit?: number;
+                /** @description Cursor returned by the previous page */
+                cursor?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Form ID */
+                form_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnswerListPageResponse"];
+                };
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Client error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    post_answer_handler: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Form ID */
+                form_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnswerCreateSchema"];
+            };
+        };
+        responses: {
+            /** @description The request has succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The server could not understand the request due to invalid syntax. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is unauthorized. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Access is forbidden. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The server cannot find the requested resource. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Client error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2837,323 +3147,13 @@ export interface operations {
             };
         };
     };
-    get_form_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FormSchema"];
-                };
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    update_form_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FormUpdateSchema"];
-            };
-        };
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FormSchema"];
-                };
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Client error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    get_answer_by_form_id_handler: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of answers to return */
-                limit?: number;
-                /** @description Cursor returned by the previous page */
-                cursor?: string;
-            };
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AnswerListPageResponse"];
-                };
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Client error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    post_answer_handler: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Form ID */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AnswerCreateSchema"];
-            };
-        };
-        responses: {
-            /** @description The request has succeeded. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description The server could not understand the request due to invalid syntax. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is unauthorized. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Access is forbidden. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description The server cannot find the requested resource. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Client error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
     archive_form_handler: {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 /** @description Form ID */
-                id: string;
+                form_id: string;
             };
             cookie?: never;
         };
@@ -3219,7 +3219,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Form ID */
-                id: string;
+                form_id: string;
             };
             cookie?: never;
         };

--- a/src/hooks/useFormActions.ts
+++ b/src/hooks/useFormActions.ts
@@ -7,9 +7,9 @@ import { proxyClient } from '@/lib/proxyClient';
 export const useFormActions = () => {
   const archiveForm = async (formId: string): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.POST(
-      '/api/v1/forms/{id}/archive',
+      '/api/v1/forms/{form_id}/archive',
       {
-        params: { path: { id: formId } },
+        params: { path: { form_id: formId } },
       }
     );
     const result = handleMutationResponse(response, data, error);
@@ -18,9 +18,9 @@ export const useFormActions = () => {
 
   const restoreForm = async (formId: string): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.POST(
-      '/api/v1/archived-forms/{id}/restore',
+      '/api/v1/archived-forms/{form_id}/restore',
       {
-        params: { path: { id: formId } },
+        params: { path: { form_id: formId } },
       }
     );
     const result = handleMutationResponse(response, data, error);

--- a/src/hooks/useFormEditActions.ts
+++ b/src/hooks/useFormEditActions.ts
@@ -6,14 +6,14 @@ import type { ApiPaths } from '@/lib/api/types';
 import { proxyClient } from '@/lib/proxyClient';
 
 type FormUpdateBody =
-  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}']['put']['requestBody']['content']['application/json'];
 
 export const useFormEditActions = (formId: string) => {
   const updateForm = async (body: FormUpdateBody): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.PUT(
-      '/api/v1/forms/{id}',
+      '/api/v1/forms/{form_id}',
       {
-        params: { path: { id: formId } },
+        params: { path: { form_id: formId } },
         body,
       }
     );

--- a/src/hooks/useFormLabelActions.ts
+++ b/src/hooks/useFormLabelActions.ts
@@ -7,9 +7,9 @@ import { proxyClient } from '@/lib/proxyClient';
 export const useFormLabelActions = (formId: string) => {
   const updateLabels = async (labelIds: string[]): Promise<{ ok: boolean }> => {
     const { data, error, response } = await proxyClient.PUT(
-      '/api/v1/forms/{id}',
+      '/api/v1/forms/{form_id}',
       {
-        params: { path: { id: formId } },
+        params: { path: { form_id: formId } },
         body: { labels: labelIds },
       }
     );

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -16,11 +16,11 @@ export type GetFormsPageResponse =
   ApiPaths['/api/v1/forms']['get']['responses'][200]['content']['application/json'];
 export type GetFormsResponse = GetFormsPageResponse['items'];
 export type GetFormResponse =
-  ApiPaths['/api/v1/forms/{id}']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}']['get']['responses'][200]['content']['application/json'];
 export type CreateFormResponse =
   ApiPaths['/api/v1/forms']['post']['responses'][201]['content']['application/json'];
 export type GetFormAnswersPageResponse =
-  ApiPaths['/api/v1/forms/{id}/answers']['get']['responses'][200]['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}/answers']['get']['responses'][200]['content']['application/json'];
 export type GetFormAnswersResponse = GetFormAnswersPageResponse['items'];
 export type GetAnswersPageResponse =
   ApiPaths['/api/v1/forms/answers']['get']['responses'][200]['content']['application/json'];

--- a/tests/component/FormEditForm.test.tsx
+++ b/tests/component/FormEditForm.test.tsx
@@ -8,7 +8,7 @@ import type { GetFormResponse } from '@/lib/api-types';
 import { renderWithProviders, screen, waitFor } from './render';
 
 type FormUpdateBody =
-  ApiPaths['/api/v1/forms/{id}']['put']['requestBody']['content']['application/json'];
+  ApiPaths['/api/v1/forms/{form_id}']['put']['requestBody']['content']['application/json'];
 
 const { updateFormMock } = vi.hoisted(() => ({
   updateFormMock: vi


### PR DESCRIPTION
## 概要

backend [#1264](https://github.com/GiganticMinecraft/seichi-portal-backend/pull/1264) で OpenAPI のフォーム ID パスパラメータが `{id}` → `{form_id}` に統一されました。#938 で導入した CI の `OpenAPI codegen check` がこの schema drift を検出し、全 PR で失敗する状態になっています（チェックの設計どおりの動作です）。

## 変更内容

- `pnpm codegen` で `src/generated/api-types.ts` を再生成
- 利用側 14 ファイルの path リテラル（`/api/v1/forms/{id}` 系 → `{form_id}` 系）と path params（`path: { id: ... }` → `path: { form_id: ... }`）を機械的に追随

URL 構造は不変のためリクエスト互換性への影響はありません（backend PR 記載どおり）。

## 確認

- `pnpm type-check`（38 件のエラーがすべて解消）/ `pnpm lint` / `pnpm fmt` ✔
- `pnpm test:unit` / `pnpm test:component` ✔
- `pnpm build` ✔

マージ後、open 中の PR（#939 / #940）の `OpenAPI codegen check` は base との merge ref で解消されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)