### PR TITLE
運営ダッシュボードの回答一覧にフィルター・検索を追加

### DIFF
--- a/src/app/(protected)/admin/_components/Dashboard.tsx
+++ b/src/app/(protected)/admin/_components/Dashboard.tsx
@@ -1,45 +1,137 @@
 'use client';
 
+import { Search } from '@mui/icons-material';
 import {
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
+  Box,
+  InputAdornment,
+  LinearProgress,
+  Stack,
+  TextField,
+  Typography,
 } from '@mui/material';
+import type { Dayjs } from 'dayjs';
 import { useRouter } from 'next/navigation';
 import * as React from 'react';
 
-import InfiniteScrollSentinel from '@/app/_components/InfiniteScrollSentinel';
+import AnswerLabelFilter from '@/app/(protected)/_components/AnswersList/AnswerLabelFilter';
+import { filterAnswers } from '@/app/(protected)/_components/AnswersList/answerListFilters';
+import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
-import { formatString } from '@/generic/DateFormatter';
-import type { GetAnswersPageResponse, GetFormsResponse } from '@/lib/api-types';
-import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
+import type {
+  GetAnswerLabelsResponse,
+  GetAnswersPageResponse,
+  GetFormsResponse,
+} from '@/lib/api-types';
 
-interface Row {
-  id: string;
-  formId: string;
-  category: string;
-  title: string;
-  date: string;
-}
+import { filterAnswersByFormAndDate } from '../_lib/dashboardAnswerFilters';
+import { toDashboardAnswerRows } from '../_lib/dashboardAnswerRows';
+import type { DashboardAnswerRow } from '../_lib/dashboardAnswerRows';
+
+import DashboardAnswersGrid from './DashboardAnswersGrid';
+import DashboardDateRangeFilter from './DashboardDateRangeFilter';
+import DashboardFormFilter from './DashboardFormFilter';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const DataTable = (props: {
   initialAnswers: GetAnswersPageResponse;
   forms: GetFormsResponse;
 }) => {
   const router = useRouter();
+
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+  const [formFilter, setFormFilter] = React.useState<GetFormsResponse>([]);
+  const [labelFilter, setLabelFilter] = React.useState<GetAnswerLabelsResponse>(
+    []
+  );
+  const [startDate, setStartDate] = React.useState<Dayjs | null>(null);
+  const [endDate, setEndDate] = React.useState<Dayjs | null>(null);
+
+  React.useEffect(() => {
+    const trimmed = search.trim();
+    if (trimmed === '') {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedSearch(trimmed);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (value.trim() === '') {
+      setDebouncedSearch('');
+    }
+  };
+
+  const isSearching = debouncedSearch !== '';
+
   const {
     items: answers,
     hasMore,
     isLoadingMore,
-    sentinelRef,
+    loadMore,
   } = useInfiniteApiQuery(
     '/api/v1/forms/answers',
     (cursor) => ({ query: cursor === undefined ? {} : { cursor } }),
     props.initialAnswers
+  );
+
+  const { data: searchData, isLoading: isSearchLoading } = useApiQuery(
+    '/api/v1/search/answers',
+    // form_id を渡さないことで全フォーム横断検索になる
+    isSearching ? { query: { query: debouncedSearch } } : null,
+    { keepPreviousData: true }
+  );
+
+  const sourceAnswers = React.useMemo(
+    () => (isSearching ? (searchData?.answers ?? []) : answers),
+    [isSearching, searchData, answers]
+  );
+
+  const formIds = React.useMemo(
+    () => formFilter.map((form) => form.id),
+    [formFilter]
+  );
+
+  const dateRange = React.useMemo(
+    () => ({
+      startIso: startDate ? startDate.startOf('day').toISOString() : null,
+      endIso: endDate ? endDate.endOf('day').toISOString() : null,
+    }),
+    [startDate, endDate]
+  );
+
+  const isNonSearchFilterActive =
+    formIds.length > 0 ||
+    labelFilter.length > 0 ||
+    dateRange.startIso !== null ||
+    dateRange.endIso !== null;
+
+  // 種別・ラベル・日付範囲での絞り込みはクライアントサイドで行うため、絞り込みが有効な間は
+  // hasMore が false になるまで残りページを読み込みきる。テキスト検索中は
+  // /api/v1/search/answers が最初から全件を返すため不要。
+  React.useEffect(() => {
+    if (!isSearching && isNonSearchFilterActive && hasMore && !isLoadingMore) {
+      loadMore();
+    }
+  }, [isSearching, isNonSearchFilterActive, hasMore, isLoadingMore, loadMore]);
+
+  const isPrefetchingForFilter =
+    !isSearching && isNonSearchFilterActive && hasMore;
+
+  const filteredAnswers = React.useMemo(
+    () =>
+      filterAnswers(
+        filterAnswersByFormAndDate(sourceAnswers, { formIds, dateRange }),
+        { labels: labelFilter }
+      ),
+    [sourceAnswers, formIds, dateRange, labelFilter]
   );
 
   const formTitleById = React.useMemo(
@@ -47,56 +139,95 @@ const DataTable = (props: {
     [props.forms]
   );
 
-  const rows = React.useMemo<Row[]>(
-    () =>
-      answers.map((answer) => ({
-        id: answer.id,
-        formId: answer.form_id,
-        category: formTitleById.get(answer.form_id) ?? 'unknown form',
-        title: resolveAnswerTitle(answer.title),
-        date: formatString(answer.timestamp),
-      })),
-    [answers, formTitleById]
+  const rows = React.useMemo(
+    () => toDashboardAnswerRows(filteredAnswers, formTitleById),
+    [filteredAnswers, formTitleById]
   );
 
-  const handleRowClick = (row: Row) => {
+  const labelOptions = React.useMemo(() => {
+    const byId = new Map<string, GetAnswerLabelsResponse[number]>();
+    for (const answer of sourceAnswers) {
+      for (const label of answer.labels) {
+        byId.set(label.id, label);
+      }
+    }
+    return Array.from(byId.values());
+  }, [sourceAnswers]);
+
+  const handleRowClick = (row: DashboardAnswerRow) => {
     router.push(`/admin/forms/${row.formId}/answers/${row.id}`);
   };
 
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>種別</TableCell>
-            <TableCell>タイトル</TableCell>
-            <TableCell>日付</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((row) => (
-            <TableRow
-              key={row.id}
-              hover
-              onClick={() => {
-                handleRowClick(row);
-              }}
-              sx={{ cursor: 'pointer' }}
-            >
-              <TableCell>{row.category}</TableCell>
-              <TableCell>{row.title}</TableCell>
-              <TableCell>{row.date}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      {hasMore && (
-        <InfiniteScrollSentinel
-          sentinelRef={sentinelRef}
-          isLoadingMore={isLoadingMore}
+    <Box sx={{ width: '100%' }}>
+      <Stack spacing={1.5} sx={{ mb: 2 }}>
+        <Typography variant="h5" component="h1">
+          回答一覧
+        </Typography>
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{ alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
+        >
+          <TextField
+            variant="standard"
+            size="small"
+            label="タイトルを検索"
+            value={search}
+            onChange={(e) => {
+              handleSearchChange(e.target.value);
+            }}
+            sx={{ minWidth: 240 }}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+          <DashboardFormFilter
+            formOptions={props.forms}
+            setFormFilter={setFormFilter}
+          />
+          <AnswerLabelFilter
+            labelOptions={labelOptions}
+            setLabelFilter={setLabelFilter}
+          />
+          <DashboardDateRangeFilter
+            startDate={startDate}
+            endDate={endDate}
+            onStartDateChange={setStartDate}
+            onEndDateChange={setEndDate}
+          />
+        </Stack>
+      </Stack>
+      <Box sx={{ position: 'relative' }}>
+        {(isSearching && isSearchLoading) || isPrefetchingForFilter ? (
+          <LinearProgress
+            sx={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1 }}
+          />
+        ) : null}
+        {isPrefetchingForFilter && (
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            sx={{ display: 'block', mb: 0.5 }}
+          >
+            絞り込みのため全件を読み込み中です。結果が確定するまでお待ちください。
+          </Typography>
+        )}
+        <DashboardAnswersGrid
+          rows={rows}
+          hasMore={!isSearching && hasMore}
+          isLoadingMore={!isSearching && isLoadingMore}
+          onLoadMore={loadMore}
+          onRowClick={handleRowClick}
         />
-      )}
-    </TableContainer>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/app/(protected)/admin/_components/DashboardAnswersGrid.tsx
+++ b/src/app/(protected)/admin/_components/DashboardAnswersGrid.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Box, Chip, CircularProgress, Stack } from '@mui/material';
+import { DataGrid, gridClasses, useGridApiRef } from '@mui/x-data-grid';
+import type {
+  GridColDef,
+  GridEventListener,
+  GridRenderCellParams,
+  GridRowParams,
+} from '@mui/x-data-grid';
+import * as React from 'react';
+
+import type { DashboardAnswerRow } from '../_lib/dashboardAnswerRows';
+
+const SCROLL_END_THRESHOLD_PX = 200;
+
+const DashboardAnswersGrid = ({
+  rows,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  onRowClick,
+}: {
+  rows: DashboardAnswerRow[];
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  onRowClick: (row: DashboardAnswerRow) => void;
+}) => {
+  const apiRef = useGridApiRef();
+
+  // Community 版 DataGrid には onRowsScrollEnd が無いため、内部の仮想スクロールコンテナを直接監視する
+  React.useEffect(() => {
+    if (!hasMore) return;
+
+    const scroller = apiRef.current?.rootElementRef.current?.querySelector(
+      `.${gridClasses.virtualScroller}`
+    );
+    if (!scroller) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = scroller;
+      if (scrollHeight - scrollTop - clientHeight < SCROLL_END_THRESHOLD_PX) {
+        onLoadMore();
+      }
+    };
+
+    scroller.addEventListener('scroll', handleScroll);
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll);
+    };
+  }, [apiRef, hasMore, onLoadMore]);
+
+  const handleRowClick: GridEventListener<'rowClick'> = (
+    params: GridRowParams<DashboardAnswerRow>
+  ) => {
+    onRowClick(params.row);
+  };
+
+  const columns: GridColDef[] = [
+    { field: 'category', headerName: '種別', minWidth: 160, flex: 0.8 },
+    { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
+    {
+      field: 'labels',
+      headerName: 'ラベル',
+      minWidth: 200,
+      flex: 1,
+      sortable: false,
+      renderCell: (
+        params: GridRenderCellParams<
+          DashboardAnswerRow,
+          DashboardAnswerRow['labels']
+        >
+      ) => (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          useFlexGap
+          sx={{ flexWrap: 'wrap', py: 0.75 }}
+        >
+          {params.value?.map((label) => (
+            <Chip key={label.id} label={label.name} size="small" />
+          ))}
+        </Stack>
+      ),
+    },
+    { field: 'date', headerName: '日付', minWidth: 200, flex: 0.8 },
+  ];
+
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <DataGrid
+        apiRef={apiRef}
+        rows={rows}
+        columns={columns}
+        onRowClick={handleRowClick}
+        sx={{
+          border: 0,
+          height: 560,
+          '& .MuiDataGrid-columnHeaders': {
+            backgroundColor: 'action.hover',
+          },
+        }}
+        disableRowSelectionOnClick
+        slots={{
+          footer: () =>
+            isLoadingMore ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
+                <CircularProgress size={20} />
+              </Box>
+            ) : null,
+        }}
+      />
+    </Box>
+  );
+};
+
+export default DashboardAnswersGrid;

--- a/src/app/(protected)/admin/_components/DashboardDateRangeFilter.tsx
+++ b/src/app/(protected)/admin/_components/DashboardDateRangeFilter.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Stack } from '@mui/material';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import type { Dayjs } from 'dayjs';
+
+const DashboardDateRangeFilter = ({
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+}: {
+  startDate: Dayjs | null;
+  endDate: Dayjs | null;
+  onStartDateChange: (value: Dayjs | null) => void;
+  onEndDateChange: (value: Dayjs | null) => void;
+}) => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <DatePicker
+          label="開始日"
+          value={startDate}
+          onChange={onStartDateChange}
+          slotProps={{
+            textField: { variant: 'standard', size: 'small' },
+            field: { clearable: true },
+          }}
+          sx={{ minWidth: 160 }}
+        />
+        <DatePicker
+          label="終了日"
+          value={endDate}
+          onChange={onEndDateChange}
+          slotProps={{
+            textField: { variant: 'standard', size: 'small' },
+            field: { clearable: true },
+          }}
+          sx={{ minWidth: 160 }}
+        />
+      </Stack>
+    </LocalizationProvider>
+  );
+};
+
+export default DashboardDateRangeFilter;

--- a/src/app/(protected)/admin/_components/DashboardFormFilter.tsx
+++ b/src/app/(protected)/admin/_components/DashboardFormFilter.tsx
@@ -1,0 +1,47 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import type { Dispatch, SetStateAction } from 'react';
+
+import type { GetFormsResponse } from '@/lib/api-types';
+
+const DashboardFormFilter = (props: {
+  formOptions: GetFormsResponse;
+  setFormFilter: Dispatch<SetStateAction<GetFormsResponse>>;
+}) => {
+  return (
+    <Autocomplete
+      multiple
+      id="dashboard-form-filter"
+      options={props.formOptions.map((form) => form.title)}
+      getOptionLabel={(option) => option}
+      sx={{ minWidth: 240, flexGrow: 1 }}
+      slotProps={{
+        listbox: {
+          sx: {
+            '& .MuiAutocomplete-option': {
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            },
+          },
+        },
+        popper: { sx: { minWidth: 240 } },
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          size="small"
+          label="種別で絞り込み"
+        />
+      )}
+      onChange={(_event, value) => {
+        props.setFormFilter(
+          props.formOptions.filter((form) => value.includes(form.title))
+        );
+      }}
+    />
+  );
+};
+
+export default DashboardFormFilter;

--- a/src/app/(protected)/admin/_lib/dashboardAnswerFilters.ts
+++ b/src/app/(protected)/admin/_lib/dashboardAnswerFilters.ts
@@ -1,0 +1,41 @@
+import type { GetAnswersResponse } from '@/lib/api-types';
+
+export interface DashboardAnswerFilter {
+  /** 選択中のフォーム ID。空配列のときは絞り込まない。 */
+  formIds: string[];
+  /** 絞り込み対象期間。ISO 8601 文字列で、両端を含む。未指定(null)のときはその端を絞り込まない。 */
+  dateRange: {
+    startIso: string | null;
+    endIso: string | null;
+  };
+}
+
+export const filterAnswersByFormAndDate = (
+  answers: GetAnswersResponse,
+  filter: DashboardAnswerFilter
+): GetAnswersResponse => {
+  const startMs =
+    filter.dateRange.startIso === null
+      ? null
+      : Date.parse(filter.dateRange.startIso);
+  const endMs =
+    filter.dateRange.endIso === null
+      ? null
+      : Date.parse(filter.dateRange.endIso);
+
+  return answers.filter((answer) => {
+    if (filter.formIds.length > 0 && !filter.formIds.includes(answer.form_id)) {
+      return false;
+    }
+
+    const answerMs = Date.parse(answer.timestamp);
+    if (startMs !== null && answerMs < startMs) {
+      return false;
+    }
+    if (endMs !== null && answerMs > endMs) {
+      return false;
+    }
+
+    return true;
+  });
+};

--- a/src/app/(protected)/admin/_lib/dashboardAnswerRows.ts
+++ b/src/app/(protected)/admin/_lib/dashboardAnswerRows.ts
@@ -1,0 +1,30 @@
+import { formatString } from '@/generic/DateFormatter';
+import type {
+  GetAnswerLabelsResponse,
+  GetAnswersResponse,
+} from '@/lib/api-types';
+import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
+
+export type DashboardAnswerRow = {
+  id: string;
+  formId: string;
+  category: string;
+  title: string;
+  date: string;
+  labels: GetAnswerLabelsResponse;
+};
+
+const UNKNOWN_FORM_TITLE = 'unknown form';
+
+export const toDashboardAnswerRows = (
+  answers: GetAnswersResponse,
+  formTitleById: ReadonlyMap<string, string>
+): DashboardAnswerRow[] =>
+  answers.map((answer) => ({
+    id: answer.id,
+    formId: answer.form_id,
+    category: formTitleById.get(answer.form_id) ?? UNKNOWN_FORM_TITLE,
+    title: resolveAnswerTitle(answer.title),
+    date: formatString(answer.timestamp),
+    labels: answer.labels,
+  }));

--- a/tests/unit/dashboardAnswerFilters.test.ts
+++ b/tests/unit/dashboardAnswerFilters.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterAnswersByFormAndDate } from '@/app/(protected)/admin/_lib/dashboardAnswerFilters';
+import type { GetAnswersResponse } from '@/lib/api-types';
+
+const answer = (
+  id: string,
+  formId: string,
+  timestamp: string
+): GetAnswersResponse[number] => ({
+  id,
+  form_id: formId,
+  answers: [],
+  author: {
+    type: 'AUTHENTICATED_USER',
+    user: {
+      uuid: 'user-id',
+      name: 'ユーザー',
+      role: 'STANDARD_USER',
+    },
+  },
+  labels: [],
+  publication: 'PUBLIC',
+  timestamp,
+});
+
+const answers = [
+  answer('answer-1', 'form-a', '2026-06-01T10:00:00+09:00'),
+  answer('answer-2', 'form-b', '2026-06-10T10:00:00+09:00'),
+  answer('answer-3', 'form-a', '2026-06-20T10:00:00+09:00'),
+] satisfies GetAnswersResponse;
+
+const noFilter = { formIds: [], dateRange: { startIso: null, endIso: null } };
+
+describe('filterAnswersByFormAndDate', () => {
+  it('フォーム・日付とも未指定のときは全件を返す', () => {
+    const filtered = filterAnswersByFormAndDate(answers, noFilter);
+
+    expect(filtered.map((a) => a.id)).toEqual([
+      'answer-1',
+      'answer-2',
+      'answer-3',
+    ]);
+  });
+
+  it('選択したフォーム ID のいずれかに一致する回答だけを残す', () => {
+    const filtered = filterAnswersByFormAndDate(answers, {
+      ...noFilter,
+      formIds: ['form-a'],
+    });
+
+    expect(filtered.map((a) => a.id)).toEqual(['answer-1', 'answer-3']);
+  });
+
+  it('日付範囲は両端を含めて絞り込む', () => {
+    const filtered = filterAnswersByFormAndDate(answers, {
+      ...noFilter,
+      dateRange: {
+        startIso: '2026-06-01T01:00:00.000Z',
+        endIso: '2026-06-10T01:00:00.000Z',
+      },
+    });
+
+    // answer-1: 2026-06-01T01:00:00Z (=10:00+09:00) は開始境界と一致するため含む
+    // answer-2: 2026-06-10T01:00:00Z (=10:00+09:00) は終了境界と一致するため含む
+    // answer-3: 2026-06-20T01:00:00Z は範囲外のため除外
+    expect(filtered.map((a) => a.id)).toEqual(['answer-1', 'answer-2']);
+  });
+
+  it('フォームと日付範囲は AND 条件で絞り込む', () => {
+    const filtered = filterAnswersByFormAndDate(answers, {
+      formIds: ['form-a'],
+      dateRange: {
+        startIso: '2026-06-01T00:00:00.000Z',
+        endIso: '2026-06-05T00:00:00.000Z',
+      },
+    });
+
+    expect(filtered.map((a) => a.id)).toEqual(['answer-1']);
+  });
+});

--- a/tests/unit/dashboardAnswerRows.test.ts
+++ b/tests/unit/dashboardAnswerRows.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { toDashboardAnswerRows } from '@/app/(protected)/admin/_lib/dashboardAnswerRows';
+import type { GetAnswersResponse } from '@/lib/api-types';
+
+const createAnswer = (
+  overrides: Partial<GetAnswersResponse[number]>
+): GetAnswersResponse[number] => ({
+  id: 'answer-id',
+  form_id: 'form-id',
+  answers: [],
+  author: {
+    type: 'AUTHENTICATED_USER',
+    user: {
+      uuid: 'user-id',
+      name: 'ユーザー',
+      role: 'STANDARD_USER',
+    },
+  },
+  labels: [],
+  publication: 'PUBLIC',
+  timestamp: '2026-06-01T10:00:00+09:00',
+  ...overrides,
+});
+
+describe('toDashboardAnswerRows', () => {
+  it('回答一覧の行へフォーム名を含む表示用の値を渡す', () => {
+    const rows = toDashboardAnswerRows(
+      [
+        createAnswer({
+          id: 'with-title',
+          form_id: 'form-a',
+          title: '回答タイトル',
+          labels: [{ id: 'label-id', name: 'ラベル' }],
+        }),
+      ],
+      new Map([['form-a', 'フォームA']])
+    );
+
+    expect(rows).toEqual([
+      {
+        id: 'with-title',
+        formId: 'form-a',
+        category: 'フォームA',
+        title: '回答タイトル',
+        date: '2026年06月01日 10時00分',
+        labels: [{ id: 'label-id', name: 'ラベル' }],
+      },
+    ]);
+  });
+
+  it('フォーム一覧に存在しない form_id のときは unknown form を表示する', () => {
+    const rows = toDashboardAnswerRows(
+      [createAnswer({ id: 'orphan', form_id: 'missing-form' })],
+      new Map()
+    );
+
+    expect(rows[0]?.category).toBe('unknown form');
+  });
+
+  it('回答タイトルが null または未指定のときは未設定を示す表示へ変換する', () => {
+    const rows = toDashboardAnswerRows(
+      [
+        createAnswer({ id: 'null-title', title: null }),
+        createAnswer({ id: 'missing-title' }),
+      ],
+      new Map()
+    );
+
+    expect(rows.map((row) => row.title)).toEqual([
+      '(タイトル未設定)',
+      '(タイトル未設定)',
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要
- 運営ダッシュボード(`/admin`)の回答一覧が種別横断の一覧表示のみで、フィルター・検索が一切できなかったため、タイトル検索(フリーテキスト)・種別(フォーム)・ラベル・日付範囲での絞り込みを追加した
- タイトル検索は `/api/v1/search/answers` を `form_id` を渡さずに呼び出すことでフォーム横断検索を実現。種別・ラベル・日付範囲はクライアントサイドで絞り込み、いずれかが有効な間は残りページをバックグラウンドで自動読み込みして絞り込み対象を全件へ拡張する(読み込み中はUIに表示)
- 表示は単一フォームの回答一覧(`AnswersList`配下)と同じ`DataGrid`構成に揃え、ラベル絞り込みロジック(`filterAnswers`)は新規実装せず既存のものを再利用した
- 影響範囲は `admin/_components/Dashboard.tsx` とその配下の新規コンポーネント・純粋関数のみで、バックエンドAPIや他画面への変更はない

## 確認事項
- `pnpm lint` / `pnpm type-check` / `pnpm test:unit`(108件)がすべて成功することを確認済み
- 新規追加した純粋関数(`dashboardAnswerFilters.ts`: 種別・日付範囲のAND絞り込み、`dashboardAnswerRows.ts`: 行データ整形)にユニットテストを追加し、境界値(日付範囲の両端含む判定、未一致フォームのフォールバック表示)を確認済み
- 実装後にコードレビュー(サブエージェント)を行い、指摘のうちPrettierフォーマット崩れと検索中のfooterスピナー誤表示は修正済み。残る指摘(先読み用useEffectがSWRの内部フラグを流用している点、日付範囲がブラウザのローカルタイムゾーン基準である点)は動作上の不具合ではないため対応を見送った
- 実ブラウザでの動作確認(スクリーンショット等)は未実施

## 補足
- なし

🤖 Generated with Claude Code