### PR TITLE
feat: 管理者サイドバーの Forms/Users を開閉可能にし、ラベル管理・グループ管理への直リンクを追加する

### DIFF
--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -1,19 +1,88 @@
 'use client';
 
-import { Star } from '@mui/icons-material';
 import {
+  ExpandLess,
+  ExpandMore,
+  Groups,
+  Label,
+  Star,
+} from '@mui/icons-material';
+import {
+  Box,
   Typography,
   MenuList,
   MenuItem,
   ListItemIcon,
+  IconButton,
+  Collapse,
   Divider,
 } from '@mui/material';
 import Drawer from '@mui/material/Drawer';
 import NextLink from 'next/link';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
 
 import { AUTCHED_DRAWER_WIDTH_PX } from '../../layoutConstants';
 
+type MenuChild = {
+  label: string;
+  url: string;
+  icon: ReactNode;
+};
+
+type MenuNode = {
+  label: string;
+  url: string;
+  icon: ReactNode;
+  children?: MenuChild[];
+};
+
+const MENU_ITEMS: MenuNode[] = [
+  { label: 'Dashboard', url: '/admin', icon: <Star /> },
+  {
+    label: 'Forms',
+    url: '/admin/forms',
+    icon: <Star />,
+    children: [
+      {
+        label: 'ラベルの管理',
+        url: '/admin/labels?tab=forms',
+        icon: <Label fontSize="small" />,
+      },
+    ],
+  },
+  {
+    label: 'Users',
+    url: '/admin/users',
+    icon: <Star />,
+    children: [
+      {
+        label: 'グループの管理',
+        url: '/admin/groups',
+        icon: <Groups fontSize="small" />,
+      },
+    ],
+  },
+  { label: 'Webhooks', url: '/admin/webhooks', icon: <Star /> },
+];
+
 const DashboardMenu = () => {
+  const [expandedUrls, setExpandedUrls] = useState<ReadonlySet<string>>(
+    new Set()
+  );
+
+  const toggleExpanded = (url: string) => {
+    setExpandedUrls((prev) => {
+      const next = new Set(prev);
+      if (next.has(url)) {
+        next.delete(url);
+      } else {
+        next.add(url);
+      }
+      return next;
+    });
+  };
+
   return (
     <Drawer
       variant="permanent"
@@ -31,41 +100,81 @@ const DashboardMenu = () => {
         Menu
       </Typography>
       <MenuList>
-        {[
-          {
-            label: 'Dashboard',
-            url: '/admin',
-          },
-          {
-            label: 'Forms',
-            url: '/admin/forms',
-          },
-          {
-            label: 'Users',
-            url: '/admin/users',
-          },
-          {
-            label: 'Webhooks',
-            url: '/admin/webhooks',
-          },
-        ].map((value) => {
+        {MENU_ITEMS.map((item) => {
+          const expanded = expandedUrls.has(item.url);
+
           return (
-            <MenuItem
-              key={value.url}
-              component={NextLink}
-              href={value.url}
-              sx={{ color: 'text.primary', textDecoration: 'none' }}
-            >
-              <ListItemIcon
-                sx={{
-                  color: 'text.secondary',
-                  paddingRight: '32px',
-                }}
-              >
-                <Star />
-              </ListItemIcon>
-              {value.label}
-            </MenuItem>
+            <Box key={item.url}>
+              <MenuItem sx={{ color: 'text.primary', padding: 0 }}>
+                <Box
+                  component={NextLink}
+                  href={item.url}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flex: 1,
+                    minWidth: 0,
+                    color: 'inherit',
+                    textDecoration: 'none',
+                    px: 2,
+                    py: '6px',
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      color: 'text.secondary',
+                      paddingRight: '32px',
+                    }}
+                  >
+                    {item.icon}
+                  </ListItemIcon>
+                  {item.label}
+                </Box>
+                {item.children && (
+                  <IconButton
+                    size="small"
+                    aria-label={`${item.label}のメニューを${
+                      expanded ? '折りたたむ' : '展開する'
+                    }`}
+                    aria-expanded={expanded}
+                    onClick={() => {
+                      toggleExpanded(item.url);
+                    }}
+                    sx={{ mr: 1 }}
+                  >
+                    {expanded ? <ExpandLess /> : <ExpandMore />}
+                  </IconButton>
+                )}
+              </MenuItem>
+              {item.children && (
+                <Collapse in={expanded} timeout="auto" unmountOnExit>
+                  <MenuList disablePadding>
+                    {item.children.map((child) => (
+                      <MenuItem
+                        key={child.url}
+                        component={NextLink}
+                        href={child.url}
+                        sx={{
+                          color: 'text.primary',
+                          textDecoration: 'none',
+                          pl: 4,
+                        }}
+                      >
+                        <ListItemIcon
+                          sx={{
+                            color: 'text.secondary',
+                            paddingRight: '32px',
+                          }}
+                        >
+                          {child.icon}
+                        </ListItemIcon>
+                        {child.label}
+                      </MenuItem>
+                    ))}
+                  </MenuList>
+                </Collapse>
+              )}
+            </Box>
           );
         })}
       </MenuList>


### PR DESCRIPTION
## 概要
- ラベルの管理・グループの管理は、それぞれフォーム一覧・ユーザー一覧ページ内のボタンからしか辿り着けず不便だったため、サイドバーの Forms・Users 項目を開閉可能にし、配下に直接リンクを追加した
- Forms/Users 本体のクリックは従来通り各一覧ページへ遷移し、項目右端の展開ボタンでサブメニュー（ラベルの管理 → `/admin/labels?tab=forms`、グループの管理 → `/admin/groups`）を開閉する
- 変更は `src/app/(protected)/admin/_components/DashboardMenu.tsx` のみ。既存のフォーム一覧・ユーザー一覧内のボタン導線はそのまま残している

## 確認事項
- ESLint / `tsc --noEmit` / Prettier がすべて通過することを確認
- admin 画面は MSAL 認証が必要でこの環境からは実ブラウザでログインできないため、Vitest + Testing Library の component test を一時的に作成し、実際のクリック操作（展開 → ラベル管理/グループ管理リンクの出現とhref確認 → 折りたたみ）を検証した上で削除した
- レビュー観点: 展開ボタンの `aria-label`（「◯◯のメニューを展開する/折りたたむ」）が UI として妥当か、サブメニューのインデント・アイコン(`Label`, `Groups`)の見た目が意図通りか

🤖 Generated with Claude Code