### PR TITLE
fix: 複数選択・単一選択で同じラベルの選択肢が連動選択される不具合を修正

### DIFF
--- a/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
+++ b/src/app/(public)/forms/[formId]/_components/AnswerSubmissionForm.tsx
@@ -16,7 +16,7 @@ import MarkdownText from '@/app/_components/MarkdownText';
 import RequiredChip from '@/app/_components/RequiredChip';
 import type { GetQuestionsResponse } from '@/lib/api-types';
 
-import { TEMPORARY_USER_FIELDS } from './answerFormTypes';
+import { resolveChoiceLabels, TEMPORARY_USER_FIELDS } from './answerFormTypes';
 import type { AnswerFormInput } from './answerFormTypes';
 import QuestionFieldRenderer from './QuestionFieldRenderer';
 
@@ -50,7 +50,7 @@ const AnswerSubmissionForm = ({
   } = useForm<AnswerFormInput>();
 
   const handleAnswerSubmit = async (data: AnswerFormInput) => {
-    const result = await onSubmitAnswers(data);
+    const result = await onSubmitAnswers(resolveChoiceLabels(data, questions));
     if (!result.ok) {
       return;
     }

--- a/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
+++ b/src/app/(public)/forms/[formId]/_components/QuestionFieldRenderer.tsx
@@ -15,6 +15,7 @@ import { Controller } from 'react-hook-form';
 import type { Control, FieldErrors, UseFormRegister } from 'react-hook-form';
 import { match, P } from 'ts-pattern';
 
+import { getChoiceKey } from './answerFormTypes';
 import type { AnswerFormInput, AnswerQuestion } from './answerFormTypes';
 
 type Props = {
@@ -101,7 +102,7 @@ const QuestionFieldRenderer = ({
                   {question.choices.map((choice, index) => (
                     <MenuItem
                       key={`q-${questionId}.a-${index}`}
-                      value={choice.label}
+                      value={getChoiceKey(choice, index)}
                     >
                       {choice.label}
                     </MenuItem>
@@ -143,64 +144,67 @@ const QuestionFieldRenderer = ({
                 .otherwise(() => []);
               const choiceOrder = new Map(
                 question.choices.map((item, itemIndex) => [
-                  item.label,
+                  getChoiceKey(item, itemIndex),
                   itemIndex,
                 ])
               );
 
               return (
                 <Grid container spacing={2} sx={{ mt: 1 }}>
-                  {question.choices.map((choice, index) => (
-                    <Grid
-                      size={{ xs: 12, sm: 6, md: 4 }}
-                      key={`q-${questionId}.a-${index}`}
-                    >
-                      <FormControlLabel
-                        control={
-                          <Checkbox
-                            checked={selectedValues.includes(choice.label)}
-                            onChange={(_, checked) => {
-                              if (question.choices.length === 1) {
-                                field.onChange(checked ? choice.label : false);
-                                return;
-                              }
+                  {question.choices.map((choice, index) => {
+                    const choiceKey = getChoiceKey(choice, index);
 
-                              const nextValues = match({
-                                checked,
-                                alreadySelected: selectedValues.includes(
-                                  choice.label
-                                ),
-                              })
-                                .with(
-                                  { checked: true, alreadySelected: true },
-                                  () => selectedValues
-                                )
-                                .with({ checked: true }, () => [
-                                  ...selectedValues,
-                                  choice.label,
-                                ])
-                                .otherwise(() =>
-                                  selectedValues.filter(
-                                    (value) => value !== choice.label
+                    return (
+                      <Grid
+                        size={{ xs: 12, sm: 6, md: 4 }}
+                        key={`q-${questionId}.a-${index}`}
+                      >
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={selectedValues.includes(choiceKey)}
+                              onChange={(_, checked) => {
+                                if (question.choices.length === 1) {
+                                  field.onChange(checked ? choiceKey : false);
+                                  return;
+                                }
+
+                                const nextValues = match({
+                                  checked,
+                                  alreadySelected:
+                                    selectedValues.includes(choiceKey),
+                                })
+                                  .with(
+                                    { checked: true, alreadySelected: true },
+                                    () => selectedValues
                                   )
+                                  .with({ checked: true }, () => [
+                                    ...selectedValues,
+                                    choiceKey,
+                                  ])
+                                  .otherwise(() =>
+                                    selectedValues.filter(
+                                      (value) => value !== choiceKey
+                                    )
+                                  );
+                                const orderedValues = [...nextValues].sort(
+                                  (left, right) =>
+                                    (choiceOrder.get(left) ?? -1) -
+                                    (choiceOrder.get(right) ?? -1)
                                 );
-                              const orderedValues = [...nextValues].sort(
-                                (left, right) =>
-                                  (choiceOrder.get(left) ?? -1) -
-                                  (choiceOrder.get(right) ?? -1)
-                              );
 
-                              field.onChange(orderedValues);
-                            }}
-                            onBlur={field.onBlur}
-                            ref={index === 0 ? field.ref : undefined}
-                            disabled={disabled}
-                          />
-                        }
-                        label={choice.label}
-                      />
-                    </Grid>
-                  ))}
+                                field.onChange(orderedValues);
+                              }}
+                              onBlur={field.onBlur}
+                              ref={index === 0 ? field.ref : undefined}
+                              disabled={disabled}
+                            />
+                          }
+                          label={choice.label}
+                        />
+                      </Grid>
+                    );
+                  })}
                 </Grid>
               );
             }}

--- a/src/app/(public)/forms/[formId]/_components/answerFormTypes.ts
+++ b/src/app/(public)/forms/[formId]/_components/answerFormTypes.ts
@@ -12,6 +12,68 @@ export interface AnswerFormInput {
 
 export type AnswerQuestion = GetQuestionsResponse[number];
 
+type ChoiceQuestion = Extract<
+  AnswerQuestion,
+  { question_type: 'SingleChoice' | 'MultipleChoice' }
+>;
+
+export type AnswerChoice = ChoiceQuestion['choices'][number];
+
+/**
+ * 選択肢を一意に識別する key。
+ * choice.id（未保存の選択肢では null になりうる）を優先し、無ければ表示順の index で代替する。
+ * 選択肢のラベルが重複していても選択状態を取り違えないようにするために使う。
+ */
+export const getChoiceKey = (choice: AnswerChoice, index: number): string =>
+  choice.id != null ? `id:${choice.id}` : `idx:${index}`;
+
+/**
+ * SingleChoice / MultipleChoice の回答値（getChoiceKey ベース）を、
+ * 送信用の label ベースの値へ変換する。
+ * API は選択肢を label(文字列) でしか受け付けないため、送信直前にここで変換する。
+ */
+export const resolveChoiceLabels = (
+  data: AnswerFormInput,
+  questions: GetQuestionsResponse
+): AnswerFormInput => {
+  const labelByKeyPerQuestion = new Map(
+    questions
+      .filter(
+        (question): question is ChoiceQuestion =>
+          question.question_type === 'SingleChoice' ||
+          question.question_type === 'MultipleChoice'
+      )
+      .map((question) => [
+        question.id,
+        new Map(
+          question.choices.map((choice, index) => [
+            getChoiceKey(choice, index),
+            choice.label,
+          ])
+        ),
+      ])
+  );
+
+  return Object.fromEntries(
+    Object.entries(data).map(([questionId, value]) => {
+      const labelByKey = labelByKeyPerQuestion.get(questionId);
+      if (!labelByKey) {
+        return [questionId, value];
+      }
+
+      if (typeof value === 'string') {
+        return [questionId, labelByKey.get(value) ?? value];
+      }
+
+      if (Array.isArray(value)) {
+        return [questionId, value.map((key) => labelByKey.get(key) ?? key)];
+      }
+
+      return [questionId, value];
+    })
+  );
+};
+
 /**
  * 未ログイン回答で入力する投稿者情報のフィールド名。
  * 質問の回答（key は質問 UUID）と区別するため、衝突しない予約キーを使う。

--- a/tests/component/AnswerSubmissionForm.test.tsx
+++ b/tests/component/AnswerSubmissionForm.test.tsx
@@ -154,6 +154,60 @@ describe('AnswerSubmissionForm', () => {
     });
   });
 
+  it('同じラベルの選択肢が複数ある複数選択で、片方だけを選択できる', async () => {
+    const user = userEvent.setup();
+    const onSubmitAnswers = vi
+      .fn<(data: AnswerFormInput) => Promise<{ ok: boolean }>>()
+      .mockResolvedValue({ ok: true });
+
+    const duplicateLabelQuestions: GetQuestionsResponse = [
+      {
+        id: '8f98a37f-9070-4624-b161-f288769160d5',
+        template_key: 'consultation_topics',
+        title: '相談したい内容',
+        description: '',
+        is_required: false,
+        position: 1,
+        question_type: 'MultipleChoice',
+        choices: [
+          { id: 1, label: 'その他', position: 1 },
+          { id: 2, label: 'その他', position: 2 },
+        ],
+      },
+    ];
+
+    renderWithProviders(
+      <AnswerSubmissionForm
+        questions={duplicateLabelQuestions}
+        title="お問い合わせ"
+        description=""
+        isTemporary={false}
+        onSubmitAnswers={onSubmitAnswers}
+      />
+    );
+
+    const [firstChoice, secondChoice] = screen.getAllByRole('checkbox', {
+      name: 'その他',
+    });
+    if (!firstChoice || !secondChoice) {
+      throw new Error(
+        '「その他」のチェックボックスが2つ見つかりませんでした。'
+      );
+    }
+    await user.click(firstChoice);
+
+    expect(firstChoice).toBeChecked();
+    expect(secondChoice).not.toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    await waitFor(() => {
+      expect(onSubmitAnswers).toHaveBeenCalledWith({
+        '8f98a37f-9070-4624-b161-f288769160d5': ['その他'],
+      });
+    });
+  });
+
   it('単一選択の回答を未選択へ戻せる', async () => {
     const user = userEvent.setup();
     const onSubmitAnswers = vi


### PR DESCRIPTION
## 概要
- 複数選択・単一選択の質問で、同じラベルの選択肢が2つ以上ある場合に、片方をチェックするともう一方も連動してチェック済みになってしまう不具合を修正
- 原因は `QuestionFieldRenderer.tsx` が選択状態の一意キーとして `choice.label`（表示テキスト）を使っていたこと。ラベルが重複するとキーが衝突し区別できなくなっていた
- `choice.id`（未保存の選択肢では `null` になりうるため、その場合は index をフォールバック）ベースの key で選択状態を管理するよう変更。API は選択肢を label(文字列) でしか受け付けないため、`AnswerSubmissionForm.tsx` の送信直前で `resolveChoiceLabels()` により key → label へ変換するようにした

## 確認事項
- 同じラベルの選択肢が2つある複数選択で、片方だけをチェックでき、送信内容も正しく1件のみ含まれることを確認するコンポーネントテストを追加し、通過を確認
- 既存の単体テスト（`pnpm test:unit`）・コンポーネントテスト（`pnpm test:component`）が全て通過することを確認
- `tsc --noEmit` と `eslint` が通ることを確認

## 補足
- 送信ペイロード（`AnswerContentSchema`）自体は label(文字列) のみを受け付ける設計のため、バックエンド側で同一ラベルの選択肢そのものを区別することはできない。今回の修正はフロントエンドのチェックボックス連動不具合の解消が目的で、バックエンドの回答データ表現には変更を加えていない

🤖 Generated with Claude Code