### PR TITLE
fix: 管理者UIをスマホ幅で操作できるようにする

### DIFF
--- a/src/app/(protected)/_components/AnswersList/AnswerLabelFilter.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswerLabelFilter.tsx
@@ -14,7 +14,11 @@ const AnswerLabelFilter = (props: {
       id="answer-label-filter"
       options={props.labelOptions.map((label) => label.name)}
       getOptionLabel={(option) => option}
-      sx={{ minWidth: 240, flexGrow: 1 }}
+      sx={{
+        minWidth: { xs: 0, sm: 240 },
+        width: { xs: '100%', sm: 'auto' },
+        flexGrow: 1,
+      }}
       slotProps={{
         listbox: {
           sx: {

--- a/src/app/(protected)/_components/AnswersList/AnswersView.tsx
+++ b/src/app/(protected)/_components/AnswersList/AnswersView.tsx
@@ -142,7 +142,7 @@ const AnswersView = ({
   );
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box sx={{ width: '100%', minWidth: 0 }}>
       <Box
         sx={{
           display: 'flex',
@@ -156,7 +156,14 @@ const AnswersView = ({
         <Typography variant="h5" component="h1">
           {formTitle}
         </Typography>
-        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          sx={{
+            alignItems: { xs: 'stretch', sm: 'center' },
+            width: { xs: '100%', sm: 'auto' },
+          }}
+        >
           <TextField
             variant="standard"
             size="small"
@@ -165,7 +172,10 @@ const AnswersView = ({
             onChange={(e) => {
               onSearchChange(e.target.value);
             }}
-            sx={{ minWidth: 240 }}
+            sx={{
+              minWidth: { xs: 0, sm: 240 },
+              width: { xs: '100%', sm: 'auto' },
+            }}
             slotProps={{
               input: {
                 startAdornment: (

--- a/src/app/(protected)/admin/_components/AdminShell.tsx
+++ b/src/app/(protected)/admin/_components/AdminShell.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useState, type ReactNode } from 'react';
+
+import NavBar from '@/app/_components/NavBar';
+
+import styles from '../../../page.module.css';
+
+import DashboardMenu from './DashboardMenu';
+
+type AdminShellProps = {
+  searchSlot: ReactNode;
+  children: ReactNode;
+};
+
+const AdminShell = ({ searchSlot, children }: AdminShellProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <>
+      <NavBar
+        homeHref="/admin"
+        searchSlot={searchSlot}
+        withDrawerZIndex
+        {...(isMobile && {
+          onMenuButtonClick: () => {
+            setMobileOpen((prev) => !prev);
+          },
+        })}
+      />
+      <main className={styles['main']}>
+        <DashboardMenu
+          variant={isMobile ? 'temporary' : 'permanent'}
+          open={isMobile ? mobileOpen : true}
+          {...(isMobile && {
+            onClose: () => {
+              setMobileOpen(false);
+            },
+          })}
+        />
+        {children}
+      </main>
+    </>
+  );
+};
+
+export default AdminShell;

--- a/src/app/(protected)/admin/_components/Dashboard.tsx
+++ b/src/app/(protected)/admin/_components/Dashboard.tsx
@@ -132,7 +132,7 @@ const DataTable = (props: {
   };
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box sx={{ width: '100%', minWidth: 0 }}>
       <Stack spacing={1.5} sx={{ mb: 2 }}>
         <Typography variant="h5" component="h1">
           回答一覧
@@ -150,7 +150,10 @@ const DataTable = (props: {
             onChange={(e) => {
               handleSearchChange(e.target.value);
             }}
-            sx={{ minWidth: 240 }}
+            sx={{
+              minWidth: { xs: 0, sm: 240 },
+              width: { xs: '100%', sm: 'auto' },
+            }}
             slotProps={{
               input: {
                 startAdornment: (

--- a/src/app/(protected)/admin/_components/DashboardDateRangeFilter.tsx
+++ b/src/app/(protected)/admin/_components/DashboardDateRangeFilter.tsx
@@ -19,7 +19,14 @@ const DashboardDateRangeFilter = ({
 }) => {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1}
+        sx={{
+          alignItems: { xs: 'stretch', sm: 'center' },
+          width: { xs: '100%', sm: 'auto' },
+        }}
+      >
         <DatePicker
           label="開始日"
           value={startDate}
@@ -28,7 +35,10 @@ const DashboardDateRangeFilter = ({
             textField: { variant: 'standard', size: 'small' },
             field: { clearable: true },
           }}
-          sx={{ minWidth: 160 }}
+          sx={{
+            minWidth: { xs: 0, sm: 160 },
+            width: { xs: '100%', sm: 'auto' },
+          }}
         />
         <DatePicker
           label="終了日"
@@ -38,7 +48,10 @@ const DashboardDateRangeFilter = ({
             textField: { variant: 'standard', size: 'small' },
             field: { clearable: true },
           }}
-          sx={{ minWidth: 160 }}
+          sx={{
+            minWidth: { xs: 0, sm: 160 },
+            width: { xs: '100%', sm: 'auto' },
+          }}
         />
       </Stack>
     </LocalizationProvider>

--- a/src/app/(protected)/admin/_components/DashboardFormFilter.tsx
+++ b/src/app/(protected)/admin/_components/DashboardFormFilter.tsx
@@ -14,7 +14,11 @@ const DashboardFormFilter = (props: {
       id="dashboard-form-filter"
       options={props.formOptions.map((form) => form.title)}
       getOptionLabel={(option) => option}
-      sx={{ minWidth: 240, flexGrow: 1 }}
+      sx={{
+        minWidth: { xs: 0, sm: 240 },
+        width: { xs: '100%', sm: 'auto' },
+        flexGrow: 1,
+      }}
       slotProps={{
         listbox: {
           sx: {

--- a/src/app/(protected)/admin/_components/DashboardMenu.tsx
+++ b/src/app/(protected)/admin/_components/DashboardMenu.tsx
@@ -66,7 +66,13 @@ const MENU_ITEMS: MenuNode[] = [
   { label: 'Webhooks', url: '/admin/webhooks', icon: <Star /> },
 ];
 
-const DashboardMenu = () => {
+type DashboardMenuProps = {
+  variant: 'permanent' | 'temporary';
+  open?: boolean;
+  onClose?: () => void;
+};
+
+const DashboardMenu = ({ variant, open, onClose }: DashboardMenuProps) => {
   const [expandedUrls, setExpandedUrls] = useState<ReadonlySet<string>>(
     new Set()
   );
@@ -85,9 +91,12 @@ const DashboardMenu = () => {
 
   return (
     <Drawer
-      variant="permanent"
+      variant={variant}
+      open={open}
+      onClose={onClose}
+      ModalProps={variant === 'temporary' ? { keepMounted: true } : undefined}
       sx={{
-        width: AUTCHED_DRAWER_WIDTH_PX,
+        ...(variant === 'permanent' && { width: AUTCHED_DRAWER_WIDTH_PX }),
         [`& .MuiDrawer-paper`]: {
           width: AUTCHED_DRAWER_WIDTH_PX,
           boxSizing: 'border-box',
@@ -109,6 +118,9 @@ const DashboardMenu = () => {
                 <Box
                   component={NextLink}
                   href={item.url}
+                  onClick={() => {
+                    onClose?.();
+                  }}
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
@@ -154,6 +166,9 @@ const DashboardMenu = () => {
                         key={child.url}
                         component={NextLink}
                         href={child.url}
+                        onClick={() => {
+                          onClose?.();
+                        }}
                         sx={{
                           color: 'text.primary',
                           textDecoration: 'none',

--- a/src/app/(protected)/admin/_components/SearchField.tsx
+++ b/src/app/(protected)/admin/_components/SearchField.tsx
@@ -57,7 +57,8 @@ const SearchField = () => {
         p: '2px 4px',
         display: 'flex',
         alignItems: 'center',
-        width: 400,
+        width: { xs: 140, sm: 260, md: 400 },
+        minWidth: 0,
         backgroundColor: alpha(theme.palette.common.white, 0.85),
         border: `1px solid ${alpha(theme.palette.text.primary, 0.2)}`,
         ...theme.applyStyles('dark', {

--- a/src/app/(protected)/admin/forms/_components/FormsList/FormLabelFilter.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsList/FormLabelFilter.tsx
@@ -14,7 +14,11 @@ const FormLabelFilter = (props: {
       id="label"
       options={props.labelOptions.map((label) => label.name)}
       getOptionLabel={(option) => option}
-      sx={{ minWidth: 280, flexGrow: 1 }}
+      sx={{
+        minWidth: { xs: 0, sm: 280 },
+        width: { xs: '100%', sm: 'auto' },
+        flexGrow: 1,
+      }}
       slotProps={{
         listbox: {
           sx: {

--- a/src/app/(protected)/admin/forms/_components/FormsList/FormsToolbar.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormsList/FormsToolbar.tsx
@@ -25,14 +25,18 @@ const FormsToolbar = ({
 }: Props) => {
   return (
     <Stack
-      direction="row"
+      direction={{ xs: 'column', sm: 'row' }}
       spacing={2}
-      sx={{ alignItems: 'center', width: '100%' }}
+      sx={{ alignItems: { xs: 'stretch', sm: 'center' }, width: '100%' }}
     >
       <Stack
-        direction="row"
+        direction={{ xs: 'column', sm: 'row' }}
         spacing={2}
-        sx={{ alignItems: 'center', flexGrow: 1, minWidth: 0 }}
+        sx={{
+          alignItems: { xs: 'stretch', sm: 'center' },
+          flexGrow: 1,
+          minWidth: 0,
+        }}
       >
         <TextField
           variant="standard"
@@ -42,7 +46,10 @@ const FormsToolbar = ({
           onChange={(e) => {
             onTitleSearchChange(e.target.value);
           }}
-          sx={{ minWidth: 200 }}
+          sx={{
+            minWidth: { xs: 0, sm: 200 },
+            width: { xs: '100%', sm: 'auto' },
+          }}
           slotProps={{
             input: {
               startAdornment: (
@@ -58,9 +65,17 @@ const FormsToolbar = ({
           setLabelFilter={onLabelFilterChange}
         />
       </Stack>
-      <Divider orientation="vertical" flexItem />
+      <Divider
+        orientation="vertical"
+        flexItem
+        sx={{ display: { xs: 'none', sm: 'block' } }}
+      />
       <ToManageFormLabelButton />
-      <Divider orientation="vertical" flexItem />
+      <Divider
+        orientation="vertical"
+        flexItem
+        sx={{ display: { xs: 'none', sm: 'block' } }}
+      />
       <FormCreateButton />
     </Stack>
   );

--- a/src/app/(protected)/admin/layout.tsx
+++ b/src/app/(protected)/admin/layout.tsx
@@ -1,12 +1,9 @@
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
-import NavBar from '@/app/_components/NavBar';
 import { getAdminAccess } from '@/lib/server/session';
 
-import styles from '../../page.module.css';
-
-import DashboardMenu from './_components/DashboardMenu';
+import AdminShell from './_components/AdminShell';
 import SearchField from './_components/SearchField';
 
 const RootLayout = async ({ children }: { children: ReactNode }) => {
@@ -16,15 +13,7 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
     redirect('/home?accessDenied=admin');
   }
 
-  return (
-    <>
-      <NavBar homeHref="/admin" searchSlot={<SearchField />} withDrawerZIndex />
-      <main className={styles['main']}>
-        <DashboardMenu />
-        {children}
-      </main>
-    </>
-  );
+  return <AdminShell searchSlot={<SearchField />}>{children}</AdminShell>;
 };
 
 export default RootLayout;

--- a/src/app/(protected)/admin/users/_components/UsersTable/UserListHeader.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersTable/UserListHeader.tsx
@@ -42,7 +42,11 @@ const UserListHeader = ({
       onChange={(e) => {
         onSearchChange(e.target.value);
       }}
-      sx={{ minWidth: 240, ml: 'auto' }}
+      sx={{
+        minWidth: { xs: 0, sm: 240 },
+        width: { xs: '100%', sm: 'auto' },
+        ml: { xs: 0, sm: 'auto' },
+      }}
       slotProps={{
         input: {
           startAdornment: (

--- a/src/app/(protected)/admin/users/_components/UsersTable/UsersView.tsx
+++ b/src/app/(protected)/admin/users/_components/UsersTable/UsersView.tsx
@@ -29,7 +29,7 @@ const UsersView = ({
   autoOpenUserId?: string | null;
 }) => {
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, minWidth: 0 }}>
       <UserListHeader
         count={rows.length}
         search={search}
@@ -45,7 +45,7 @@ const UsersView = ({
             sx={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1 }}
           />
         )}
-        <Table sx={{ tableLayout: 'fixed' }}>
+        <Table sx={{ tableLayout: 'fixed', minWidth: 560 }}>
           <TableHead>
             <TableRow sx={{ '& th': { fontWeight: 'bold' } }}>
               <TableCell sx={{ width: '32%' }}>ユーザー</TableCell>

--- a/src/app/_components/NavBar.tsx
+++ b/src/app/_components/NavBar.tsx
@@ -3,6 +3,7 @@
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import HomeIcon from '@mui/icons-material/Home';
 import LogoutIcon from '@mui/icons-material/Logout';
+import MenuIcon from '@mui/icons-material/Menu';
 import PersonIcon from '@mui/icons-material/Person';
 import {
   Box,
@@ -167,12 +168,14 @@ type NavBarProps = {
   homeHref?: string;
   searchSlot?: ReactNode;
   withDrawerZIndex?: boolean;
+  onMenuButtonClick?: () => void;
 };
 
 const NavBar = ({
   homeHref = '/',
   searchSlot,
   withDrawerZIndex = false,
+  onMenuButtonClick,
 }: NavBarProps) => {
   const user = useOptionalCurrentUser();
 
@@ -187,13 +190,28 @@ const NavBar = ({
         }
       >
         <Toolbar>
+          {onMenuButtonClick && (
+            <IconButton
+              color="inherit"
+              aria-label="サイドメニューを開く"
+              onClick={onMenuButtonClick}
+              sx={{ mr: 1 }}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
           <Image
             src="/favicon.ico"
             width={48}
             height={48}
             alt="seichi-portal logo"
           />
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <Typography
+            variant="h6"
+            component="div"
+            noWrap
+            sx={{ flexGrow: 1, minWidth: 0 }}
+          >
             <Link
               component={NextLink}
               href={homeHref}


### PR DESCRIPTION
## 概要
- 管理者用サイドバー(Drawer)が`variant="permanent"`固定で常時展開されており、スマホ幅では本文が押しつぶされて操作できなかった。
- `md`未満では`temporary` Drawerに切り替え、NavBar左端のハンバーガーメニューで開閉できるようにした（メニュー項目クリックで自動的に閉じる）。デスクトップ(`md`以上)の見た目・挙動は変更していない。
- サイドバー修正後に見えてきた同種の問題（固定`minWidth`のコンポーネントがrow並びでモバイル幅を超えて見切れる、DataGrid/Tableの列幅で親要素が`minWidth:0`を持たずページ全体が横スクロールする）を admin 配下で洗い出し、まとめて修正した。対象: 検索欄・ラベルフィルタ・日付範囲フィルタ・ユーザー一覧テーブルなど。

## 確認事項
- `pnpm type-check` / `pnpm lint` / `pnpm exec prettier --check` を実行し、いずれも成功を確認した。
- コミット時の pre-commit フック（lint / type-check / fmt）、push時の pre-push フック（unit test 116件）がいずれも成功した。
- 実機・ブラウザでの見た目確認はユーザー側で実施し、フィードバックを受けて反復修正した（サイドバー開閉→検索欄→回答一覧のラベルフィルタ→ダッシュボードの日付範囲→ユーザー一覧テーブルの順に発見・修正）。
- `AnswersView`/`Dashboard`/`UsersView`は`(standard)`一般ユーザー側とも共通のコンポーネントを含むため、レビューでは admin 以外の画面（回答一覧など）で表示崩れがないかも見てほしい。

## 補足
- `src/app/page.module.css`の`.main`（`padding: 6rem`固定）は`(public)`レイアウトと共有のため今回は変更していない。個別コンポーネント側のレスポンシブ対応で吸収した。
- フォーム編集画面（`QuestionList`/`ChoiceEditor`/`FormSettings`など）や`groups`/`search`ページは、今回発見した「固定`minWidth`」の兆候が見当たらなかったため対象外にしている。

🤖 Generated with Claude Code