### PR TITLE
fix: ログイン失敗時にバックエンド通信エラーとアカウント未紐づけを区別する

### DIFF
--- a/src/app/(public)/_components/useLandingLogin.ts
+++ b/src/app/(public)/_components/useLandingLogin.ts
@@ -14,6 +14,8 @@ import { normalizeRedirectTarget } from '@/lib/redirect';
 
 const LOGIN_ERROR_MESSAGE =
   'ログインに失敗しました。Minecraftアカウントに紐づいたMicrosoftアカウントでサインインしてください。';
+const BACKEND_UNREACHABLE_ERROR_MESSAGE =
+  'サーバーとの通信に失敗しました。しばらく時間を置いて再試行してください。';
 const RETRY_ERROR_MESSAGE =
   'ログインに失敗しました。時間を置いて再試行してください。';
 const LOGIN_PROCESSING_ERROR_MESSAGE = 'ログイン処理に失敗しました。';
@@ -45,14 +47,29 @@ const fetchPostLoginRedirect = async (): Promise<string> => {
   return '/';
 };
 
-const exchangeMinecraftAccessToken = async (accessToken: string) => {
+type LoginFailureReason = 'invalid_account' | 'backend_unreachable';
+
+const exchangeMinecraftAccessToken = async (
+  accessToken: string
+): Promise<{ ok: true } | { ok: false; reason: LoginFailureReason }> => {
   const response = await fetch('/api/minecraft-access-token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ token: accessToken }),
   });
 
-  return response.ok;
+  if (response.ok) return { ok: true };
+
+  const body: unknown = await response.json().catch(() => null);
+  const reason: LoginFailureReason =
+    typeof body === 'object' &&
+    body !== null &&
+    'code' in body &&
+    body.code === 'backend_unreachable'
+      ? 'backend_unreachable'
+      : 'invalid_account';
+
+  return { ok: false, reason };
 };
 
 type CompleteLoginParams = {
@@ -61,7 +78,8 @@ type CompleteLoginParams = {
   router: ReturnType<typeof useRouter>;
 };
 
-type CompleteLoginResult = { success: true } | { success: false };
+type CompleteLoginResult =
+  { success: true } | { success: false; reason: LoginFailureReason };
 
 const completeLogin = async ({
   account,
@@ -74,12 +92,12 @@ const completeLogin = async ({
   };
 
   const tokenResponse = await instance.acquireTokenSilent(request);
-  const isLinkedMinecraftAccount = await exchangeMinecraftAccessToken(
+  const exchangeResult = await exchangeMinecraftAccessToken(
     tokenResponse.accessToken
   );
 
-  if (!isLinkedMinecraftAccount) {
-    return { success: false };
+  if (!exchangeResult.ok) {
+    return { success: false, reason: exchangeResult.reason };
   }
 
   router.push(await fetchPostLoginRedirect());
@@ -120,7 +138,11 @@ export const useLandingLogin = () => {
       try {
         const result = await completeLogin({ account, instance, router });
         if (!result.success) {
-          setProcessingErrorMessage(LOGIN_ERROR_MESSAGE);
+          setProcessingErrorMessage(
+            result.reason === 'backend_unreachable'
+              ? BACKEND_UNREACHABLE_ERROR_MESSAGE
+              : LOGIN_ERROR_MESSAGE
+          );
           setIsProcessing(false);
         }
       } catch (error) {

--- a/src/app/api/minecraft-access-token/route.ts
+++ b/src/app/api/minecraft-access-token/route.ts
@@ -6,7 +6,12 @@ import {
   minecraftAccessTokenResponseSchema,
   xboxLiveServiceTokenResponseSchema,
 } from '@/_schemas/loginSchema';
-import { authorizationHeader, serverApiClient } from '@/lib/server/backend';
+import {
+  authorizationHeader,
+  BackendError,
+  requireBackendResponse,
+  serverApiClient,
+} from '@/lib/server/backend';
 
 const microsoftAccountTokenSchema = z.object({
   token: z.string().min(1),
@@ -43,25 +48,19 @@ export async function POST(req: NextRequest) {
       xboxServiceSecurityToken
     );
 
-    const sessionResult = await createSession(minecraftAccessTokenResult);
-    if (!sessionResult.ok) {
-      console.error(
-        'Failed to create backend session:',
-        sessionResult.status,
-        sessionResult.statusText
-      );
-      return NextResponse.json(
-        { error: 'Failed to create backend session' },
-        { status: 502 }
-      );
-    }
-
+    const sessionResponse = await createSession(minecraftAccessTokenResult);
     const nextResponse = NextResponse.json({});
-    const setCookieHeader = sessionResult.headers.get('Set-Cookie');
+    const setCookieHeader = sessionResponse.headers.get('Set-Cookie');
 
     if (setCookieHeader === null) {
+      console.error(
+        'Backend session response did not include a Set-Cookie header'
+      );
       return NextResponse.json(
-        { error: 'Backend session cookie was not returned' },
+        {
+          error: 'Backend session cookie was not returned',
+          code: 'backend_unreachable',
+        },
         { status: 502 }
       );
     }
@@ -70,15 +69,39 @@ export async function POST(req: NextRequest) {
     return nextResponse;
   } catch (error) {
     console.error('Minecraft login flow failed:', error);
+
+    if (error instanceof BackendError) {
+      const isBackendSideFailure =
+        error.code === 'network_error' || error.status >= 500;
+
+      if (isBackendSideFailure) {
+        return NextResponse.json(
+          {
+            error: 'Failed to communicate with backend service',
+            code: 'backend_unreachable',
+          },
+          { status: 503 }
+        );
+      }
+
+      return NextResponse.json(
+        { error: 'Failed to create backend session', code: 'invalid_account' },
+        { status: 502 }
+      );
+    }
+
     if (error instanceof UpstreamServiceError || error instanceof z.ZodError) {
       return NextResponse.json(
-        { error: 'Failed during upstream authentication' },
+        {
+          error: 'Failed during upstream authentication',
+          code: 'invalid_account',
+        },
         { status: 502 }
       );
     }
 
     return NextResponse.json(
-      { error: 'Unexpected error during login' },
+      { error: 'Unexpected error during login', code: 'backend_unreachable' },
       { status: 500 }
     );
   }
@@ -183,14 +206,16 @@ const createSession = async ({
   token,
   expires,
 }: Awaited<ReturnType<typeof acquireMinecraftAccessToken>>) => {
-  const { response } = await serverApiClient.POST('/api/v1/session', {
-    headers: {
-      ...authorizationHeader(token),
-    },
-    body: {
-      expires: expires,
-    },
-  });
+  const { response } = await requireBackendResponse(
+    serverApiClient.POST('/api/v1/session', {
+      headers: {
+        ...authorizationHeader(token),
+      },
+      body: {
+        expires: expires,
+      },
+    })
+  );
 
   return response;
 };


### PR DESCRIPTION
## 概要
- バックエンドが未起動/通信不能の場合でも、実際は無関係な「Minecraftアカウントに紐づいたMicrosoftアカウントでサインインしてください」という文言が表示されており、原因の切り分けができなかった。
- `src/app/api/minecraft-access-token/route.ts` で、セッション作成 (`/api/v1/session`) の失敗を `BackendError` の種類(`network_error`/HTTPステータス)で判別し、バックエンド疎通失敗時は `code: 'backend_unreachable'`（503）、アカウント未紐づけ等のクライアントエラー時は `code: 'invalid_account'`（502）を返すようにした。
- `src/app/(public)/_components/useLandingLogin.ts` は返却された `code` を見て、バックエンド疎通失敗時のみ新設の「サーバーとの通信に失敗しました。しばらく時間を置いて再試行してください。」を表示し、それ以外は既存のアカウント紐づけ案内文言を表示するようにした。

## 確認事項
- `tsc --noEmit`、`eslint`、`prettier --check` を実行し、変更箇所にエラーがないことを確認（pre-commit フックでも成功）。
- `vitest run`（89件）が全て成功することを確認（pre-push フックで実行）。
- 実機でバックエンドを停止した状態でログインを試み、`POST /api/minecraft-access-token` が `503`（`code: 'backend_unreachable'`）を返すことをログで確認。

## 補足
- 動作確認中に、MSAL のリダイレクトログイン完了直後に発生する hydration mismatch warning（`disabled` 属性のSSR/クライアント不一致）を確認したが、本PRの変更箇所とは無関係の既存事象であり、今回は対応していない。

🤖 Generated with Claude Code