### PR TITLE
fix: 管理画面のコンテンツ余白を縮小してフォーム一覧テーブルの横幅を広げる

### DIFF
--- a/src/app/(protected)/admin/_components/AdminShell.tsx
+++ b/src/app/(protected)/admin/_components/AdminShell.tsx
@@ -1,12 +1,11 @@
 'use client';
 
+import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useState, type ReactNode } from 'react';
 
 import NavBar from '@/app/_components/NavBar';
-
-import styles from '../../../page.module.css';
 
 import DashboardMenu from './DashboardMenu';
 
@@ -32,7 +31,16 @@ const AdminShell = ({ searchSlot, children }: AdminShellProps) => {
           },
         })}
       />
-      <main className={styles['main']}>
+      <Box
+        component="main"
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          minHeight: '100vh',
+          pt: { xs: 'calc(56px + 1rem)', md: 'calc(64px + 2rem)' },
+          pb: { xs: '1rem', md: '2rem' },
+        }}
+      >
         <DashboardMenu
           variant={isMobile ? 'temporary' : 'permanent'}
           open={isMobile ? mobileOpen : true}
@@ -42,8 +50,17 @@ const AdminShell = ({ searchSlot, children }: AdminShellProps) => {
             },
           })}
         />
-        {children}
-      </main>
+        <Box
+          component="div"
+          sx={{
+            flexGrow: 1,
+            minWidth: 0,
+            px: { xs: '1rem', md: '2rem' },
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
## 概要
- 管理者向けフォーム一覧テーブルの横幅が狭く見える問題を修正
- 原因: `AdminShell.tsx` が Next.js ボイラープレート由来の `page.module.css` の `.main { padding: 6rem; ... }` を流用しており、サイドバー幅（240px）に加えて上下左右96pxずつの余白がかかることでコンテンツ領域が大きく削られていた
- 一般ユーザー側レイアウト（`(protected)/(standard)/layout.tsx`、`px: 2rem` 程度）と同水準の余白に揃え、サイドバーとコンテンツを別 `Box` に分離して余白をコンテンツ側のみに適用するよう変更（サイドバーは画面端に密着する構成に変更）
- 影響範囲は管理画面（`AdminShell` を使う全ページ）のコンテンツ幅のみ。`(public)/layout.tsx` は同じ CSS ファイルを引き続き使用しており影響なし

## 確認事項
- `pnpm type-check` / `pnpm lint` / unit test（pre-push フック経由、123 件）が全て成功することを確認
- 実ブラウザでの見た目確認は、管理画面が MSAL 認証とバックエンド API に依存しており容易にモックできないため未実施。レビューで実機確認いただけると助かります

## 補足
- 特になし

🤖 Generated with Claude Code