### PR TITLE
fix: フォーム編集・作成画面をスマホ幅で操作しやすくする

### DIFF
--- a/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
+++ b/src/app/(protected)/admin/forms/_components/FormEditor/FormSettings.tsx
@@ -169,7 +169,7 @@ const AcceptancePeriodSettings = ({
         }
       />
       {hasAcceptancePeriod && (
-        <Stack direction="row" spacing={2}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
           <Stack spacing={0.5} sx={{ flex: 1 }}>
             <FieldLabel label="回答開始日" required />
             <TextField

--- a/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
+++ b/src/app/(protected)/admin/forms/create/_components/FormCreateForm.tsx
@@ -79,6 +79,7 @@ const FormCreateForm = (props: {
   return (
     <Container
       component="form"
+      disableGutters
       onSubmit={(e) => {
         void handleSubmit(createForm)(e);
       }}

--- a/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
+++ b/src/app/(protected)/admin/forms/edit/[id]/_components/FormEditForm.tsx
@@ -88,6 +88,7 @@ const FormEditForm = (props: {
   return (
     <Container
       component="form"
+      disableGutters
       onSubmit={(e) => {
         void handleSubmit(onSubmit)(e);
       }}


### PR DESCRIPTION
## 概要
- スマホ幅でフォーム編集・作成画面を開くと、フォーム設定カードの左右余白が過大になり、実質的な操作幅が画面の半分程度まで狭くなっていた
- 原因は `AdminShell` の左右パディング・`Container` のデフォルトガター・`CardContent` の内部パディングが三重に重なっていたこと。`FormEditForm.tsx` / `FormCreateForm.tsx` の `Container` に `disableGutters` を指定し、`AdminShell` と重複していたガター分を解消した
- あわせて `FormSettings.tsx` の回答期間（開始日・終了日）入力欄が xs 幅でも横並びのままだったため、`Stack` の `direction` を `{ xs: 'column', sm: 'row' }` にして縦積みに変更した

## 確認事項
- `tsc --noEmit` / `eslint` / `prettier --check`（pre-commit hook経由）/ 単体テスト（pre-push hook経由、123件）はすべて通過
- 実ブラウザでの見た目確認は未実施。対象ルートは MSAL 認証必須の保護ルートで、この環境からは Microsoft ログインに到達できずスマホ幅でのスクリーンショット確認ができなかった
- 手計算では、スマホ幅(390px前後)での左右余白合計が約96px(画面の約24%)から約64px(約16%)に減る見込み。実機での見た目確認をお願いしたい

## 補足
- デスクトップ幅では `Container` の `maxWidth="lg"` によるセンタリングは維持されるため、広い画面での見た目への影響はない想定

🤖 Generated with Claude Code