### PR TITLE
perf: 公開フォームページのフォーム取得と投稿制限取得を並列化する

### DIFF
--- a/src/app/(public)/forms/[formId]/page.tsx
+++ b/src/app/(public)/forms/[formId]/page.tsx
@@ -46,20 +46,20 @@ const Home = async ({ params }: { params: Promise<{ formId: string }> }) => {
   const { formId } = await params;
 
   // ログイン時は認証ヘッダ付き、未ログイン時は匿名でフォームを取得する。
-  const form = await requireBackendData(
-    serverApiClient.GET('/api/v1/forms/{form_id}', {
-      ...(isAuthenticated
-        ? { headers: authorizationHeader(session.token) }
-        : {}),
-      params: {
-        path: { form_id: formId },
-      },
-    })
-  );
-
-  const restriction = isAuthenticated
-    ? await fetchOwnRestriction(session)
-    : null;
+  // restriction はフォーム取得結果に依存しないため並列で取得する。
+  const [form, restriction] = await Promise.all([
+    requireBackendData(
+      serverApiClient.GET('/api/v1/forms/{form_id}', {
+        ...(isAuthenticated
+          ? { headers: authorizationHeader(session.token) }
+          : {}),
+        params: {
+          path: { form_id: formId },
+        },
+      })
+    ),
+    isAuthenticated ? fetchOwnRestriction(session) : Promise.resolve(null),
+  ]);
 
   return (
     <AnswerForm


### PR DESCRIPTION
## 概要
- `src/app/(public)/forms/[formId]/page.tsx` で、フォーム本体の取得(`/api/v1/forms/{form_id}`)と自分自身の投稿制限取得(`fetchOwnRestriction`)が直列 await になっていた
- `restriction` は `session` のみに依存し `form` の結果を使わないため、`Promise.all` で並列化してレスポンスタイムを両方の合計から最大値へ短縮した
- 未ログイン時は従来通り `restriction` を取得せず `null` 扱い(挙動は変更なし)

## 確認事項
- `pnpm tsc --noEmit` / `pnpm eslint` で型・lint エラーなしを確認
- pre-commit フック(lint / type-check / fmt)、pre-push フック(unit-test 111件)すべて通過
- ロジック自体は既存の分岐(`isAuthenticated` の有無で `fetchOwnRestriction` を呼ぶかどうか)をそのまま維持しており、挙動に変更がないことをコードレベルで確認

## 補足
- vercel-react-best-practices スキルの `async-parallel` ルールに基づく指摘の修正

🤖 Generated with Claude Code