### PR TITLE
関連回答の追加・一覧UIを改善する

### DIFF
--- a/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerAdder.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import Autocomplete from '@mui/material/Autocomplete';
+import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { formatString } from '@/generic/DateFormatter';
 import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
 import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
 import type { AnswerSearchResponse } from '@/lib/api-types';
 import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
+
+import { AnswerPublicationChip } from './AnswerMeta';
+import AnswerStatusChip from './AnswerStatusChip';
 
 type SearchedAnswer = AnswerSearchResponse['answers'][number];
 
@@ -34,10 +40,17 @@ const AdminRelatedAnswerAdder = ({
     (answer) => !excluded.has(answer.id)
   );
 
+  const noOptionsText =
+    search.trim() === ''
+      ? 'キーワードを入力すると候補が表示されます'
+      : '該当する回答が見つかりません';
+
   return (
     <Autocomplete<SearchedAnswer>
       options={options}
       loading={isLoading}
+      loadingText="検索中..."
+      noOptionsText={noOptionsText}
       filterOptions={(options) => options}
       inputValue={search}
       onInputChange={(_event, value) => {
@@ -53,6 +66,25 @@ const AdminRelatedAnswerAdder = ({
         }
         handleSearchChange('');
         void addRelatedAnswer(option.form_id, option.id);
+      }}
+      renderOption={(props, option) => {
+        const { key, ...optionProps } = props;
+        return (
+          <li key={key} {...optionProps}>
+            <Stack spacing={0.5} sx={{ width: '100%', py: 0.5 }}>
+              <Typography variant="body2">
+                {resolveAnswerTitle(option.title)}
+              </Typography>
+              <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                <AnswerStatusChip status={option.status} />
+                <AnswerPublicationChip publication={option.publication} />
+                <Typography variant="caption" color="textSecondary">
+                  {formatString(option.timestamp)}
+                </Typography>
+              </Stack>
+            </Stack>
+          </li>
+        );
       }}
       renderInput={(params) => (
         <TextField {...params} label="関連付ける回答を検索" size="small" />

--- a/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerUrlAdder.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AdminRelatedAnswerUrlAdder.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import AddIcon from '@mui/icons-material/Add';
+import { IconButton, InputAdornment, TextField } from '@mui/material';
+import { useState } from 'react';
+
+import SnackbarAlert, { useSnackbar } from '@/app/_components/SnackbarAlert';
+import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
+
+const ANSWER_URL_PATTERN = /\/forms\/([^/?#]+)\/answers\/([^/?#]+)/;
+
+const parseAnswerUrl = (
+  input: string
+): { formId: string; answerId: string } | null => {
+  const match = ANSWER_URL_PATTERN.exec(input.trim());
+  const formId = match?.[1];
+  const answerId = match?.[2];
+  if (!formId || !answerId) {
+    return null;
+  }
+  return { formId, answerId };
+};
+
+const AdminRelatedAnswerUrlAdder = ({
+  formId,
+  answerId,
+  excludedAnswerIds,
+}: {
+  formId: string;
+  answerId: string;
+  excludedAnswerIds: string[];
+}) => {
+  const [url, setUrl] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+  const { addRelatedAnswer } = useRelatedAnswerActions(formId, answerId);
+
+  const handleSubmit = async () => {
+    const parsed = parseAnswerUrl(url);
+    if (!parsed) {
+      showSnackbar(
+        '回答の詳細ページのURLを正しく貼り付けてください。',
+        'error'
+      );
+      return;
+    }
+    if (parsed.answerId === answerId) {
+      showSnackbar('自分自身を関連付けることはできません。', 'error');
+      return;
+    }
+    if (excludedAnswerIds.includes(parsed.answerId)) {
+      showSnackbar('この回答は既に関連付けられています。', 'error');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const result = await addRelatedAnswer(parsed.formId, parsed.answerId);
+    setIsSubmitting(false);
+
+    if (result.ok) {
+      setUrl('');
+    } else if (result.forbidden) {
+      showSnackbar('関連付けを追加する権限がありません。', 'error');
+    } else {
+      showSnackbar(
+        '追加に失敗しました。URLが正しいかご確認ください。',
+        'error'
+      );
+    }
+  };
+
+  return (
+    <>
+      <TextField
+        label="回答のURLを貼り付けて追加"
+        size="small"
+        value={url}
+        onChange={(event) => {
+          setUrl(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !isSubmitting) {
+            event.preventDefault();
+            void handleSubmit();
+          }
+        }}
+        disabled={isSubmitting}
+        sx={{ minWidth: 280 }}
+        slotProps={{
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="追加"
+                  size="small"
+                  disabled={isSubmitting || url.trim() === ''}
+                  onClick={() => {
+                    void handleSubmit();
+                  }}
+                >
+                  <AddIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+      <SnackbarAlert
+        open={snackbar.open}
+        message={snackbar.message}
+        severity={snackbar.severity}
+        onClose={closeSnackbar}
+      />
+    </>
+  );
+};
+
+export default AdminRelatedAnswerUrlAdder;

--- a/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/AnswerMeta.tsx
@@ -51,7 +51,7 @@ const AuthorName = ({ author }: { author: Author }) => {
   return <Typography>{author.user.name}</Typography>;
 };
 
-const AnswerPublicationChip = ({
+export const AnswerPublicationChip = ({
   publication,
 }: {
   publication: GetAnswerResponse['publication'];

--- a/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/RelatedAnswerItem.tsx
@@ -1,28 +1,34 @@
 'use client';
 
-import { Chip } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  IconButton,
+  ListItem,
+  ListItemButton,
+  Stack,
+  Typography,
+} from '@mui/material';
 import Link from 'next/link';
 
 import { useApiQuery } from '@/app/_swr/useApiQuery';
+import { formatString } from '@/generic/DateFormatter';
 import type { RelatedAnswerResponse } from '@/lib/api-types';
 import { resolveAnswerTitle } from '@/lib/forms/answerTitle';
+
+import { AnswerPublicationChip } from './AnswerMeta';
+import AnswerStatusChip from './AnswerStatusChip';
 
 const RelatedAnswerItem = ({
   relation,
   isAdmin,
   onRemove,
+  divider,
 }: {
   relation: RelatedAnswerResponse;
   isAdmin: boolean;
   onRemove?: (() => void) | undefined;
+  divider: boolean;
 }) => {
-  const handleDelete = onRemove
-    ? (event: React.SyntheticEvent) => {
-        event.preventDefault();
-        onRemove();
-      }
-    : undefined;
-
   const answerQuery = useApiQuery(
     '/api/v1/forms/{form_id}/answers/{answer_id}',
     {
@@ -31,19 +37,46 @@ const RelatedAnswerItem = ({
   );
 
   const href = `${isAdmin ? '/admin' : ''}/forms/${relation.form_id}/answers/${relation.answer_id}`;
-  const label = answerQuery.data
-    ? resolveAnswerTitle(answerQuery.data.title)
-    : '読み込み中...';
+  const data = answerQuery.data;
+  const label = data ? resolveAnswerTitle(data.title) : '読み込み中...';
 
   return (
-    <Chip
-      component={Link}
-      href={href}
-      label={label}
-      clickable
-      variant="outlined"
-      onDelete={handleDelete}
-    />
+    <ListItem
+      disablePadding
+      divider={divider}
+      secondaryAction={
+        onRemove ? (
+          <IconButton
+            edge="end"
+            aria-label="関連付けを解除"
+            onClick={() => {
+              onRemove();
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        ) : undefined
+      }
+    >
+      <ListItemButton
+        component={Link}
+        href={href}
+        sx={{ pr: onRemove ? 6 : 2 }}
+      >
+        <Stack spacing={0.5} sx={{ width: '100%', py: 0.5 }}>
+          <Typography variant="body2">{label}</Typography>
+          {data && (
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+              <AnswerStatusChip status={data.status} />
+              <AnswerPublicationChip publication={data.publication} />
+              <Typography variant="caption" color="textSecondary">
+                {formatString(data.timestamp)}
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      </ListItemButton>
+    </ListItem>
   );
 };
 

--- a/src/app/(protected)/_components/AnswerDetail/RelatedAnswers.tsx
+++ b/src/app/(protected)/_components/AnswerDetail/RelatedAnswers.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Stack, Typography } from '@mui/material';
+import { List, Stack, Typography } from '@mui/material';
 
 import { useRelatedAnswerActions } from '@/hooks/useRelatedAnswerActions';
 import type { RelatedAnswerResponse } from '@/lib/api-types';
 
 import AdminRelatedAnswerAdder from './AdminRelatedAnswerAdder';
+import AdminRelatedAnswerUrlAdder from './AdminRelatedAnswerUrlAdder';
 import RelatedAnswerItem from './RelatedAnswerItem';
 
 const RelatedAnswers = ({
@@ -20,21 +21,40 @@ const RelatedAnswers = ({
   answerId: string;
 }) => {
   const { removeRelatedAnswer } = useRelatedAnswerActions(formId, answerId);
+  const excludedAnswerIds = relations.map((relation) => relation.answer_id);
 
   return (
     <Stack spacing={1}>
       <Typography variant="subtitle1">関連する回答</Typography>
+      {isAdmin && (
+        <Stack spacing={1}>
+          <AdminRelatedAnswerAdder
+            formId={formId}
+            answerId={answerId}
+            excludedAnswerIds={excludedAnswerIds}
+          />
+          <AdminRelatedAnswerUrlAdder
+            formId={formId}
+            answerId={answerId}
+            excludedAnswerIds={excludedAnswerIds}
+          />
+        </Stack>
+      )}
       {relations.length === 0 ? (
         <Typography color="textSecondary">
           関連付けられた回答はありません
         </Typography>
       ) : (
-        <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
-          {relations.map((relation) => (
+        <List
+          disablePadding
+          sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}
+        >
+          {relations.map((relation, index) => (
             <RelatedAnswerItem
               key={`${relation.form_id}:${relation.answer_id}`}
               relation={relation}
               isAdmin={isAdmin}
+              divider={index < relations.length - 1}
               onRemove={
                 isAdmin
                   ? () => {
@@ -44,14 +64,7 @@ const RelatedAnswers = ({
               }
             />
           ))}
-        </Stack>
-      )}
-      {isAdmin && (
-        <AdminRelatedAnswerAdder
-          formId={formId}
-          answerId={answerId}
-          excludedAnswerIds={relations.map((relation) => relation.answer_id)}
-        />
+        </List>
       )}
     </Stack>
   );

--- a/tests/component/RelatedAnswers.test.tsx
+++ b/tests/component/RelatedAnswers.test.tsx
@@ -1,0 +1,292 @@
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import RelatedAnswers from '@/app/(protected)/_components/AnswerDetail/RelatedAnswers';
+import type { RelatedAnswerResponse } from '@/lib/api-types';
+
+import { renderWithProviders, screen, within } from './render';
+
+const useApiQueryMock =
+  vi.fn<
+    (path: string, params?: unknown) => { data: unknown; isLoading: boolean }
+  >();
+vi.mock('@/app/_swr/useApiQuery', () => ({
+  useApiQuery: (path: string, params?: unknown) =>
+    useApiQueryMock(path, params),
+}));
+
+const addRelatedAnswerMock = vi.fn().mockResolvedValue({ ok: true });
+const removeRelatedAnswerMock = vi.fn().mockResolvedValue({ ok: true });
+vi.mock('@/hooks/useRelatedAnswerActions', () => ({
+  useRelatedAnswerActions: () => ({
+    addRelatedAnswer: addRelatedAnswerMock,
+    removeRelatedAnswer: removeRelatedAnswerMock,
+  }),
+}));
+
+const relations: RelatedAnswerResponse[] = [
+  { form_id: 'form-id', answer_id: 'related-1' },
+  { form_id: 'form-id', answer_id: 'related-2' },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  useApiQueryMock.mockReset();
+});
+
+describe('RelatedAnswers のレイアウト', () => {
+  it('管理者向けの追加UIが関連回答の一覧より前に配置される', () => {
+    useApiQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={relations}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const container = screen.getByText('関連する回答').parentElement;
+    if (!container) {
+      throw new Error('container not found');
+    }
+    const html = container.innerHTML;
+    const adderIndex = html.indexOf('関連付ける回答を検索');
+    const urlAdderIndex = html.indexOf('回答のURLを貼り付けて追加');
+    const listItemIndex = html.indexOf('related-1');
+
+    expect(adderIndex).toBeGreaterThan(-1);
+    expect(urlAdderIndex).toBeGreaterThan(-1);
+    expect(adderIndex).toBeLessThan(
+      listItemIndex === -1 ? Infinity : listItemIndex
+    );
+    expect(urlAdderIndex).toBeLessThan(
+      listItemIndex === -1 ? Infinity : listItemIndex
+    );
+  });
+});
+
+describe('RelatedAnswerItem の一覧表示', () => {
+  it('関連付け済みの回答をタイトル・ステータス・公開設定・日時付きの行で表示する', async () => {
+    useApiQueryMock.mockImplementation((path, params) => {
+      const answerId =
+        params &&
+        typeof params === 'object' &&
+        'path' in params &&
+        params.path &&
+        typeof params.path === 'object' &&
+        'answer_id' in params.path
+          ? params.path.answer_id
+          : undefined;
+      if (
+        path === '/api/v1/forms/{form_id}/answers/{answer_id}' &&
+        answerId === 'related-1'
+      ) {
+        return {
+          data: {
+            title: '関連回答A',
+            status: 'COMPLETED',
+            publication: 'PRIVATE',
+            timestamp: '2024-01-01T00:00:00Z',
+          },
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[{ form_id: 'form-id', answer_id: 'related-1' }]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    expect(await screen.findByText('関連回答A')).toBeVisible();
+    expect(screen.getByText('対応済み')).toBeVisible();
+    expect(screen.getByText('非公開')).toBeVisible();
+  });
+
+  it('削除ボタンをクリックしてもリンク遷移せず削除処理のみ呼ばれる', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockReturnValue({
+      data: {
+        title: '関連回答A',
+        status: 'COMPLETED',
+        publication: 'PUBLIC',
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[{ form_id: 'form-id', answer_id: 'related-1' }]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    await user.click(
+      await screen.findByRole('button', { name: '関連付けを解除' })
+    );
+
+    expect(removeRelatedAnswerMock).toHaveBeenCalledWith('related-1');
+  });
+});
+
+describe('AdminRelatedAnswerAdder の検索候補表示', () => {
+  it('未入力時は日本語の案内文を表示する(MUI既定の "No options" にしない)', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const input = screen.getByLabelText('関連付ける回答を検索');
+    await user.click(input);
+
+    expect(
+      await screen.findByText('キーワードを入力すると候補が表示されます')
+    ).toBeVisible();
+  });
+
+  it('検索候補にステータス・公開設定・日時を表示する', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockImplementation((path, params) => {
+      if (path === '/api/v1/search/answers' && params !== null) {
+        return {
+          data: {
+            answers: [
+              {
+                id: 'candidate-1',
+                form_id: 'form-id',
+                title: '候補の回答',
+                status: 'IN_PROGRESS',
+                publication: 'PRIVATE',
+                timestamp: '2024-01-01T00:00:00Z',
+                labels: [],
+                answers: [],
+                author: { type: 'ANONYMOUS' },
+              },
+            ],
+          },
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const input = screen.getByLabelText('関連付ける回答を検索');
+    await user.type(input, '候補');
+
+    const option = await screen.findByRole(
+      'option',
+      { name: /候補の回答/ },
+      { timeout: 2000 }
+    );
+    expect(within(option).getByText('対応中')).toBeVisible();
+    expect(within(option).getByText('非公開')).toBeVisible();
+  });
+});
+
+describe('AdminRelatedAnswerUrlAdder', () => {
+  it('不正なURLを入力するとエラーメッセージを表示し、追加処理は呼ばれない', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const input = screen.getByLabelText('回答のURLを貼り付けて追加');
+    await user.type(input, 'https://example.com/not-an-answer-url');
+    await user.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(
+      await screen.findByText(
+        '回答の詳細ページのURLを正しく貼り付けてください。'
+      )
+    ).toBeVisible();
+    expect(addRelatedAnswerMock).not.toHaveBeenCalled();
+  });
+
+  it('正しいURLを入力すると解析したform_id/answer_idで追加処理を呼ぶ', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={[]}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const input = screen.getByLabelText('回答のURLを貼り付けて追加');
+    await user.type(
+      input,
+      'https://portal.example.com/admin/forms/target-form/answers/target-answer'
+    );
+    await user.click(screen.getByRole('button', { name: '追加' }));
+
+    await vi.waitFor(() => {
+      expect(addRelatedAnswerMock).toHaveBeenCalledWith(
+        'target-form',
+        'target-answer'
+      );
+    });
+    expect(input).toHaveValue('');
+  });
+
+  it('既に関連付け済みの回答IDを含むURLを入力するとエラーメッセージを表示する', async () => {
+    const user = userEvent.setup();
+    useApiQueryMock.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(
+      <RelatedAnswers
+        relations={relations}
+        isAdmin
+        formId="form-id"
+        answerId="answer-id"
+      />
+    );
+
+    const input = screen.getByLabelText('回答のURLを貼り付けて追加');
+    await user.type(
+      input,
+      'https://portal.example.com/admin/forms/form-id/answers/related-1'
+    );
+    await user.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(
+      await screen.findByText('この回答は既に関連付けられています。')
+    ).toBeVisible();
+    expect(addRelatedAnswerMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
- 関連回答機能のUIに、以下のUX上の問題があったため改善した
  - 検索欄が未入力の間は英語の "No options" が表示され直感的でない
  - 関連回答が増えるたびに検索欄・コメント欄が下に押し出される
  - 検索候補・関連付け済みの回答がタイトルしかわからず、状態や公開設定が確認できない
  - 関連付けたい回答のIDがわかっていても直接指定して追加する手段がない
- 対応内容
  - 検索候補の未入力時/該当なし時のメッセージを日本語化(`AdminRelatedAnswerAdder.tsx`)
  - 検索欄・追加UIをチップ一覧より前の固定位置へ移動し、関連回答が増えても位置が動かないようにした(`RelatedAnswers.tsx`)
  - 検索候補・関連付け済み一覧の双方にステータス・公開設定・日時を表示(`AnswerStatusChip`/`AnswerPublicationChip`を再利用)
  - 回答詳細ページのURLを貼り付けてID指定で追加できる `AdminRelatedAnswerUrlAdder` を新規追加
  - 関連付け済みの一覧をチップの折り返し表示から `List`/`ListItemButton` によるリスト表示に変更し、行クリックで詳細へ、削除ボタンは `secondaryAction` として分離(構造上リンク遷移と競合しない)

## 確認事項
- `pnpm tsc --noEmit` / `pnpm lint` / `pnpm exec vitest run --config vitest.component.config.ts` をすべて実行し、既存26ファイル・110件超のコンポーネントテストと新規追加分がすべて成功することを確認した
- 新規コンポーネント向けに `tests/component/RelatedAnswers.test.tsx` を追加し、以下を検証している
  - 追加UIがチップ一覧より前に配置されること(レイアウト順序)
  - 検索候補未入力時の日本語メッセージ表示
  - 検索候補・関連付け済み一覧にステータス/公開設定が表示されること
  - URL貼り付け追加の異常系(不正URL、自己参照、重複)とID解析結果でのPOST呼び出し
  - 削除ボタンをクリックしてもリンク遷移せず削除処理のみ呼ばれること
- 実ブラウザでの目視確認は、この環境でPlaywrightのChromiumが起動できなかった(共有ライブラリ不足)ため実施できていない。レイアウト・アイコン配置周りは実際の画面での見た目チェックをレビュアーにお願いしたい

## 補足
- なし

🤖 Generated with Claude Code