### PR TITLE
回答設定のユーザーグループ選択に未サインインユーザー許可を統合する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/AnswerGroupField.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/AnswerGroupField.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import PersonOffOutlined from '@mui/icons-material/PersonOffOutlined';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import { useWatch } from 'react-hook-form';
+import type { Control, UseFormSetValue } from 'react-hook-form';
+
+import type { GetUserGroupsResponse } from '@/lib/api-types';
+
+import type { FormEditorValues } from '../../_schema/formEditorSchema';
+
+const UNAUTHENTICATED_OPTION_ID = '__unauthenticated__';
+const ALL_AUTHENTICATED_OPTION_ID = '__all_authenticated__';
+
+const unauthenticatedOption = {
+  id: UNAUTHENTICATED_OPTION_ID,
+  name: '未サインインユーザー',
+};
+
+const allAuthenticatedOption = {
+  id: ALL_AUTHENTICATED_OPTION_ID,
+  name: 'ログイン済みユーザー（全員）',
+};
+
+const GROUP_DISABLED_BY_UNAUTHENTICATED_TOOLTIP =
+  '未サインインユーザーの回答を許可している間は、グループによる制限はできません。';
+
+type GroupOption = GetUserGroupsResponse[number] | typeof unauthenticatedOption;
+
+const AnswerGroupField = (props: {
+  control: Control<FormEditorValues>;
+  setValue: UseFormSetValue<FormEditorValues>;
+  groupOptions: GetUserGroupsResponse;
+}) => {
+  const answerGroupIds = useWatch({
+    control: props.control,
+    name: 'settings.answer_group_ids',
+  });
+  const allowTemporaryAnswers = useWatch({
+    control: props.control,
+    name: 'settings.allow_temporary_answers',
+  });
+
+  const options: GroupOption[] = [unauthenticatedOption, ...props.groupOptions];
+
+  const value: (GroupOption | typeof allAuthenticatedOption)[] = [
+    ...(answerGroupIds.length === 0 ? [allAuthenticatedOption] : []),
+    ...(allowTemporaryAnswers ? [unauthenticatedOption] : []),
+    ...props.groupOptions.filter((group) => answerGroupIds.includes(group.id)),
+  ];
+
+  const allAuthenticatedTooltip = allowTemporaryAnswers
+    ? GROUP_DISABLED_BY_UNAUTHENTICATED_TOOLTIP
+    : 'グループを1つも指定していないため、ログイン済みユーザーは全員回答できます。特定のグループのみに絞るには、上記からグループを追加してください。';
+
+  return (
+    <Autocomplete<GroupOption | typeof allAuthenticatedOption, true>
+      multiple
+      id="settings.answer_group_ids"
+      options={options}
+      getOptionLabel={(option) => option.name}
+      getOptionKey={(option) => option.id}
+      getOptionDisabled={(option) =>
+        allowTemporaryAnswers && option.id !== UNAUTHENTICATED_OPTION_ID
+      }
+      value={value}
+      isOptionEqualToValue={(option, current) => option.id === current.id}
+      renderOption={(renderProps, option) => {
+        const { key, ...optionProps } = renderProps;
+        const isUnauthenticated = option.id === UNAUTHENTICATED_OPTION_ID;
+        const isDisabled = Boolean(optionProps['aria-disabled']);
+
+        const box = (
+          <Box
+            {...optionProps}
+            key={isDisabled ? undefined : key}
+            component="span"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              ...(isDisabled && { pointerEvents: 'none', opacity: 0.5 }),
+            }}
+          >
+            {isUnauthenticated && <PersonOffOutlined fontSize="small" />}
+            {option.name}
+          </Box>
+        );
+
+        if (isDisabled) {
+          return (
+            <Tooltip
+              key={key}
+              title={GROUP_DISABLED_BY_UNAUTHENTICATED_TOOLTIP}
+            >
+              {box}
+            </Tooltip>
+          );
+        }
+
+        return box;
+      }}
+      renderValue={(renderedValue, getItemProps) =>
+        renderedValue.map((option, index) => {
+          const { key, onDelete, ...itemProps } = getItemProps({ index });
+          const isUnauthenticated = option.id === UNAUTHENTICATED_OPTION_ID;
+          const isAllAuthenticated = option.id === ALL_AUTHENTICATED_OPTION_ID;
+
+          if (isAllAuthenticated) {
+            return (
+              <Tooltip key={key} title={allAuthenticatedTooltip}>
+                <Chip {...itemProps} label={option.name} variant="outlined" />
+              </Tooltip>
+            );
+          }
+
+          return (
+            <Chip
+              key={key}
+              {...itemProps}
+              onDelete={onDelete}
+              label={option.name}
+              icon={isUnauthenticated ? <PersonOffOutlined /> : undefined}
+              color={isUnauthenticated ? 'warning' : 'default'}
+              variant="filled"
+            />
+          );
+        })
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="回答を投稿・閲覧できるユーザーグループ"
+          helperText="指定したグループに所属するユーザーのみがこのフォームに回答したり、回答（公開設定が「公開」の場合）を閲覧したりできるようになります。「未サインインユーザー」を選ぶと、グループによる制限はできなくなり、サインインしていない訪問者も含め全員が回答できるようになります。"
+        />
+      )}
+      onChange={(_event, newValue) => {
+        const hasUnauthenticated = newValue.some(
+          (option) => option.id === UNAUTHENTICATED_OPTION_ID
+        );
+        const groupIds = hasUnauthenticated
+          ? []
+          : newValue
+              .filter(
+                (option) =>
+                  option.id !== UNAUTHENTICATED_OPTION_ID &&
+                  option.id !== ALL_AUTHENTICATED_OPTION_ID
+              )
+              .map((option) => option.id);
+
+        props.setValue('settings.answer_group_ids', groupIds);
+        props.setValue('settings.allow_temporary_answers', hasUnauthenticated);
+      }}
+    />
+  );
+};
+
+export default AnswerGroupField;

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormGroupField.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormGroupField.tsx
@@ -12,7 +12,7 @@ import type { FormEditorValues } from '../../_schema/formEditorSchema';
 
 const FormGroupField = (props: {
   control: Control<FormEditorValues>;
-  name: 'settings.allowed_group_ids' | 'settings.answer_group_ids';
+  name: 'settings.allowed_group_ids';
   label: string;
   helperText: string;
   groupOptions: GetUserGroupsResponse;
@@ -34,6 +34,7 @@ const FormGroupField = (props: {
       disabled={props.disabled}
       options={props.groupOptions}
       getOptionLabel={(option) => option.name}
+      getOptionKey={(option) => option.id}
       value={selectedGroups}
       isOptionEqualToValue={(option, value) => option.id === value.id}
       renderOption={(renderProps, option) => {

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -25,6 +25,7 @@ import type {
 
 import type { FormEditorValues } from '../../_schema/formEditorSchema';
 
+import AnswerGroupField from './AnswerGroupField';
 import FormGroupField from './FormGroupField';
 import FormLabelField from './FormLabelField';
 
@@ -189,10 +190,6 @@ const AnswerSettings = ({
     control,
     name: 'settings.hide_author',
   });
-  const allowTemporaryAnswers = useWatch({
-    control,
-    name: 'settings.allow_temporary_answers',
-  });
   const { field: answerVisibilityField } = useController({
     control,
     name: 'settings.answer_visibility',
@@ -248,23 +245,10 @@ const AnswerSettings = ({
             : '一般ユーザーには回答者を匿名として表示します。管理者には従来どおり回答者情報が表示されます。'}
         </Typography>
       </Stack>
-      <FormGroupField
+      <AnswerGroupField
         control={control}
-        name="settings.answer_group_ids"
-        label="回答を投稿・閲覧できるユーザーグループ"
-        helperText="指定すると、選択したグループに所属するユーザーのみがこのフォームに回答したり、回答（公開設定が「公開」の場合）を閲覧したりできるようになります。未指定の場合は全員が対象になります。"
+        setValue={setValue}
         groupOptions={groupOptions}
-      />
-      <FormControlLabel
-        label="未サインインユーザーの回答を許可する"
-        control={
-          <Checkbox
-            checked={allowTemporaryAnswers}
-            onChange={(_, checked) => {
-              setValue('settings.allow_temporary_answers', checked);
-            }}
-          />
-        }
       />
       <Stack spacing={0.5}>
         <FieldLabel label="デフォルトの回答タイトル" />

--- a/tests/component/FormEditForm.test.tsx
+++ b/tests/component/FormEditForm.test.tsx
@@ -77,7 +77,7 @@ describe('FormEditForm', () => {
       <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
     );
 
-    expectCheckedIcon('未サインインユーザーの回答を許可する');
+    expect(screen.getByText('未サインインユーザー')).toBeInTheDocument();
     expectCheckedIcon('回答者を隠して公開する');
     expectCheckedIcon('この質問への回答を必須にする');
   });


### PR DESCRIPTION
## 概要
- バックエンド (seichi-portal-backend#1302) で未認証回答の許可 (`allow_temporary_answers`) とユーザーグループ制限 (`answer_group_ids`) を独立に扱えるようになったが、フロントエンドは独立したチェックボックスのままで、組み合わせたときの実際の挙動(グループ未指定なら常にログイン済み全員が回答可能、など)がヘルパーテキストでしか説明されておらず伝わりにくかった。
- 「回答を投稿・閲覧できるユーザーグループ」の選択肢に「未サインインユーザー」を統合し、状態をUI構造で表現するようにした。
  - グループを1つも指定していない間は「ログイン済みユーザー(全員)」を削除不可のチップとして自動表示し、暗黙の許可状態を可視化。
  - 未サインインユーザーを選んでいる間はグループの追加選択を無効化し、「未サインイン許可 + 特定グループ限定」という意図しない組み合わせを作れないようにした。
  - ダークモードで視認性が低かった未サインインチップの配色を `secondary`/`outlined` から `warning`/`filled` に変更した。
- API/DBのスキーマ・フィールド名(`answer_group_ids`, `allow_temporary_answers`)は変更していない。UIの見せ方のみの変更。

## 確認事項
- `tsc --noEmit`、`eslint`、`next build`、`vitest`(pre-push hook) はすべて成功。
- MUI Autocomplete の `renderOption`/`renderValue` を独自実装しているため、`getOptionKey` を明示的に `id` ベースにして key 警告(重複/欠落)を解消していることを確認した。
- 管理画面はMSAL認証必須のため、この環境ではブラウザでの実地確認はできていない。フォーム作成・編集画面の「回答設定」で、以下をレビュー時に確認してほしい:
  - グループ未指定時に「ログイン済みユーザー(全員)」チップが出て削除できないこと
  - 「未サインインユーザー」選択中はグループの追加候補がグレーアウトして選べないこと
  - ダークモードで未サインインチップの文字・アイコンが視認できること

## 補足
- 本PRはUIの見せ方の変更のみで、フォームのデフォルト値やAPIリクエスト形状(`toFormUpdateBody`など)は変更していない。

🤖 Generated with Claude Code