### PR TITLE
fix: ラベルの追加・編集・削除後に一覧を動的に更新する

### DIFF
--- a/src/hooks/useLabelCRUD.ts
+++ b/src/hooks/useLabelCRUD.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useSWRConfig } from 'swr';
 
 import { useSingleFlightAction } from '@/hooks/useSingleFlightAction';
@@ -7,6 +8,7 @@ import { proxyClient } from '@/lib/proxyClient';
 
 export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
   const { mutate } = useSWRConfig();
+  const router = useRouter();
   const key =
     labelType === 'answers'
       ? ['/api/v1/labels/answers']
@@ -17,13 +19,19 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
       const { response } = await proxyClient.POST('/api/v1/labels/answers', {
         body: { name },
       });
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     } else {
       const { response } = await proxyClient.POST('/api/v1/labels/forms', {
         body: { name },
       });
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     }
   };
@@ -34,7 +42,10 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
         '/api/v1/labels/answers/{label_id}',
         { params: { path: { label_id: String(id) } } }
       );
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     } else {
       const { response } = await proxyClient.DELETE(
@@ -43,7 +54,10 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
           params: { path: { label_id: String(id) } },
         }
       );
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     }
   };
@@ -60,7 +74,10 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
           body: { name },
         }
       );
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     } else {
       const { response } = await proxyClient.PATCH(
@@ -70,7 +87,10 @@ export const useLabelCRUD = (labelType: 'answers' | 'forms') => {
           body: { name },
         }
       );
-      if (response.ok) await mutate(key);
+      if (response.ok) {
+        await mutate(key);
+        router.refresh();
+      }
       return { ok: response.ok };
     }
   };


### PR DESCRIPTION
## Summary
- ラベル(フォーム用/回答用)の追加・編集・削除後、一覧がリロードするまで更新されない不具合を修正
- 原因: ラベル一覧はサーバーコンポーネントからpropsで渡されており、CRUD後に呼んでいた SWR の `mutate` はそれを購読するコンポーネントが存在せず反映されていなかった
- 対処: `useLabelCRUD` の各操作成功時に `router.refresh()` を追加し、フォーム一覧(`FormsPageContent.tsx`)と同じ方式でサーバーコンポーネントを再フェッチするようにした

## Test plan
- [x] `tsc --noEmit` / `eslint` / unit test 通過(pre-commit, pre-push hookで確認済み)
- [ ] 管理画面でラベルの追加・編集・削除を行い、リロードなしで一覧に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)