### PR TITLE
Webhook URL 設定を変更/削除ボタン方式のUIに統一する

### DIFF
--- a/src/app/(protected)/admin/_components/WebhookUrlField.tsx
+++ b/src/app/(protected)/admin/_components/WebhookUrlField.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Chip, Stack, TextField, Typography } from '@mui/material';
 import { useState } from 'react';
+import { match } from 'ts-pattern';
 
 import FieldLabel from '@/app/_components/FieldLabel';
 
@@ -26,20 +27,24 @@ const WebhookUrlField = ({
 
   const hasPendingValue = value.trim() !== '';
 
-  const chipLabel = isPendingDelete
-    ? '削除予定'
-    : hasPendingValue
-      ? '変更予定'
-      : enabled
-        ? '設定済み'
-        : '未設定';
-  const chipColor = isPendingDelete
-    ? 'error'
-    : hasPendingValue
-      ? 'info'
-      : enabled
-        ? 'success'
-        : 'default';
+  const { chipLabel, chipColor } = match({
+    isPendingDelete,
+    hasPendingValue,
+    enabled,
+  })
+    .with({ isPendingDelete: true }, () => ({
+      chipLabel: '削除予定',
+      chipColor: 'error' as const,
+    }))
+    .with({ hasPendingValue: true }, () => ({
+      chipLabel: '変更予定',
+      chipColor: 'info' as const,
+    }))
+    .with({ enabled: true }, () => ({
+      chipLabel: '設定済み',
+      chipColor: 'success' as const,
+    }))
+    .otherwise(() => ({ chipLabel: '未設定', chipColor: 'default' as const }));
 
   const cancelEditing = () => {
     onChange('');

--- a/src/app/(protected)/admin/_components/WebhookUrlField.tsx
+++ b/src/app/(protected)/admin/_components/WebhookUrlField.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Button, Chip, Stack, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+
+import FieldLabel from '@/app/_components/FieldLabel';
+
+type WebhookUrlFieldProps = {
+  label?: string;
+  enabled: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  isPendingDelete: boolean;
+  onPendingDeleteChange: (isPendingDelete: boolean) => void;
+};
+
+const WebhookUrlField = ({
+  label = 'Webhook URL',
+  enabled,
+  value,
+  onChange,
+  isPendingDelete,
+  onPendingDeleteChange,
+}: WebhookUrlFieldProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const hasPendingValue = value.trim() !== '';
+
+  const chipLabel = isPendingDelete
+    ? '削除予定'
+    : hasPendingValue
+      ? '変更予定'
+      : enabled
+        ? '設定済み'
+        : '未設定';
+  const chipColor = isPendingDelete
+    ? 'error'
+    : hasPendingValue
+      ? 'info'
+      : enabled
+        ? 'success'
+        : 'default';
+
+  const cancelEditing = () => {
+    onChange('');
+    setIsEditing(false);
+  };
+
+  return (
+    <Stack spacing={0.5}>
+      <Stack spacing={1} direction="row" sx={{ alignItems: 'center' }}>
+        <FieldLabel label={label} />
+        <Chip label={chipLabel} color={chipColor} size="small" />
+      </Stack>
+
+      {isPendingDelete ? (
+        <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
+          <Typography variant="caption" color="textSecondary">
+            保存すると Webhook 設定を削除します。
+          </Typography>
+          <Button
+            size="small"
+            onClick={() => {
+              onPendingDeleteChange(false);
+            }}
+          >
+            取り消す
+          </Button>
+        </Stack>
+      ) : isEditing ? (
+        <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
+          <TextField
+            value={value}
+            onChange={(e) => {
+              onChange(e.target.value);
+            }}
+            type="url"
+            autoFocus
+            fullWidth
+            helperText="新しく設定する Webhook URL を入力してください。"
+            slotProps={{ htmlInput: { 'aria-label': label } }}
+          />
+          <Button size="small" onClick={cancelEditing}>
+            キャンセル
+          </Button>
+        </Stack>
+      ) : (
+        <Stack spacing={1} direction="row">
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            変更
+          </Button>
+          {enabled && (
+            <Button
+              size="small"
+              color="error"
+              onClick={() => {
+                onPendingDeleteChange(true);
+              }}
+            >
+              削除
+            </Button>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+export default WebhookUrlField;

--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -2,7 +2,6 @@
 
 import {
   Checkbox,
-  Chip,
   Divider,
   FormControlLabel,
   MenuItem,
@@ -17,6 +16,7 @@ import type {
   UseFormSetValue,
 } from 'react-hook-form';
 
+import WebhookUrlField from '@/app/(protected)/admin/_components/WebhookUrlField';
 import FieldLabel from '@/app/_components/FieldLabel';
 import type {
   GetFormLabelsResponse,
@@ -36,6 +36,7 @@ type FormSettingsProps = {
   labelOptions: GetFormLabelsResponse;
   groupOptions: GetUserGroupsResponse;
   discordWebhookEnabled: boolean;
+  webhookSectionResetKey?: number;
 };
 
 const SectionHeading = ({ label }: { label: string }) => (
@@ -265,52 +266,26 @@ const AnswerSettings = ({
 };
 
 const NotificationSettings = ({
-  register,
   control,
-  setValue,
   discordWebhookEnabled,
-}: Pick<
-  FormSettingsProps,
-  'register' | 'control' | 'setValue' | 'discordWebhookEnabled'
->) => {
-  const discordWebhookDisabled = useWatch({
+}: Pick<FormSettingsProps, 'control' | 'discordWebhookEnabled'>) => {
+  const { field: urlField } = useController({
+    control,
+    name: 'settings.discord_webhook_url',
+  });
+  const { field: disabledField } = useController({
     control,
     name: 'settings.discord_webhook_disabled',
   });
 
   return (
-    <Stack spacing={0.5}>
-      <Stack spacing={1} direction="row" sx={{ alignItems: 'center' }}>
-        <FieldLabel label="Webhook URL" />
-        <Chip
-          label={discordWebhookEnabled ? '設定済み' : '未設定'}
-          color={discordWebhookEnabled ? 'success' : 'default'}
-          size="small"
-        />
-      </Stack>
-      <TextField
-        {...register('settings.discord_webhook_url')}
-        type="url"
-        disabled={discordWebhookDisabled}
-        helperText={
-          discordWebhookDisabled
-            ? '無効化にチェックが入っているため、この入力内容は無視されます。'
-            : '新しく設定する Webhook URL を入力してください。空欄のまま保存すると現在の設定を維持します。'
-        }
-        slotProps={{ htmlInput: { 'aria-label': 'Webhook URL' } }}
-      />
-      <FormControlLabel
-        label="Webhook 通知を無効化する(URL入力より優先されます)"
-        control={
-          <Checkbox
-            checked={discordWebhookDisabled}
-            onChange={(_, checked) => {
-              setValue('settings.discord_webhook_disabled', checked);
-            }}
-          />
-        }
-      />
-    </Stack>
+    <WebhookUrlField
+      enabled={discordWebhookEnabled}
+      value={urlField.value}
+      onChange={urlField.onChange}
+      isPendingDelete={disabledField.value}
+      onPendingDeleteChange={disabledField.onChange}
+    />
   );
 };
 
@@ -349,9 +324,8 @@ const FormSettings = (props: FormSettingsProps) => {
 
       <SectionHeading label="通知設定" />
       <NotificationSettings
-        register={props.register}
+        key={props.webhookSectionResetKey ?? 0}
         control={props.control}
-        setValue={props.setValue}
         discordWebhookEnabled={props.discordWebhookEnabled}
       />
     </Stack>

--- a/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -54,6 +54,7 @@ const FormEditForm = (props: {
   const [discordWebhookEnabled, setDiscordWebhookEnabled] = useState(
     props.form.settings.discord_webhook_enabled
   );
+  const [webhookSectionResetKey, setWebhookSectionResetKey] = useState(0);
 
   const { fields, append, remove, move } = useFieldArray({
     control,
@@ -82,6 +83,7 @@ const FormEditForm = (props: {
     );
     setValue('settings.discord_webhook_url', '');
     setValue('settings.discord_webhook_disabled', false);
+    setWebhookSectionResetKey((key) => key + 1);
   };
 
   return (
@@ -106,6 +108,7 @@ const FormEditForm = (props: {
                 labelOptions={props.labelOptions}
                 groupOptions={props.groupOptions}
                 discordWebhookEnabled={discordWebhookEnabled}
+                webhookSectionResetKey={webhookSectionResetKey}
               />
             </CardContent>
             <QuestionList

--- a/src/app/(protected)/admin/webhooks/_components/GlobalWebhookSettings.tsx
+++ b/src/app/(protected)/admin/webhooks/_components/GlobalWebhookSettings.tsx
@@ -5,21 +5,21 @@ import {
   Button,
   Card,
   CardContent,
-  Chip,
   Divider,
   Stack,
-  TextField,
   Typography,
 } from '@mui/material';
 import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useController, useForm } from 'react-hook-form';
 
+import WebhookUrlField from '@/app/(protected)/admin/_components/WebhookUrlField';
 import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
 import { useGlobalDiscordWebhook } from '@/hooks/useGlobalDiscordWebhook';
 import type { GetGlobalDiscordWebhookResponse } from '@/lib/api-types';
 
 import {
   defaultGlobalWebhookFormValues,
+  hasGlobalWebhookPendingChange,
   toGlobalWebhookUpdateUrl,
 } from '../_lib/globalWebhookForm';
 import type { GlobalWebhookFormValues } from '../_lib/globalWebhookForm';
@@ -37,6 +37,16 @@ const GlobalWebhookSettings = ({
     formState: { isSubmitting },
   } = useForm<GlobalWebhookFormValues>({
     defaultValues: defaultGlobalWebhookFormValues,
+  });
+
+  const { field: urlField } = useController({ control, name: 'url' });
+  const { field: disabledField } = useController({
+    control,
+    name: 'disabled',
+  });
+  const hasPendingChange = hasGlobalWebhookPendingChange({
+    url: urlField.value,
+    disabled: disabledField.value,
   });
 
   const { updateWebhook } = useGlobalDiscordWebhook();
@@ -65,41 +75,29 @@ const GlobalWebhookSettings = ({
           void handleSubmit(onSubmit)(e);
         }}
       >
-        <Stack spacing={1} direction="row" sx={{ alignItems: 'center', mb: 1 }}>
-          <Typography variant="h6" component="h2">
-            グローバル Discord Webhook
-          </Typography>
-          <Chip
-            label={enabled ? '有効' : '無効'}
-            color={enabled ? 'success' : 'default'}
-            size="small"
-          />
-        </Stack>
+        <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+          グローバル Discord Webhook
+        </Typography>
         <Divider sx={{ mb: 2 }} />
         <Stack spacing={2}>
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             すべてのフォームの通知をまとめて送信する Discord Webhook
-            です。セキュリティのため設定済みの URL
-            は再表示されません。空欄のまま保存すると通知を無効化します。
+            です。セキュリティのため設定済みの URL は再表示されません。
           </Typography>
-          <Controller
-            name="url"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label="Discord Webhook URL"
-                placeholder="https://discord.com/api/webhooks/..."
-                fullWidth
-              />
-            )}
+          <WebhookUrlField
+            label="Discord Webhook URL"
+            enabled={enabled}
+            value={urlField.value}
+            onChange={urlField.onChange}
+            isPendingDelete={disabledField.value}
+            onPendingDeleteChange={disabledField.onChange}
           />
           <Button
             variant="contained"
             endIcon={<SaveAltIcon />}
             type="submit"
             sx={{ alignSelf: 'flex-start' }}
-            disabled={isSubmitting}
+            disabled={isSubmitting || !hasPendingChange}
           >
             保存
           </Button>

--- a/src/app/(protected)/admin/webhooks/_lib/globalWebhookForm.ts
+++ b/src/app/(protected)/admin/webhooks/_lib/globalWebhookForm.ts
@@ -1,14 +1,22 @@
 export type GlobalWebhookFormValues = {
   url: string;
+  disabled: boolean;
 };
 
 export const defaultGlobalWebhookFormValues: GlobalWebhookFormValues = {
   url: '',
+  disabled: false,
 };
+
+export const hasGlobalWebhookPendingChange = (
+  values: GlobalWebhookFormValues
+): boolean => values.disabled || values.url.trim() !== '';
 
 export const toGlobalWebhookUpdateUrl = (
   values: GlobalWebhookFormValues
 ): string | null => {
+  if (values.disabled) return null;
+
   const trimmed = values.url.trim();
   return trimmed === '' ? null : trimmed;
 };

--- a/tests/component/FormEditForm.test.tsx
+++ b/tests/component/FormEditForm.test.tsx
@@ -82,25 +82,60 @@ describe('FormEditForm', () => {
     expectCheckedIcon('この質問への回答を必須にする');
   });
 
-  it('Webhook 無効化のチェックで URL 入力を無効にする', async () => {
+  it('Webhook 未設定時は変更ボタンのみ表示し、削除ボタンは表示しない', () => {
+    renderWithProviders(
+      <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
+    );
+
+    expect(screen.getByText('未設定')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '変更' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '削除' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('変更ボタンで URL 入力欄を開き、入力すると変更予定になり、キャンセルで閉じる', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(
       <FormEditForm form={form} labelOptions={[]} groupOptions={[]} />
     );
 
-    const webhookDisabled = screen.getByRole('checkbox', {
-      name: 'Webhook 通知を無効化する(URL入力より優先されます)',
-    });
+    await user.click(screen.getByRole('button', { name: '変更' }));
+
     const webhookUrl = screen.getByRole('textbox', { name: 'Webhook URL' });
+    await user.type(webhookUrl, 'https://example.com/webhook');
 
-    expect(webhookDisabled).not.toBeChecked();
-    expect(webhookUrl).not.toBeDisabled();
+    expect(screen.getByText('変更予定')).toBeInTheDocument();
 
-    await user.click(webhookDisabled);
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
 
-    expect(webhookDisabled).toBeChecked();
-    expect(webhookUrl).toBeDisabled();
+    expect(
+      screen.queryByRole('textbox', { name: 'Webhook URL' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('未設定')).toBeInTheDocument();
+  });
+
+  it('設定済みの Webhook で削除ボタンを押すと削除予定になり、取り消すボタンで元に戻る', async () => {
+    const user = userEvent.setup();
+    const enabledForm: GetFormResponse = {
+      ...form,
+      settings: { ...form.settings, discord_webhook_enabled: true },
+    };
+
+    renderWithProviders(
+      <FormEditForm form={enabledForm} labelOptions={[]} groupOptions={[]} />
+    );
+
+    expect(screen.getByText('設定済み')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+
+    expect(screen.getByText('削除予定')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '取り消す' }));
+
+    expect(screen.getByText('設定済み')).toBeInTheDocument();
   });
 
   it('取得した Checkbox の値を保存データへ反映する', async () => {

--- a/tests/component/GlobalWebhookSettings.test.tsx
+++ b/tests/component/GlobalWebhookSettings.test.tsx
@@ -1,0 +1,76 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import GlobalWebhookSettings from '@/app/(protected)/admin/webhooks/_components/GlobalWebhookSettings';
+
+import { renderWithProviders, screen } from './render';
+
+const { updateWebhookMock } = vi.hoisted(() => ({
+  updateWebhookMock: vi
+    .fn<(url: string | null) => Promise<{ ok: boolean }>>()
+    .mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('@/hooks/useGlobalDiscordWebhook', () => ({
+  useGlobalDiscordWebhook: () => ({ updateWebhook: updateWebhookMock }),
+}));
+
+describe('GlobalWebhookSettings', () => {
+  beforeEach(() => {
+    updateWebhookMock.mockClear();
+  });
+
+  it('未設定時は変更ボタンのみ表示し、保存ボタンは無効', () => {
+    renderWithProviders(
+      <GlobalWebhookSettings currentStatus={{ enabled: false }} />
+    );
+
+    expect(screen.getByText('未設定')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '変更' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '削除' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '保存' })).toBeDisabled();
+  });
+
+  it('変更ボタンで URL を入力すると保存ボタンが有効になり、送信すると新しい URL が送られる', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <GlobalWebhookSettings currentStatus={{ enabled: false }} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '変更' }));
+    await user.type(
+      screen.getByRole('textbox', { name: 'Discord Webhook URL' }),
+      'https://discord.com/api/webhooks/xxx'
+    );
+
+    const saveButton = screen.getByRole('button', { name: '保存' });
+    expect(saveButton).not.toBeDisabled();
+
+    await user.click(saveButton);
+
+    expect(updateWebhookMock).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/xxx'
+    );
+  });
+
+  it('設定済みの場合、削除ボタンで削除予定にでき、保存すると null が送られる', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <GlobalWebhookSettings currentStatus={{ enabled: true }} />
+    );
+
+    expect(screen.getByText('設定済み')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+
+    expect(screen.getByText('削除予定')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    expect(updateWebhookMock).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
## 概要
- フォーム編集画面の Webhook URL 設定は「チェックボックス+空欄なら維持」という表現で、無効化チェックがURL入力より優先されるという注記が必要になるほど分かりにくかった
- GitHub Repository Secrets のように、閲覧時は状態Chip（設定済み/未設定）のみを表示し、「変更」「削除」ボタンで初めて編集・削除の意図を明示させる方式に変更
- フォーム編集の Webhook URL 設定と、グローバル Discord Webhook 設定の両方で共通の `WebhookUrlField` コンポーネント（`admin/_components/`）を新設し、同じ挙動に統一した
- グローバル Discord Webhook の更新APIは部分更新ができず常にフルリプレースのため、削除予定フラグを追加。あわせて、保留中の変更がないまま保存ボタンを押すと空欄が送られて意図せず無効化されてしまっていた既存のリスクも解消（保留中の変更がない場合は保存ボタンを無効化）

## 確認事項
- MSAL認証と実バックエンドが必要な画面のため、サンドボックス環境では実ブラウザでの確認ができず、実DOM描画+実クリック操作によるコンポーネントテスト（vitest + Testing Library）で代替検証した
- `tests/component/FormEditForm.test.tsx`：フォーム編集のWebhook設定について、未設定時は変更ボタンのみ表示・削除ボタン非表示／変更ボタンで入力欄を開いて入力すると「変更予定」になりキャンセルで閉じる／設定済み状態で削除ボタンを押すと「削除予定」になり取り消すボタンで元に戻る、を確認
- `tests/component/GlobalWebhookSettings.test.tsx`（新規）：未設定時は保存ボタンが無効化される／変更ボタンでURLを入力すると保存ボタンが有効になり新しいURLが送信される／削除ボタンで削除予定にすると保存時に `null` が送信される、を確認
- `pnpm tsc --noEmit` / `pnpm eslint` / `pnpm prettier --check` / `pnpm vitest run --config vitest.component.config.ts` / `pnpm vitest run --config vitest.unit.config.ts`（pre-push hook経由）はすべて成功

## 補足
- Webhook URL 専用の Zod スキーマは元々存在せず、`formEditorSchema.ts` の設定オブジェクトに統合されている。今回この構造は変更していない
- Playwright によるE2Eテストは追加していない（認証・バックエンド連携が必要なため、コンポーネントテストでの検証に留めた）

🤖 Generated with Claude Code