### PR TITLE
fix: Discord OAuth のリダイレクト先を公開 origin に固定

### DIFF
--- a/src/app/api/discord/route.ts
+++ b/src/app/api/discord/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-import { getDiscordConfig } from '@/env.server';
+import { getDiscordConfig, getMsalOrigin } from '@/env.server';
 import {
   getPostLoginRedirectFromRequest,
   setPostLoginRedirectCookie,
@@ -36,10 +36,11 @@ const clearDiscordOauthStateCookie = (response: NextResponse) => {
 
 export async function GET(req: NextRequest) {
   const { clientId, clientSecret, redirectUri } = getDiscordConfig();
+  const msalOrigin = getMsalOrigin();
   const seichiPortalToken = await getCachedToken(req.cookies);
 
   if (!seichiPortalToken) {
-    const response = NextResponse.redirect(`${req.nextUrl.origin}/login`);
+    const response = NextResponse.redirect(`${msalOrigin}/login`);
     setPostLoginRedirectCookie(response, getPostLoginRedirectFromRequest(req));
     return response;
   }
@@ -66,7 +67,7 @@ export async function GET(req: NextRequest) {
 
   const storedState = req.cookies.get(DISCORD_OAUTH_STATE_COOKIE)?.value;
   if (!state || !storedState || state !== storedState) {
-    const response = NextResponse.redirect(`${req.nextUrl.origin}/badrequest`);
+    const response = NextResponse.redirect(`${msalOrigin}/badrequest`);
     clearDiscordOauthStateCookie(response);
     return response;
   }
@@ -131,7 +132,7 @@ export async function GET(req: NextRequest) {
       return response;
     }
 
-    const response = NextResponse.redirect(`${req.nextUrl.origin}/`);
+    const response = NextResponse.redirect(`${msalOrigin}/`);
     clearDiscordOauthStateCookie(response);
     return response;
   } catch (error) {

--- a/src/env.server.ts
+++ b/src/env.server.ts
@@ -33,13 +33,28 @@ export const getOtelSdkDisabled = () =>
   otelSdkDisabledSchema.parse(process.env['OTEL_SDK_DISABLED'] || undefined) ===
   'true';
 
+const msalRedirectUrlSchema = z.url().refine(
+  (value) => {
+    const protocol = new URL(value).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  },
+  { message: 'MS_APP_REDIRECT_URL must use http or https' }
+);
+
+const getMsalRedirectUrl = () =>
+  msalRedirectUrlSchema.parse(process.env['MS_APP_REDIRECT_URL']);
+
+const getOrigin = (url: string) => new URL(url).origin;
+
 const msalConfigSchema = z.object({
   clientId: z.string().min(1),
-  redirectUri: z.url(),
+  redirectUri: msalRedirectUrlSchema,
 });
 
 export const getMsalConfig = () =>
   msalConfigSchema.parse({
     clientId: process.env['MS_APP_CLIENT_ID'],
-    redirectUri: process.env['MS_APP_REDIRECT_URL'],
+    redirectUri: getMsalRedirectUrl(),
   });
+
+export const getMsalOrigin = () => getOrigin(getMsalRedirectUrl());

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import {
   setPostLoginRedirectCookie,
 } from '@/lib/postLoginRedirect';
 
-import { getBackendServerUrl } from './env.server';
+import { getBackendServerUrl, getMsalOrigin } from './env.server';
 import { getCachedToken } from './user-token/mcToken';
 
 // 未ログインでも到達してよい公開ページ。回答ページ /forms/{id} のみ
@@ -78,7 +78,7 @@ const continueWithCurrentPath = (request: NextRequest) => {
 };
 
 const redirectToLogin = (request: NextRequest) => {
-  const response = NextResponse.redirect(`${request.nextUrl.origin}/`);
+  const response = NextResponse.redirect(`${getMsalOrigin()}/`);
   setPostLoginRedirectCookie(
     response,
     getPostLoginRedirectFromRequest(request)

--- a/tests/unit/discordRoute.test.ts
+++ b/tests/unit/discordRoute.test.ts
@@ -1,0 +1,169 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getDiscordConfigMock, getCachedTokenMock, linkDiscordMock } =
+  vi.hoisted(() => ({
+    getDiscordConfigMock: vi.fn(),
+    getCachedTokenMock: vi.fn(),
+    linkDiscordMock: vi.fn(),
+  }));
+
+vi.mock('@/env.server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/env.server')>()),
+  getDiscordConfig: getDiscordConfigMock,
+}));
+
+vi.mock('@/user-token/mcToken', () => ({
+  getCachedToken: getCachedTokenMock,
+}));
+
+vi.mock('@/lib/server/backend', () => ({
+  authorizationHeader: (token: string) => ({
+    Authorization: `Bearer ${token}`,
+  }),
+  serverApiClient: {
+    POST: linkDiscordMock,
+  },
+}));
+
+import { GET } from '@/app/api/discord/route';
+
+const DISCORD_OAUTH_STATE_COOKIE = 'SEICHI_PORTAL__DISCORD_OAUTH_STATE';
+const discordRedirectUri = 'https://portal.seichi.click/api/discord';
+const originalRedirectUrl = process.env['MS_APP_REDIRECT_URL'];
+
+const request = (url: string, cookie?: string) => {
+  if (cookie === undefined) return new NextRequest(url);
+
+  return new NextRequest(url, { headers: { cookie } });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env['MS_APP_REDIRECT_URL'] = 'https://portal.seichi.click';
+  getDiscordConfigMock.mockReturnValue({
+    clientId: 'discord-client-id',
+    clientSecret: 'discord-client-secret',
+    redirectUri: discordRedirectUri,
+  });
+});
+
+afterEach(() => {
+  if (originalRedirectUrl === undefined) {
+    delete process.env['MS_APP_REDIRECT_URL'];
+  } else {
+    process.env['MS_APP_REDIRECT_URL'] = originalRedirectUrl;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('Discord OAuth route', () => {
+  it('未ログイン時は設定済み origin の login へ遷移し、復帰先 cookie を設定する', async () => {
+    getCachedTokenMock.mockResolvedValue(null);
+
+    const response = await GET(
+      request('http://0.0.0.0:3000/api/discord?from=internal')
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://portal.seichi.click/login'
+    );
+    expect(response.headers.get('set-cookie')).toContain(
+      'SEICHI_PORTAL__POST_LOGIN_REDIRECT='
+    );
+  });
+
+  it('認証済みで code がない場合は raw の Discord redirect URI を authorize URL に渡す', async () => {
+    getCachedTokenMock.mockResolvedValue('seichi-token');
+
+    const response = await GET(request('http://0.0.0.0:3000/api/discord'));
+    const location = new URL(response.headers.get('location') ?? '');
+
+    expect(location.origin).toBe('https://discord.com');
+    expect(location.pathname).toBe('/oauth2/authorize');
+    expect(location.searchParams.get('redirect_uri')).toBe(discordRedirectUri);
+    expect(location.searchParams.get('client_id')).toBe('discord-client-id');
+    expect(response.headers.get('set-cookie')).toContain(
+      `${DISCORD_OAUTH_STATE_COOKIE}=`
+    );
+  });
+
+  it('state が不正な場合は設定済み origin の badrequest へ遷移し、state cookie を削除する', async () => {
+    getCachedTokenMock.mockResolvedValue('seichi-token');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await GET(
+      request(
+        'http://0.0.0.0:3000/api/discord?code=code&state=request-state',
+        `${DISCORD_OAUTH_STATE_COOKIE}=stored-state`
+      )
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://portal.seichi.click/badrequest'
+    );
+    expect(response.headers.get('set-cookie')).toContain(
+      `${DISCORD_OAUTH_STATE_COOKIE}=;`
+    );
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(linkDiscordMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['http://localhost:3000', 'http://localhost:3000/'],
+    ['https://portal.seichi.click', 'https://portal.seichi.click/'],
+  ])(
+    'MS_APP_REDIRECT_URL=%s の連携成功後は %s へ遷移し、token body と link payload を維持する',
+    async (redirectUrl, expectedLocation) => {
+      process.env['MS_APP_REDIRECT_URL'] = redirectUrl;
+      getCachedTokenMock.mockResolvedValue('seichi-token');
+      linkDiscordMock.mockResolvedValue({
+        response: new Response(null, { status: 204 }),
+      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({ access_token: 'discord-access-token' }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        )
+      );
+
+      const response = await GET(
+        request(
+          'http://0.0.0.0:3000/api/discord?code=code&state=stored-state',
+          `${DISCORD_OAUTH_STATE_COOKIE}=stored-state`
+        )
+      );
+
+      expect(response.headers.get('location')).toBe(expectedLocation);
+      expect(response.headers.get('set-cookie')).toContain(
+        `${DISCORD_OAUTH_STATE_COOKIE}=;`
+      );
+      expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+
+      const fetchMock = vi.mocked(fetch);
+      const [, fetchInit] = fetchMock.mock.calls[0] ?? [];
+      expect(fetchInit).toMatchObject({
+        method: 'POST',
+        body: new URLSearchParams({
+          client_id: 'discord-client-id',
+          client_secret: 'discord-client-secret',
+          code: 'code',
+          grant_type: 'authorization_code',
+          redirect_uri: discordRedirectUri,
+        }).toString(),
+      });
+      expect(linkDiscordMock).toHaveBeenCalledWith('/api/v1/link-discord', {
+        headers: { Authorization: 'Bearer seichi-token' },
+        body: { token: 'discord-access-token' },
+      });
+    }
+  );
+});

--- a/tests/unit/msalOrigin.test.ts
+++ b/tests/unit/msalOrigin.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getMsalConfig, getMsalOrigin } from '@/env.server';
+
+const originalRedirectUrl = process.env['MS_APP_REDIRECT_URL'];
+const originalClientId = process.env['MS_APP_CLIENT_ID'];
+
+afterEach(() => {
+  if (originalRedirectUrl === undefined) {
+    delete process.env['MS_APP_REDIRECT_URL'];
+  } else {
+    process.env['MS_APP_REDIRECT_URL'] = originalRedirectUrl;
+  }
+
+  if (originalClientId === undefined) {
+    delete process.env['MS_APP_CLIENT_ID'];
+  } else {
+    process.env['MS_APP_CLIENT_ID'] = originalClientId;
+  }
+});
+
+describe('getMsalOrigin', () => {
+  it.each([
+    ['http://localhost:3000', 'http://localhost:3000'],
+    ['https://portal.seichi.click/', 'https://portal.seichi.click'],
+  ])('redirect URI %s から %s だけを返す', (redirectUrl, expectedOrigin) => {
+    process.env['MS_APP_REDIRECT_URL'] = redirectUrl;
+
+    expect(getMsalOrigin()).toBe(expectedOrigin);
+  });
+
+  it.each([
+    ['未設定', undefined],
+    ['URL でない値', 'not-a-url'],
+    ['http/https 以外の URL', 'ftp://portal.seichi.click/callback'],
+  ])('%s の場合は Zod parse に失敗する', (_case, value) => {
+    if (value === undefined) {
+      delete process.env['MS_APP_REDIRECT_URL'];
+    } else {
+      process.env['MS_APP_REDIRECT_URL'] = value;
+    }
+
+    expect(() => getMsalOrigin()).toThrow();
+  });
+});
+
+describe('getMsalConfig', () => {
+  it('MSAL 用には redirect URI の raw value を返す', () => {
+    process.env['MS_APP_CLIENT_ID'] = 'client-id';
+    process.env['MS_APP_REDIRECT_URL'] =
+      'https://portal.seichi.click/signin-oidc/';
+
+    expect(getMsalConfig()).toEqual({
+      clientId: 'client-id',
+      redirectUri: 'https://portal.seichi.click/signin-oidc/',
+    });
+  });
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getMsalOriginMock, getCachedTokenMock } = vi.hoisted(() => ({
+  getMsalOriginMock: vi.fn(),
+  getCachedTokenMock: vi.fn(),
+}));
+
+vi.mock('@/env.server', () => ({
+  getBackendServerUrl: vi.fn(),
+  getMsalOrigin: getMsalOriginMock,
+}));
+
+vi.mock('@/user-token/mcToken', () => ({
+  getCachedToken: getCachedTokenMock,
+}));
+
+import { proxy } from '@/proxy';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMsalOriginMock.mockReturnValue('https://portal.seichi.click');
+  getCachedTokenMock.mockResolvedValue(null);
+});
+
+describe('proxy login redirect', () => {
+  it('未ログイン時は request origin ではなく設定済み origin へ遷移する', async () => {
+    const response = await proxy(
+      new NextRequest('http://0.0.0.0:3000/admin/users')
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://portal.seichi.click/'
+    );
+  });
+});


### PR DESCRIPTION
## 概要
- reverse proxy 内部の `req.nextUrl.origin` ではなく、既存の `MS_APP_REDIRECT_URL` から抽出した origin へリダイレクトするよう変更
- Discord route の login / badrequest / 成功後と proxy の未ログイン redirect を設定由来に統一
- `DISCORD_REDIRECT_URI` は authorize と token exchange の callback URL として維持し、Host 非依存・state/cookie・連携処理の回帰テストを追加

## 確認事項
- `pnpm test:unit` — 19 files / 101 tests passed
- `pnpm type-check` — passed
- `pnpm lint` — passed
- `pnpm fmt` — passed
- pre-commit / pre-push hooks — passed
- localhost、本番 origin、`0.0.0.0:3000` の request Host、state 検証、cookie 削除、Discord payload、link-discord payload を unit test で確認

## 補足
- `pnpm test`、`pnpm build`、実際の reverse proxy 環境での確認は未実行

🤖 Generated with Codex