### PR TITLE
fix: 関連回答検索のAutocompleteでキー重複を解消する

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
@@ -44,6 +44,7 @@ const AdminRelatedAnswerAdder = ({
         handleSearchChange(value);
       }}
       getOptionLabel={(option) => resolveAnswerTitle(option.title)}
+      getOptionKey={(option) => option.id}
       isOptionEqualToValue={(a, b) => a.id === b.id}
       value={null}
       onChange={(_event, option) => {


### PR DESCRIPTION
## 概要
- 回答詳細画面の「関連付ける回答を検索」Autocomplete（`AdminRelatedAnswerAdder.tsx`）で、Reactの重複key警告が発生していた
- MUIのAutocompleteは `getOptionKey` を渡さない場合、`getOptionLabel(option)` の戻り値をリストアイテムのkeyとして使う（`useAutocomplete.js` 内 `key: getOptionKey?.(option) ?? getOptionLabel(option)`）
- 同じフォーム・同じ投稿者名で表示ラベルが重複する検索結果が存在すると、この自動生成keyが衝突していた
- `getOptionKey={(option) => option.id}` を渡し、一意な `id` をkeyとして使うよう修正

## 確認事項
- `pnpm exec tsc --noEmit` でエラーなし
- コミット時の pre-commit フック（lint / type-check / fmt）がすべて成功
- push時の pre-push フック（unit-test: 23ファイル116件）がすべて成功
- 実際のブラウザでの表示確認は未実施（元のエラーが本番相当のデータで重複ラベルが発生した場合にのみ再現するため）。レビューでは、意図どおり `option.id` がkeyとして使われることのみ確認いただければ十分です

🤖 Generated with Claude Code