### PR TITLE
refactor: ネストした三項演算子を ts-pattern の match に置き換える

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ const typescriptStrictConfig = tseslint.config({
     },
   },
   rules: {
+    'no-nested-ternary': 'error',
     '@typescript-eslint/consistent-type-assertions': [
       'error',
       {

--- a/src/app/(protected)/_components/Conversation/Comments.tsx
+++ b/src/app/(protected)/_components/Conversation/Comments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Box, Typography } from '@mui/material';
+import { match } from 'ts-pattern';
 
 import type { AnswerComment } from '@/lib/api-types';
 
@@ -133,8 +134,12 @@ const Comments = (props: {
         autoOpen={deepLinkState.autoOpen}
         highlightedEntryId={deepLinkState.highlightedEntryId}
         onDrawerClose={deepLinkState.onDrawerClose}
-        inputForm={
-          props.disabled ? null : capabilities.canCompose ? (
+        inputForm={match({
+          disabled: props.disabled,
+          canCompose: capabilities.canCompose,
+        })
+          .with({ disabled: true }, () => null)
+          .with({ canCompose: true }, () => (
             <Box
               sx={{
                 p: 2,
@@ -148,8 +153,8 @@ const Comments = (props: {
                 onSend={actions.send}
               />
             </Box>
-          ) : null
-        }
+          ))
+          .otherwise(() => null)}
         onUpdate={actions.update}
         onDelete={actions.deleteEntry}
       />

--- a/src/app/(protected)/_components/Conversation/ConversationEntryBody.tsx
+++ b/src/app/(protected)/_components/Conversation/ConversationEntryBody.tsx
@@ -2,6 +2,7 @@
 
 import { Paper } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import { match } from 'ts-pattern';
 
 import MarkdownText from '@/app/_components/MarkdownText';
 
@@ -19,12 +20,12 @@ const ConversationEntryBody = ({ entry }: Props) => {
       variant={entry.surface === 'bubble' ? 'outlined' : undefined}
       sx={(theme) => ({
         p: entry.surface === 'bubble' ? 1.5 : 0,
-        backgroundColor:
-          entry.surface === 'bubble'
-            ? isAdmin
-              ? alpha(theme.palette.success.main, 0.08)
-              : theme.palette.grey[50]
-            : 'transparent',
+        backgroundColor: match({ surface: entry.surface, isAdmin })
+          .with({ surface: 'bubble', isAdmin: true }, () =>
+            alpha(theme.palette.success.main, 0.08)
+          )
+          .with({ surface: 'bubble' }, () => theme.palette.grey[50])
+          .otherwise(() => 'transparent'),
         borderRadius: entry.surface === 'bubble' ? 2 : 0,
         boxShadow: 'none',
       })}

--- a/src/app/(protected)/admin/_components/WebhookUrlField.tsx
+++ b/src/app/(protected)/admin/_components/WebhookUrlField.tsx
@@ -58,61 +58,64 @@ const WebhookUrlField = ({
         <Chip label={chipLabel} color={chipColor} size="small" />
       </Stack>
 
-      {isPendingDelete ? (
-        <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
-          <Typography variant="caption" color="textSecondary">
-            保存すると Webhook 設定を削除します。
-          </Typography>
-          <Button
-            size="small"
-            onClick={() => {
-              onPendingDeleteChange(false);
-            }}
-          >
-            取り消す
-          </Button>
-        </Stack>
-      ) : isEditing ? (
-        <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
-          <TextField
-            value={value}
-            onChange={(e) => {
-              onChange(e.target.value);
-            }}
-            type="url"
-            autoFocus
-            fullWidth
-            helperText="新しく設定する Webhook URL を入力してください。"
-            slotProps={{ htmlInput: { 'aria-label': label } }}
-          />
-          <Button size="small" onClick={cancelEditing}>
-            キャンセル
-          </Button>
-        </Stack>
-      ) : (
-        <Stack spacing={1} direction="row">
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setIsEditing(true);
-            }}
-          >
-            変更
-          </Button>
-          {enabled && (
+      {match({ isPendingDelete, isEditing })
+        .with({ isPendingDelete: true }, () => (
+          <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
+            <Typography variant="caption" color="textSecondary">
+              保存すると Webhook 設定を削除します。
+            </Typography>
             <Button
               size="small"
-              color="error"
               onClick={() => {
-                onPendingDeleteChange(true);
+                onPendingDeleteChange(false);
               }}
             >
-              削除
+              取り消す
             </Button>
-          )}
-        </Stack>
-      )}
+          </Stack>
+        ))
+        .with({ isEditing: true }, () => (
+          <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
+            <TextField
+              value={value}
+              onChange={(e) => {
+                onChange(e.target.value);
+              }}
+              type="url"
+              autoFocus
+              fullWidth
+              helperText="新しく設定する Webhook URL を入力してください。"
+              slotProps={{ htmlInput: { 'aria-label': label } }}
+            />
+            <Button size="small" onClick={cancelEditing}>
+              キャンセル
+            </Button>
+          </Stack>
+        ))
+        .otherwise(() => (
+          <Stack spacing={1} direction="row">
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => {
+                setIsEditing(true);
+              }}
+            >
+              変更
+            </Button>
+            {enabled && (
+              <Button
+                size="small"
+                color="error"
+                onClick={() => {
+                  onPendingDeleteChange(true);
+                }}
+              >
+                削除
+              </Button>
+            )}
+          </Stack>
+        ))}
     </Stack>
   );
 };

--- a/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
+++ b/src/app/(protected)/admin/forms/_lib/formEditorMappers.ts
@@ -185,11 +185,13 @@ export const toFormUpdateBody = (
       visibility: data.settings.visibility,
       allowed_group_ids: data.settings.allowed_group_ids,
       allow_temporary_answers: data.settings.allow_temporary_answers,
-      ...(data.settings.discord_webhook_disabled
-        ? { discord_webhook_url: null }
-        : data.settings.discord_webhook_url.trim() !== ''
-          ? { discord_webhook_url: data.settings.discord_webhook_url.trim() }
-          : {}),
+      ...match({
+        disabled: data.settings.discord_webhook_disabled,
+        url: data.settings.discord_webhook_url.trim(),
+      })
+        .with({ disabled: true }, () => ({ discord_webhook_url: null }))
+        .with({ url: '' }, () => ({}))
+        .otherwise(({ url }) => ({ discord_webhook_url: url })),
       answer_settings: {
         default_answer_title: toNullableNonEmptyString(
           data.settings.default_answer_title

--- a/src/app/(protected)/admin/users/_components/UserDetailDialog/RestrictionHistorySection.tsx
+++ b/src/app/(protected)/admin/users/_components/UserDetailDialog/RestrictionHistorySection.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import { match, P } from 'ts-pattern';
 
 import MarkdownText from '@/app/_components/MarkdownText';
 import { useApiQuery } from '@/app/_swr/useApiQuery';
@@ -75,11 +76,17 @@ const RestrictionHistorySection = ({ uuid }: { uuid: string }) => {
                   </Typography>
                   <Typography component="p">
                     <strong>状態:</strong>{' '}
-                    {item.lifted_at
-                      ? `解除済み（${formatString(item.lifted_at)}）`
-                      : isRestrictionExpirationPast(expiration)
-                        ? '期限切れ'
-                        : '制限中'}
+                    {match({
+                      liftedAt: item.lifted_at,
+                      isExpired: isRestrictionExpirationPast(expiration),
+                    })
+                      .with(
+                        { liftedAt: P.string },
+                        ({ liftedAt }) =>
+                          `解除済み（${formatString(liftedAt)}）`
+                      )
+                      .with({ isExpired: true }, () => '期限切れ')
+                      .otherwise(() => '制限中')}
                   </Typography>
                 </Stack>
               );

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import type { Control, FieldErrors, UseFormRegister } from 'react-hook-form';
+import { match, P } from 'ts-pattern';
 
 import type { AnswerFormInput, AnswerQuestion } from './answerFormTypes';
 
@@ -135,14 +136,11 @@ const QuestionFieldRenderer = ({
               },
             }}
             render={({ field }) => {
-              const selectedValues: string[] =
-                typeof field.value === 'string'
-                  ? field.value === ''
-                    ? []
-                    : [field.value]
-                  : Array.isArray(field.value)
-                    ? field.value
-                    : [];
+              const selectedValues: string[] = match(field.value)
+                .with('', () => [])
+                .with(P.string, (value) => [value])
+                .with(P.array(P.string), (value) => value)
+                .otherwise(() => []);
               const choiceOrder = new Map(
                 question.choices.map((item, itemIndex) => [
                   item.label,
@@ -167,13 +165,25 @@ const QuestionFieldRenderer = ({
                                 return;
                               }
 
-                              const nextValues = checked
-                                ? selectedValues.includes(choice.label)
-                                  ? selectedValues
-                                  : [...selectedValues, choice.label]
-                                : selectedValues.filter(
+                              const nextValues = match({
+                                checked,
+                                alreadySelected: selectedValues.includes(
+                                  choice.label
+                                ),
+                              })
+                                .with(
+                                  { checked: true, alreadySelected: true },
+                                  () => selectedValues
+                                )
+                                .with({ checked: true }, () => [
+                                  ...selectedValues,
+                                  choice.label,
+                                ])
+                                .otherwise(() =>
+                                  selectedValues.filter(
                                     (value) => value !== choice.label
-                                  );
+                                  )
+                                );
                               const orderedValues = [...nextValues].sort(
                                 (left, right) =>
                                   (choiceOrder.get(left) ?? -1) -

--- a/src/app/_components/ErrorDialog.tsx
+++ b/src/app/_components/ErrorDialog.tsx
@@ -20,6 +20,7 @@ import {
 import dayjs from 'dayjs';
 import Link from 'next/link';
 import { useState } from 'react';
+import { match, P } from 'ts-pattern';
 
 import { isAccessError } from '@/lib/accessError';
 import { isHttpError } from '@/lib/httpError';
@@ -49,41 +50,38 @@ const ErrorDialog = ({
   );
   const status =
     statusProp ??
-    (isHttpError(error)
-      ? error.status
-      : isAccessError(error)
-        ? error.status
-        : null);
+    match(error)
+      .with(P.when(isHttpError), (e) => e.status)
+      .with(P.when(isAccessError), (e) => e.status)
+      .otherwise(() => null);
 
   const resolvedTitle =
     title ??
-    (status === 401
-      ? 'セッションの有効期限が切れました'
-      : status === 403
-        ? 'このページを表示する権限がありません'
-        : status === 503
-          ? '現在このページを表示できません'
-          : 'データ取得中にエラーが発生しました');
+    match(status)
+      .with(401, () => 'セッションの有効期限が切れました')
+      .with(403, () => 'このページを表示する権限がありません')
+      .with(503, () => '現在このページを表示できません')
+      .otherwise(() => 'データ取得中にエラーが発生しました');
 
   const resolvedMessage =
     message ??
-    (status === 401
-      ? '再度サインインしてから操作をやり直してください。'
-      : status === 403
-        ? '権限のあるアカウントでサインインしてください。'
-        : status === 503
-          ? 'バックエンドに接続できないため、保護された画面を表示できません。'
-          : '連続して発生する場合は管理者に問い合わせてください。');
+    match(status)
+      .with(401, () => '再度サインインしてから操作をやり直してください。')
+      .with(403, () => '権限のあるアカウントでサインインしてください。')
+      .with(
+        503,
+        () => 'バックエンドに接続できないため、保護された画面を表示できません。'
+      )
+      .otherwise(() => '連続して発生する場合は管理者に問い合わせてください。');
 
   const iconColor =
     status === 401 || status === 403 ? 'warning' : ('error' as const);
 
-  const StatusIcon =
-    status === 403
-      ? LockOutlinedIcon
-      : status === 401
-        ? WarningAmberIcon
-        : ErrorIcon;
+  const statusIcons: Record<number, typeof ErrorIcon> = {
+    403: LockOutlinedIcon,
+    401: WarningAmberIcon,
+  };
+  const StatusIcon = (status !== null && statusIcons[status]) || ErrorIcon;
 
   return (
     <Dialog open={true} maxWidth="sm" fullWidth>

--- a/src/app/_swr/useApiQuery.ts
+++ b/src/app/_swr/useApiQuery.ts
@@ -2,6 +2,7 @@
 
 import useSWR from 'swr';
 import type { SWRConfiguration } from 'swr';
+import { match, P } from 'ts-pattern';
 
 import { useHasHydrated } from '@/hooks/useHasHydrated';
 
@@ -23,12 +24,12 @@ export const useApiQuery = <P extends GetPaths>(
   const hasEmptyPathParam =
     pathObj && Object.values(pathObj).some((v) => !v && v !== 0);
 
-  const key =
-    !hasHydrated || params === null || hasEmptyPathParam
-      ? null
-      : params
-        ? [path, params]
-        : [path];
+  const shouldSkip = !hasHydrated || params === null || hasEmptyPathParam;
+
+  const key = match({ shouldSkip, params })
+    .with({ shouldSkip: true }, () => null)
+    .with({ params: P.nullish }, () => [path])
+    .otherwise(({ params }) => [path, params]);
 
   return useSWR<GetResponse<P>, Error>(
     key,


### PR DESCRIPTION
## 概要
- ネストした三項演算子は条件と結果の対応が読み取りにくく可読性が悪いため、`eslint --rule no-nested-ternary` で検出した全8ファイルを ts-pattern の `match` による分岐に書き換えた
- 対象: `Comments.tsx`(inputForm 分岐)、`ConversationEntryBody.tsx`(背景色分岐)、`WebhookUrlField.tsx`(表示切替のJSX分岐)、`formEditorMappers.ts`(webhook URL の spread 分岐)、`RestrictionHistorySection.tsx`(処罰状態の文言分岐)、`QuestionFieldRenderer.tsx`(選択値の正規化・チェック更新ロジック 2箇所)、`ErrorDialog.tsx`(ステータス別のタイトル/メッセージ/アイコン分岐)、`useApiQuery.ts`(SWRキー算出)
- `ErrorDialog.tsx` の `StatusIcon` はコンポーネント参照を選ぶ箇所で、`match` の関数呼び出しに変えると `react-hooks/static-components` ルール(レンダー中にコンポーネントを生成してはいけない)に抵触したため、そこだけはオブジェクトルックアップ (`statusIcons[status] ?? ErrorIcon`) に変更した

## 確認事項
- `eslint --rule '{"no-nested-ternary":"error"}'` を再実行し、ネストした三項演算子が残っていないことを確認
- `pnpm exec eslint src` / `pnpm exec tsc --noEmit` がエラーなしで通過することを確認
- `pnpm test:unit`(111件)、`pnpm test:component`(101件)が全てパスすることを確認
- ロジックの分岐条件・返り値は変更前後で同一になるよう、各三項演算子の分岐パターンを1つずつ `match` の `.with`/`.otherwise` に対応させて書き換えた(振る舞いを変える意図の変更はなし)

🤖 Generated with Claude Code