### PR TITLE
fix: 回答フォームなど公開ページ全体の余白をスマホ幅に合わせて縮小する

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,8 +1,20 @@
 .main {
   display: flex;
   flex-direction: row;
-  padding: 6rem;
+  padding: 1rem;
   min-height: 100vh;
+}
+
+@media (min-width: 600px) {
+  .main {
+    padding: 2rem;
+  }
+}
+
+@media (min-width: 900px) {
+  .main {
+    padding: 6rem;
+  }
 }
 
 .description {


### PR DESCRIPTION
## 概要
- `src/app/page.module.css` は `create-next-app` のボイラープレートの残骸で、`.main` に PC 向けの `padding: 6rem`(96px) が画面幅に関係なく固定でかかっていた
- `(public)/layout.tsx` がこの `.main` で回答フォームを含む公開ページ全体を包んでいるため、375px幅のスマホでも左右合計192pxが余白に消え、フォーム本体(`AnswerForm.tsx` の `maxWidth: 800` のBox)が使える実質幅が183px程度まで狭くなっていた
- 画面幅に応じて `xs: 1rem` / `sm(600px以上): 2rem` / `md(900px以上): 6rem` と段階的に変える形にし、PC表示(900px以上)は変更せずスマホ・タブレットの余白のみ縮小した

## 確認事項
- `tsc --noEmit` / `prettier --check`（pre-commit hook経由）/ 単体テスト（pre-push hook経由、123件）はすべて通過
- 実ブラウザでの見た目確認は未実施。対象の回答フォーム画面はバックエンドAPIから実データを取得する作りで、この環境からは実バックエンドに到達できずローカルでの再現ができなかった
- `AnswerForm.tsx`側が既に `width: '100%'` で親幅に追従する実装になっていることはコードで確認済みのため、今回の余白修正のみで改善する見込み

## 補足
- 同じCSSファイル内の `.description` / `.grid` / `.card` などのクラスは `(public)/layout.tsx` から参照されておらず、boilerplateの死んだコードとして残っている。今回のスコープ外のため未対応

🤖 Generated with Claude Code