### PR TITLE
fix: 管理者ユーザー一覧のUUID省略と詳細表示を改善する

### DIFF
--- a/src/app/(protected)/admin/users/_components/UsersTable/UserDetailCell.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersTable/UserDetailCell.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { IconButton, Tooltip } from '@mui/material';
+import { Button } from '@mui/material';
 import { useState } from 'react';
 
 import UserDetailDialog from '../UserDetailDialog/UserDetailDialog';
@@ -30,28 +29,27 @@ const UserDetailCell = ({
   }
 
   return (
-    <Tooltip title="詳細を表示" placement="top">
-      <span>
-        <IconButton
-          size="small"
-          onClick={() => {
-            setOpen(true);
-          }}
-        >
-          <InfoOutlinedIcon fontSize="small" />
-        </IconButton>
-        <UserDetailDialog
-          uuid={userId}
-          userName={userName}
-          canManageRole={canManageRole}
-          canManageRestriction={canManageRestriction}
-          open={open}
-          onClose={() => {
-            setOpen(false);
-          }}
-        />
-      </span>
-    </Tooltip>
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        詳細
+      </Button>
+      <UserDetailDialog
+        uuid={userId}
+        userName={userName}
+        canManageRole={canManageRole}
+        canManageRestriction={canManageRestriction}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+      />
+    </>
   );
 };
 

--- a/src/app/(protected)/admin/users/_components/UsersTable/UserIdCell.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersTable/UserIdCell.tsx
@@ -5,7 +5,7 @@ import { Box, Tooltip, Typography } from '@mui/material';
 import CopyButton from '@/app/(protected)/_components/CopyButton';
 
 const UserIdCell = ({ id }: { id: string }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+  <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
     <Tooltip title={id} placement="top">
       <Typography
         variant="body2"
@@ -13,7 +13,7 @@ const UserIdCell = ({ id }: { id: string }) => (
         sx={{
           fontFamily: 'monospace',
           color: 'text.secondary',
-          maxWidth: 200,
+          minWidth: 0,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',


### PR DESCRIPTION
## 概要
- 管理者ユーザー管理画面(`/admin/users`)のUUID列で `maxWidth: 200px` が固定指定されており、列幅が十分にある画面でもUUIDが不必要に途中で見切れて表示されていたため撤廃し、実際の列幅いっぱいまで表示できるようにした（狭い場合は従来通り省略表示・Tooltipで全文表示）
- 詳細情報を開くトリガーが「i」アイコンのみでわかりにくかったため、「詳細」という文言のボタン表示に変更した
- 対象ファイル: `UserIdCell.tsx`, `UserDetailCell.tsx`

## 確認事項
- `tsc --noEmit` / `eslint` / `prettier --check` / pre-commit・pre-push フック（lint, type-check, fmt, unit-test）すべて通過を確認
- 実ブラウザでの表示確認は、認証(MSAL)が必要な管理者画面のため今回は未実施。UUID省略ロジックはCSSの `overflow: hidden` / `text-overflow: ellipsis` を維持したまま `maxWidth` のみ撤廃した変更であり、影響範囲は限定的と判断
- レビュー時に実際の管理画面でUUID表示幅とボタンの見た目を確認いただけると安心です

🤖 Generated with Claude Code