### PR TITLE
perf: DataGrid の再レンダリング最適化とデバウンス処理の共通化

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
@@ -2,14 +2,12 @@
 
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
-import { useEffect, useState } from 'react';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
 import type { AnswerSearchResponse } from '@/lib/api-types';
 import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
-
-const SEARCH_DEBOUNCE_MS = 300;
 
 type SearchedAnswer = AnswerSearchResponse['answers'][number];
 
@@ -22,30 +20,8 @@ const AdminRelatedAnswerAdder = ({
   answerId: string;
   excludedAnswerIds: string[];
 }) => {
-  const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const { search, debouncedSearch, handleSearchChange } = useDebouncedSearch();
   const { addRelatedAnswer } = useRelatedAnswerActions(formId, answerId);
-
-  useEffect(() => {
-    const trimmed = search.trim();
-    if (trimmed === '') {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setDebouncedSearch(trimmed);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [search]);
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    if (value.trim() === '') {
-      setDebouncedSearch('');
-    }
-  };
 
   const { data, isLoading } = useApiQuery(
     '/api/v1/search/answers',

--- a/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersPageContent.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import type {
   GetAnswerLabelsResponse,
   GetFormAnswersPageResponse,
@@ -14,8 +15,6 @@ import type {
 import { filterAnswers } from './answerListFilters';
 import { toAnswerListRows } from './answerListRows';
 import AnswersView from './AnswersView';
-
-const SEARCH_DEBOUNCE_MS = 300;
 
 const AnswersPageContent = ({
   form,
@@ -27,32 +26,9 @@ const AnswersPageContent = ({
   answersBasePath: string;
 }) => {
   const router = useRouter();
-  const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const { search, debouncedSearch, isSearching, handleSearchChange } =
+    useDebouncedSearch();
   const [labelFilter, setLabelFilter] = useState<GetAnswerLabelsResponse>([]);
-
-  useEffect(() => {
-    const trimmed = search.trim();
-    if (trimmed === '') {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setDebouncedSearch(trimmed);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [search]);
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    if (value.trim() === '') {
-      setDebouncedSearch('');
-    }
-  };
-
-  const isSearching = debouncedSearch !== '';
 
   const {
     items: answers,

--- a/src/app/(protected)/_components/AnswersList/AnswersView.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersView.tsx
@@ -28,6 +28,32 @@ import type { AnswerListRow } from './answerListRows';
 
 const SCROLL_END_THRESHOLD_PX = 200;
 
+const columns: GridColDef<AnswerListRow>[] = [
+  { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
+  { field: 'date', headerName: '投稿日時', minWidth: 200, flex: 0.8 },
+  {
+    field: 'labels',
+    headerName: 'ラベル',
+    minWidth: 200,
+    flex: 1,
+    sortable: false,
+    renderCell: (
+      params: GridRenderCellParams<AnswerListRow, AnswerListRow['labels']>
+    ) => (
+      <Stack
+        direction="row"
+        spacing={0.5}
+        useFlexGap
+        sx={{ flexWrap: 'wrap', py: 0.75 }}
+      >
+        {params.value?.map((label) => (
+          <Chip key={label.id} label={label.name} size="small" />
+        ))}
+      </Stack>
+    ),
+  },
+];
+
 const AnswersView = ({
   formTitle,
   rows,
@@ -83,31 +109,17 @@ const AnswersView = ({
     onAnswerClick(String(params.id));
   };
 
-  const columns: GridColDef[] = [
-    { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
-    { field: 'date', headerName: '投稿日時', minWidth: 200, flex: 0.8 },
-    {
-      field: 'labels',
-      headerName: 'ラベル',
-      minWidth: 200,
-      flex: 1,
-      sortable: false,
-      renderCell: (
-        params: GridRenderCellParams<AnswerListRow, AnswerListRow['labels']>
-      ) => (
-        <Stack
-          direction="row"
-          spacing={0.5}
-          useFlexGap
-          sx={{ flexWrap: 'wrap', py: 0.75 }}
-        >
-          {params.value?.map((label) => (
-            <Chip key={label.id} label={label.name} size="small" />
-          ))}
-        </Stack>
-      ),
-    },
-  ];
+  const slots = React.useMemo(
+    () => ({
+      footer: () =>
+        isLoadingMore ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : null,
+    }),
+    [isLoadingMore]
+  );
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -169,14 +181,7 @@ const AnswersView = ({
             },
           }}
           disableRowSelectionOnClick
-          slots={{
-            footer: () =>
-              isLoadingMore ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
-                  <CircularProgress size={20} />
-                </Box>
-              ) : null,
-          }}
+          slots={slots}
         />
       </Box>
     </Box>

--- a/src/app/(protected)/_components/MinecraftPunishmentList.tsx
+++ b/src/app/(protected)/_components/MinecraftPunishmentList.tsx
@@ -14,8 +14,8 @@ const MinecraftPunishmentList = ({
     </Typography>
   ) : (
     <Stack divider={<Divider />} spacing={1.5}>
-      {punishments.map((item, index) => (
-        <Stack key={index} spacing={0.5}>
+      {punishments.map((item) => (
+        <Stack key={`${item.punished_at}-${item.reason}`} spacing={0.5}>
           <Typography component="p">
             <strong>理由:</strong> {item.reason}
           </Typography>

--- a/src/app/(protected)/admin/_components/Dashboard.tsx
+++ b/src/app/(protected)/admin/_components/Dashboard.tsx
@@ -17,6 +17,7 @@ import AnswerLabelFilter from '@/app/(protected)/_components/AnswersList/AnswerL
 import { filterAnswers } from '@/app/(protected)/_components/AnswersList/answerListFilters';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import type {
   GetAnswerLabelsResponse,
   GetAnswersPageResponse,
@@ -31,45 +32,20 @@ import DashboardAnswersGrid from './DashboardAnswersGrid';
 import DashboardDateRangeFilter from './DashboardDateRangeFilter';
 import DashboardFormFilter from './DashboardFormFilter';
 
-const SEARCH_DEBOUNCE_MS = 300;
-
 const DataTable = (props: {
   initialAnswers: GetAnswersPageResponse;
   forms: GetFormsResponse;
 }) => {
   const router = useRouter();
 
-  const [search, setSearch] = React.useState('');
-  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+  const { search, debouncedSearch, isSearching, handleSearchChange } =
+    useDebouncedSearch();
   const [formFilter, setFormFilter] = React.useState<GetFormsResponse>([]);
   const [labelFilter, setLabelFilter] = React.useState<GetAnswerLabelsResponse>(
     []
   );
   const [startDate, setStartDate] = React.useState<Dayjs | null>(null);
   const [endDate, setEndDate] = React.useState<Dayjs | null>(null);
-
-  React.useEffect(() => {
-    const trimmed = search.trim();
-    if (trimmed === '') {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setDebouncedSearch(trimmed);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [search]);
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    if (value.trim() === '') {
-      setDebouncedSearch('');
-    }
-  };
-
-  const isSearching = debouncedSearch !== '';
 
   const {
     items: answers,

--- a/src/app/(protected)/admin/_components/DashboardAnswersGrid.tsx
+++ b/src/app/(protected)/admin/_components/DashboardAnswersGrid.tsx
@@ -14,6 +14,36 @@ import type { DashboardAnswerRow } from '../_lib/dashboardAnswerRows';
 
 const SCROLL_END_THRESHOLD_PX = 200;
 
+const columns: GridColDef<DashboardAnswerRow>[] = [
+  { field: 'category', headerName: '種別', minWidth: 160, flex: 0.8 },
+  { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
+  {
+    field: 'labels',
+    headerName: 'ラベル',
+    minWidth: 200,
+    flex: 1,
+    sortable: false,
+    renderCell: (
+      params: GridRenderCellParams<
+        DashboardAnswerRow,
+        DashboardAnswerRow['labels']
+      >
+    ) => (
+      <Stack
+        direction="row"
+        spacing={0.5}
+        useFlexGap
+        sx={{ flexWrap: 'wrap', py: 0.75 }}
+      >
+        {params.value?.map((label) => (
+          <Chip key={label.id} label={label.name} size="small" />
+        ))}
+      </Stack>
+    ),
+  },
+  { field: 'date', headerName: '日付', minWidth: 200, flex: 0.8 },
+];
+
 const DashboardAnswersGrid = ({
   rows,
   hasMore,
@@ -57,35 +87,17 @@ const DashboardAnswersGrid = ({
     onRowClick(params.row);
   };
 
-  const columns: GridColDef[] = [
-    { field: 'category', headerName: '種別', minWidth: 160, flex: 0.8 },
-    { field: 'title', headerName: 'タイトル', minWidth: 240, flex: 1.5 },
-    {
-      field: 'labels',
-      headerName: 'ラベル',
-      minWidth: 200,
-      flex: 1,
-      sortable: false,
-      renderCell: (
-        params: GridRenderCellParams<
-          DashboardAnswerRow,
-          DashboardAnswerRow['labels']
-        >
-      ) => (
-        <Stack
-          direction="row"
-          spacing={0.5}
-          useFlexGap
-          sx={{ flexWrap: 'wrap', py: 0.75 }}
-        >
-          {params.value?.map((label) => (
-            <Chip key={label.id} label={label.name} size="small" />
-          ))}
-        </Stack>
-      ),
-    },
-    { field: 'date', headerName: '日付', minWidth: 200, flex: 0.8 },
-  ];
+  const slots = React.useMemo(
+    () => ({
+      footer: () =>
+        isLoadingMore ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : null,
+    }),
+    [isLoadingMore]
+  );
 
   return (
     <Box sx={{ position: 'relative' }}>
@@ -102,14 +114,7 @@ const DashboardAnswersGrid = ({
           },
         }}
         disableRowSelectionOnClick
-        slots={{
-          footer: () =>
-            isLoadingMore ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
-                <CircularProgress size={20} />
-              </Box>
-            ) : null,
-        }}
+        slots={slots}
       />
     </Box>
   );

--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -12,7 +12,6 @@ import {
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
 import {
   toSearchResultRows,
@@ -20,29 +19,18 @@ import {
   type SearchResultRow,
 } from '@/app/(protected)/admin/_lib/searchResultRows';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 
-const SEARCH_DEBOUNCE_MS = 300;
 const SUGGESTION_LIMIT = 8;
 
 const SearchField = () => {
   const router = useRouter();
-  const [searchValue, setSearchValue] = useState('');
-  const [debouncedValue, setDebouncedValue] = useState('');
-
-  useEffect(() => {
-    const trimmed = searchValue.trim();
-    if (trimmed === '') {
-      return;
-    }
-    const timer = setTimeout(() => {
-      setDebouncedValue(trimmed);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [searchValue]);
-
-  const isSuggesting = debouncedValue !== '';
+  const {
+    search: searchValue,
+    debouncedSearch: debouncedValue,
+    isSearching: isSuggesting,
+    handleSearchChange: handleInputChange,
+  } = useDebouncedSearch();
 
   const { data } = useApiQuery(
     '/api/v1/search',
@@ -54,13 +42,6 @@ const SearchField = () => {
     isSuggesting && data
       ? toSearchResultRows(data).slice(0, SUGGESTION_LIMIT)
       : [];
-
-  const handleInputChange = (value: string) => {
-    setSearchValue(value);
-    if (value.trim() === '') {
-      setDebouncedValue('');
-    }
-  };
 
   const goToSearchPage = (value: string) => {
     if (value.trim() === '') {

--- a/src/app/(protected)/admin/users/_components/UsersTable/UsersPageContent.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersTable/UsersPageContent.tsx
@@ -6,13 +6,12 @@ import { useEffect, useState } from 'react';
 import InfiniteScrollSentinel from '@/app/_components/InfiniteScrollSentinel';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
 import { useInfiniteApiQuery } from '@/app/_swr/useInfiniteApiQuery';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import type { GetUserListPageResponse } from '@/lib/api-types';
 
 import { toUserListRows } from '../../_lib/userListRows';
 
 import UsersView from './UsersView';
-
-const SEARCH_DEBOUNCE_MS = 300;
 
 const UsersPageContent = ({
   initialUsers,
@@ -27,18 +26,15 @@ const UsersPageContent = ({
   const autoOpenUserId = searchParams.get('userId');
   const autoOpenUserName = searchParams.get('userName');
 
-  const [search, setSearch] = useState(autoOpenUserName ?? '');
-  const [debouncedSearch, setDebouncedSearch] = useState(
-    autoOpenUserName ?? ''
-  );
+  const { search, debouncedSearch, isSearching, handleSearchChange, setValue } =
+    useDebouncedSearch(autoOpenUserName ?? '');
 
   const [prevAutoOpenUserName, setPrevAutoOpenUserName] =
     useState(autoOpenUserName);
   if (autoOpenUserName !== prevAutoOpenUserName) {
     setPrevAutoOpenUserName(autoOpenUserName);
     if (autoOpenUserName) {
-      setSearch(autoOpenUserName);
-      setDebouncedSearch(autoOpenUserName);
+      setValue(autoOpenUserName);
     }
   }
 
@@ -47,29 +43,6 @@ const UsersPageContent = ({
       router.replace(pathname);
     }
   }, [autoOpenUserId, pathname, router]);
-
-  useEffect(() => {
-    const trimmed = search.trim();
-    if (trimmed === '') {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setDebouncedSearch(trimmed);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [search]);
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    if (value.trim() === '') {
-      setDebouncedSearch('');
-    }
-  };
-
-  const isSearching = debouncedSearch !== '';
 
   const {
     items: users,

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+// 検索欄をクリアした場合のみ即時反映し、それ以外は入力を SEARCH_DEBOUNCE_MS だけ遅延させて確定させる
+export const useDebouncedSearch = (initialValue = '') => {
+  const [search, setSearch] = useState(initialValue);
+  const [debouncedSearch, setDebouncedSearch] = useState(initialValue);
+
+  useEffect(() => {
+    const trimmed = search.trim();
+    if (trimmed === '') {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedSearch(trimmed);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [search]);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (value.trim() === '') {
+      setDebouncedSearch('');
+    }
+  };
+
+  const setValue = (value: string) => {
+    setSearch(value);
+    setDebouncedSearch(value);
+  };
+
+  return {
+    search,
+    debouncedSearch,
+    isSearching: debouncedSearch !== '',
+    handleSearchChange,
+    setValue,
+  };
+};


### PR DESCRIPTION
## 概要
- `DashboardAnswersGrid` / `AnswersView` の DataGrid `columns` と `slots.footer` が毎レンダーで再生成されており、`slots.footer` の identity 変化により footer サブツリーが不要に remount していたため、`columns` をモジュール直下の定数へ切り出し、`slots` を `isLoadingMore` に対して `useMemo` した
- 検索デバウンス処理(`search`/`debouncedSearch` + `setTimeout`)が `SearchField` / `Dashboard` / `AnswersPageContent` / `AdminRelatedAnswerAdder` / `UsersPageContent` の5箇所でほぼ同一実装のまま重複していたため、`src/hooks/useDebouncedSearch.ts` に共通化した(URL パラメータからの初期値復元が必要な `UsersPageContent` 向けに `setValue` を公開)
- `MinecraftPunishmentList` の `.map()` の `key` を `index` から `punished_at` + `reason` ベースへ変更した(表示専用の取得済みリストのため実害は小さいが、React のベストプラクティスに合わせた)

## 確認事項
- `pnpm exec tsc --noEmit`: エラーなし
- `pnpm exec eslint` (変更対象ファイル): エラーなし
- `pnpm test:unit` / `pnpm test:component`: 全件パス(111件 / 96件)
- `pnpm build`: ビルド成功、対象ルートすべて生成確認
- 挙動を変えない前提のリファクタリングのため、既存のデバウンス仕様(検索欄クリアで即時反映、それ以外は300ms遅延)は各サイトとも変更していない

## 補足
- 対象は React コードベースの棚卸しレビューで見つかった re-render 最適化余地3点で、いずれも影響範囲は限定的

🤖 Generated with Claude Code