### PR TITLE
fix: フォーム一覧のクリック領域をカード全体に広げる

### DIFF
--- a/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
+++ b/src/app/(protected)/(standard)/forms/_components/FormsView.tsx
@@ -5,11 +5,11 @@ import {
   Box,
   Button,
   Card,
+  CardActionArea,
   CardActions,
   CardContent,
   Chip,
   Grid,
-  Link,
   Typography,
   Alert,
   AlertTitle,
@@ -37,38 +37,34 @@ const EachForm = ({ form }: { form: FormItem }) => {
       variant="outlined"
       sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
     >
-      <CardContent sx={{ flexGrow: 1 }}>
-        <Link
-          component={NextLink}
-          href={`/forms/${form.id}`}
-          sx={{ textDecoration: 'none', color: 'inherit' }}
-        >
+      <CardActionArea component={NextLink} href={`/forms/${form.id}`}>
+        <CardContent sx={{ flexGrow: 1 }}>
           <Typography variant="h6" component="h2" gutterBottom>
             {form.title}
           </Typography>
-        </Link>
-        <Chip
-          icon={<AccessTimeIcon />}
-          label={formatResponsePeriod(responsePeriod)}
-          size="small"
-          variant="outlined"
-          sx={{ mb: 1.5 }}
-        />
-        {form.description && (
-          <MarkdownText
-            sx={{
-              typography: 'body2',
-              color: 'text.secondary',
-              display: '-webkit-box',
-              WebkitLineClamp: 3,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-            }}
-          >
-            {form.description}
-          </MarkdownText>
-        )}
-      </CardContent>
+          <Chip
+            icon={<AccessTimeIcon />}
+            label={formatResponsePeriod(responsePeriod)}
+            size="small"
+            variant="outlined"
+            sx={{ mb: 1.5 }}
+          />
+          {form.description && (
+            <MarkdownText
+              sx={{
+                typography: 'body2',
+                color: 'text.secondary',
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {form.description}
+            </MarkdownText>
+          )}
+        </CardContent>
+      </CardActionArea>
       <CardActions>
         <Button
           component={NextLink}


### PR DESCRIPTION
## 概要
- フォーム一覧（ログイン済みユーザー向け）で、タイトルの文字部分をクリックしないと回答画面に遷移できず操作しづらかった
- `CardActionArea` でカード全体（タイトル・期限チップ・説明文）をラップし、クリック領域を広げた
- 公開フォーム一覧（`PublicFormList.tsx`）で既に採用されているのと同じパターンに揃えている
- 「回答一覧」ボタンは別遷移先（`/forms/{id}/answers/`）のため `CardActionArea` の外の `CardActions` に残し、リンクのネストを避けた

## 確認事項
- `pnpm type-check` / `pnpm eslint` を実行し、エラーがないことを確認
- `pnpm test`（コミット時の pre-push フックで自動実行）: 全123テスト成功
- 対象ページは認証必須の保護ルートのため、ブラウザでの実動作確認は未実施。レビュー時に実際のクリック領域（カード全体で `/forms/{id}` に遷移すること、回答一覧ボタンが独立して機能すること）を確認してほしい

## 補足
- 変更は `src/app/(protected)/(standard)/forms/_components/FormsView.tsx` のみ

🤖 Generated with Claude Code