### PR TITLE
fix: 選択肢の追加ボタンを選択肢リストの下に配置する

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/ChoiceEditor.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/ChoiceEditor.tsx
@@ -276,9 +276,6 @@ const ChoiceEditor = (props: ChoiceEditorProps) => {
       />
       {questionType !== 'Text' && (
         <>
-          <Button variant="outlined" startIcon={<Add />} onClick={appendChoice}>
-            選択肢の追加
-          </Button>
           <SortableChoiceList
             choiceFields={choiceFields}
             questionIndex={props.questionIndex}
@@ -288,6 +285,9 @@ const ChoiceEditor = (props: ChoiceEditorProps) => {
             removeChoice={removeChoice}
             appendChoice={appendChoice}
           />
+          <Button variant="outlined" startIcon={<Add />} onClick={appendChoice}>
+            選択肢の追加
+          </Button>
         </>
       )}
     </>


### PR DESCRIPTION
## 概要
- フォーム作成画面の質問編集で、「選択肢の追加」ボタンが選択肢リストの上に表示されており、新しい選択肢が末尾に追加されてもボタンの位置が変わらず操作の流れがわかりにくかった
- `ChoiceEditor.tsx` の描画順を変更し、選択肢リストの下にボタンを表示するようにした
- 選択肢を配列末尾へ追加する処理（`useFieldArray` の `append`）自体は変更していない

## 確認事項
- `eslint` / `tsc --noEmit` / `prettier --check` を実行し、いずれもエラーなし
- pre-push フックの単体テスト（vitest, 123件）が全て通過

## 補足
- 表示位置のみの変更で、UI の見た目・操作フロー以外への影響はない

🤖 Generated with Claude Code