### PR TITLE
fix: 画面表示の「ログイン」表記を「サインイン」に統一する

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerDetailsPageView.tsx
@@ -56,7 +56,7 @@ const AnswerDetailsPageView = ({
   const canAccessMessages = data.isAdmin || isAuthor;
   const messagesDisabled = !isAuthenticatedAuthor || !canAccessMessages;
   const messagesDisabledReason = !isAuthenticatedAuthor
-    ? '未ログインユーザーの回答のため、メッセージを送信できません'
+    ? '未サインインユーザーの回答のため、メッセージを送信できません'
     : 'この回答の管理者または投稿者本人のみメッセージを閲覧できます';
 
   return (

--- a/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
@@ -19,7 +19,7 @@ const AuthorName = ({ author }: { author: Author }) => {
         sx={{ alignItems: 'center', flexWrap: 'wrap' }}
       >
         <Typography>{author.temporary_user.name}</Typography>
-        <Chip label="未ログイン" size="small" color="default" />
+        <Chip label="未サインイン" size="small" color="default" />
         <Typography variant="caption" color="textSecondary">
           連絡先:{' '}
           <Box component="span" sx={{ color: 'text.primary' }}>

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -256,7 +256,7 @@ const AnswerSettings = ({
         groupOptions={groupOptions}
       />
       <FormControlLabel
-        label="未ログインユーザーの回答を許可する"
+        label="未サインインユーザーの回答を許可する"
         control={
           <Checkbox
             checked={allowTemporaryAnswers}

--- a/src/app/(public)/_components/useLandingLogin.ts
+++ b/src/app/(public)/_components/useLandingLogin.ts
@@ -13,12 +13,12 @@ import { useRedirectLogin } from '@/app/_components/useRedirectLogin';
 import { normalizeRedirectTarget } from '@/lib/redirect';
 
 const LOGIN_ERROR_MESSAGE =
-  'ログインに失敗しました。Minecraftアカウントに紐づいたMicrosoftアカウントでサインインしてください。';
+  'サインインに失敗しました。Minecraftアカウントに紐づいたMicrosoftアカウントでサインインしてください。';
 const BACKEND_UNREACHABLE_ERROR_MESSAGE =
   'サーバーとの通信に失敗しました。しばらく時間を置いて再試行してください。';
 const RETRY_ERROR_MESSAGE =
-  'ログインに失敗しました。時間を置いて再試行してください。';
-const LOGIN_PROCESSING_ERROR_MESSAGE = 'ログイン処理に失敗しました。';
+  'サインインに失敗しました。時間を置いて再試行してください。';
+const LOGIN_PROCESSING_ERROR_MESSAGE = 'サインイン処理に失敗しました。';
 const LOGIN_REDIRECT_ERROR_MESSAGE = 'サインイン画面への遷移に失敗しました。';
 const loginRequest = {
   scopes: ['XboxLive.signin offline_access'],

--- a/tests/component/FormEditForm.test.tsx
+++ b/tests/component/FormEditForm.test.tsx
@@ -77,7 +77,7 @@ describe('FormEditForm', () => {
       <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
     );
 
-    expectCheckedIcon('未ログインユーザーの回答を許可する');
+    expectCheckedIcon('未サインインユーザーの回答を許可する');
     expectCheckedIcon('回答者を隠して公開する');
     expectCheckedIcon('この質問への回答を必須にする');
   });


### PR DESCRIPTION
## 概要
- MSアカウントによる認証を採用しているため、画面上の表記が「ログイン」「ログアウト」「サインイン」「サインアウト」に揺れていた問題を修正 (#945)
- ユーザーに表示される文言をMicrosoftの用語である「サインイン」「サインアウト」に統一
  - `useLandingLogin.ts` のログイン失敗系メッセージ（サインインに失敗しました 等）
  - 回答詳細画面の未サインインユーザー表示（Chip・メッセージ送信不可の理由文）
  - フォーム編集画面の「未サインインユーザーの回答を許可する」チェックボックスラベル
- 変数名・関数名（`handleLogin` 等）や内部コメントは対象外とし、ユーザーが実際に目にする文言のみを変更

## 確認事項
- `pnpm test:unit` / `pnpm test:component` を実行し、変更した文言に依存するテスト（`FormEditForm.test.tsx` の表示テキスト）を更新の上、全件成功を確認
- `pnpm tsc --noEmit` と `pnpm lint` でエラーがないことを確認
- コミット時・push 時の lefthook（lint / type-check / fmt / unit-test）もすべて成功

🤖 Generated with Claude Code