### PR TITLE
fix: 関連回答削除時に詳細ページへ遷移してしまう問題を修正する

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
@@ -16,6 +16,13 @@ const RelatedAnswerItem = ({
   isAdmin: boolean;
   onRemove?: (() => void) | undefined;
 }) => {
+  const handleDelete = onRemove
+    ? (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        onRemove();
+      }
+    : undefined;
+
   const answerQuery = useApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}',
     {
@@ -35,7 +42,7 @@ const RelatedAnswerItem = ({
       label={label}
       clickable
       variant="outlined"
-      onDelete={onRemove}
+      onDelete={handleDelete}
     />
   );
 };


### PR DESCRIPTION
## 概要
- 回答詳細画面で関連回答の削除アイコンをクリックすると、削除が完了する前にその関連回答の詳細ページへ遷移してしまい、「削除できずリロードされる」ように見える不具合を修正
- 原因: `RelatedAnswerItem.tsx` で MUI の `Chip` を `next/link` の `Link`(`<a>`)として描画しており、削除アイコンはその内側にネストされている。MUI の削除アイコンのクリックハンドラは `stopPropagation()` のみで `preventDefault()` を呼ばないため、React のイベント委譲の仕組み上、祖先の `<a>` のデフォルト遷移(クリック時のページ遷移)を止められず、削除APIコールと同時にリンク先へ遷移していた
- 削除ハンドラで `event.preventDefault()` を呼んでから `onRemove` を実行するよう修正

## 確認事項
- `pnpm tsc --noEmit` で型エラーがないことを確認
- コミット時の lefthook pre-commit(lint / type-check / fmt)、pre-push(unit-test 116件)がすべて成功
- ブラウザでの実動作確認(削除操作で遷移が発生しないこと)は未実施。レビューまたはマージ後の動作確認をお願いします

🤖 Generated with Claude Code