### PR TITLE
Revert "fix: Discord連携ボタンの英語をすべて大文字にしない"

### DIFF
--- a/src/app/(protected)/(standard)/users/[userId]/_components/LinkDiscordButton.tsx
+++ b/src/app/(protected)/(standard)/users/[userId]/_components/LinkDiscordButton.tsx
@@ -24,7 +24,7 @@ const LinkDiscordButton = () => {
             variant="contained"
             startIcon={<LinkIcon />}
             href="/api/discord"
-            sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
+            sx={{ alignSelf: 'flex-start' }}
           >
             Discord と連携する
           </Button>


### PR DESCRIPTION
Reverts GiganticMinecraft/seichi-portal-frontend#951

#953 でまとめて対応する